### PR TITLE
[JH] add notebook-images to jh kustomization

### DIFF
--- a/odh/base/jupyterhub/kustomization.yaml
+++ b/odh/base/jupyterhub/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 namespace: opf-jupyterhub
 resources:
   - kfdef.yaml
+  - ./notebook-images


### PR DESCRIPTION
This will also sync all the notebook images along with the jupyterhub kfdef in the [argocd app](https://github.com/operate-first/argocd-apps/blob/main/odh/jupyterhub.yaml)