### PR TITLE
Add Loki Stack using Observatorium

### DIFF
--- a/observatorium/grafana-data-sources/kustomization.yaml
+++ b/observatorium/grafana-data-sources/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - opf-test-loki-source.yaml

--- a/observatorium/grafana-data-sources/opf-test-loki-source.yaml
+++ b/observatorium/grafana-data-sources/opf-test-loki-source.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDataSource
+metadata:
+    name: loki-opf-test
+spec:
+    name: loki-opf-test
+    datasources:
+        - name: Loki-opf-test
+          type: loki
+          access: proxy
+          url: http://opf-observatorium-loki-query-frontend-http.opf-observatorium.svc.cluster.local:3100
+          isDefault: true
+          version: 1
+          editable: false
+          jsonData:
+              httpHeaderName1: 'X-Scope-OrgID'
+          secureJsonData:
+              httpHeaderValue1: 'opf-test'

--- a/observatorium/grafana.yaml
+++ b/observatorium/grafana.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: integreatly.org/v1alpha1
+kind: Grafana
+metadata:
+    annotations:
+        argocd.argoproj.io/sync-wave: "1"
+    name: grafana
+spec:
+    baseImage: quay.io/app-sre/grafana:7.1.1
+    config:
+        security:
+            admin_user: "root"
+            admin_password: "secret"
+        users:
+            viewers_can_edit: true
+            allow_sign_up: false
+            auto_assign_org: true
+            auto_assign_org_role: Viewer
+        auth:
+            disable_login_form: true
+        auth.anonymous:
+            enabled: true
+            org_role: Viewer
+        log:
+            level: warn
+            mode: console
+    dashboardLabelSelector:
+    -   matchExpressions:
+        -   key: app
+            operator: In
+            values:
+            - grafana
+    ingress:
+        enabled: true

--- a/observatorium/kfdef.yaml
+++ b/observatorium/kfdef.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+    kfctl.kubeflow.io/force-delete: "false"
+  name: opendatahub
+spec:
+  applications:
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-common
+      name: odh-common
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: grafana/cluster
+      name: grafana-cluster
+  repos:
+    - name: manifests
+      uri: 'https://github.com/opendatahub-io/odh-manifests/tarball/v0.9.0'
+  version: v0.9.0

--- a/observatorium/kustomization.yaml
+++ b/observatorium/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: opf-observatorium
+resources:
+  - observatorium.yaml
+  - kfdef.yaml
+  - grafana.yaml
+  - ./grafana-data-sources

--- a/observatorium/observatorium.yaml
+++ b/observatorium/observatorium.yaml
@@ -1,0 +1,151 @@
+---
+apiVersion: core.observatorium.io/v1alpha1
+kind: Observatorium
+metadata:
+  labels:
+    app.kubernetes.io/instance: opf-observatorium
+    app.kubernetes.io/name: observatorium-cr
+    app.kubernetes.io/part-of: observatorium
+  name: opf-observatorium
+spec:
+  # Observatorium API is scaled down
+  api:
+    image: quay.io/observatorium/observatorium:master-2020-09-08-v0.1.1-142-g61a908f
+    rbac:
+      roleBindings:
+      - name: test
+        roles:
+        - read-write
+        subjects:
+        - kind: user
+          name: admin@example.com
+      roles:
+      - name: read-write
+        permissions:
+        - read
+        - write
+        resources:
+        - logs
+        - metrics
+        tenants:
+        - test
+    replicas: 0
+    tenants:
+    - id: 1610b0c3-c509-4592-a256-a1871353dbfa
+      name: test
+      oidc:
+        clientID: test
+        clientSecret: ZXhhbXBsZS1hcHAtc2VjcmV0
+        issuerURL: http://dex.dex.svc.cluster.local:5556/dex
+        usernameClaim: email
+    tls:
+      caKey: ca.pem
+      certKey: cert.pem
+      configMapName: observatorium-opf-tls
+      keyKey: key.pem
+      secretName: observatorium-opf-tls
+      serverName: observatorium-opf-observatorium-api.opf-monitoring.svc.cluster.local
+    version: master-2020-09-08-v0.1.1-142-g61a908f
+  apiQuery:
+    replicas: 0
+    image: quay.io/thanos/thanos:master-2020-08-12-70f89d83
+    version: master-2020-08-12-70f89d83
+  compact:
+    enableDownsampling: false
+    image: quay.io/thanos/thanos:master-2020-08-12-70f89d83
+    replicas: 0
+    retentionResolution1h: 1s
+    retentionResolution5m: 1s
+    retentionResolutionRaw: 14d
+    version: master-2020-08-12-70f89d83
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  hashrings:
+  - hashring: default
+    tenants: []
+  # Only Loki Components are scaled up
+  loki:
+    image: quay.io/4n4nd/loki:1.6.1
+    replicas:
+      distributor: 1
+      ingester: 1
+      querier: 1
+      query_frontend: 1
+      table_manager: 1
+    version: 1.6.1
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 250Mi
+  objectStorageConfig:
+    loki:
+      accessKeyIdKey: aws_access_key_id
+      bucketsKey: buckets
+      endpointKey: endpoint
+      regionKey: region
+      secretAccessKeyKey: aws_secret_access_key
+      secretName: loki-objectstorage
+    thanos:
+      key: thanos.yaml
+      name: thanos-objectstorage
+  # All other Thanos and Observatorium components are scaled down
+  query:
+    image: quay.io/thanos/thanos:master-2020-08-12-70f89d83
+    replicas: 0
+    version: master-2020-08-12-70f89d83
+  queryFrontend:
+    image: quay.io/thanos/thanos:master-2020-08-12-70f89d83
+    replicas: 0
+    version: master-2020-08-12-70f89d83
+  receivers:
+    image: quay.io/thanos/thanos:master-2020-08-12-70f89d83
+    replicas: 0
+    version: master-2020-08-12-70f89d83
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2Gi
+  rule:
+    image: quay.io/thanos/thanos:master-2020-08-12-70f89d83
+    replicas: 0
+    version: master-2020-08-12-70f89d83
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  store:
+    cache:
+      exporterImage: prom/memcached-exporter:v0.6.0
+      exporterVersion: v0.6.0
+      image: quay.io/4n4nd/memcached:1.6.3-alpine
+      memoryLimitMb: 1024
+      replicas: 0
+      version: 1.6.3-alpine
+    image: quay.io/thanos/thanos:master-2020-08-12-70f89d83
+    shards: 0
+    version: master-2020-08-12-70f89d83
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Gi
+  thanosReceiveController:
+    replicas: 0
+    image: quay.io/observatorium/thanos-receive-controller:master-2020-02-06-b66e0c8
+    version: master-2020-02-06-b66e0c8


### PR DESCRIPTION
The Observatorium CR consists a lot of thanos configuration because it is required, but all of thanos stuff has been scaled down.