### PR TITLE
Add github alertmanager receiver

### DIFF
--- a/odh/base/monitoring/github-receiver-service.yaml
+++ b/odh/base/monitoring/github-receiver-service.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   ports:
     - port: 9393
-      protocol: TCP
       targetPort: receiver
   selector:
     # Pods with labels matching this key/value pair will be publically

--- a/odh/base/monitoring/github-receiver-service.yaml
+++ b/odh/base/monitoring/github-receiver-service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: github-receiver-service
+spec:
+  ports:
+    - port: 9393
+      protocol: TCP
+      targetPort: receiver
+  selector:
+    # Pods with labels matching this key/value pair will be publically
+    # accessible through the service IP and port.
+    run: github-receiver
+  type: ClusterIP

--- a/odh/base/monitoring/github-receiver.yaml
+++ b/odh/base/monitoring/github-receiver.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: github-receiver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: github-receiver
+  template:
+    metadata:
+      labels:
+        run: github-receiver
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9990'
+    spec:
+      containers:
+        - name: github-receiver
+          image: quay.io/operate-first/alertmanager-github-receiver:v0.10
+          env:
+            - name: GITHUB_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: github-secrets
+                  key: auth-token
+          args: ["--authtoken=$(GITHUB_AUTH_TOKEN)",
+                 "--org=operate-first",
+                 "--repo=SRE",
+                 "--label=in progress",
+                 "--enable-inmemory=false"]
+          ports:
+            - containerPort: 9393
+              name: receiver
+            - containerPort: 9990
+              name: metrics

--- a/odh/base/monitoring/kustomization.yaml
+++ b/odh/base/monitoring/kustomization.yaml
@@ -4,8 +4,5 @@ kind: Kustomization
 namespace: opf-monitoring
 resources:
   - kfdef.yaml
-  - prometheus.yaml
-  - prometheus-route.yaml
-  - grafana.yaml
   - github-receiver.yaml
   - github-receiver-service.yaml

--- a/odh/base/monitoring/kustomization.yaml
+++ b/odh/base/monitoring/kustomization.yaml
@@ -4,3 +4,8 @@ kind: Kustomization
 namespace: opf-monitoring
 resources:
   - kfdef.yaml
+  - prometheus.yaml
+  - prometheus-route.yaml
+  - grafana.yaml
+  - github-receiver.yaml
+  - github-receiver-service.yaml

--- a/odh/overlays/crc/monitoring/example-github-secret.yaml
+++ b/odh/overlays/crc/monitoring/example-github-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-secrets
+type: Opaque
+data:
+  auth-token: GITHUB-AUTH-TOKEN

--- a/odh/overlays/crc/monitoring/kustomization.yaml
+++ b/odh/overlays/crc/monitoring/kustomization.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
+namespace: opf-monitoring
 resources:
   - ../../../base/monitoring
+  - example-github-secret.yaml

--- a/odh/overlays/moc/monitoring/.sops.yaml
+++ b/odh/overlays/moc/monitoring/.sops.yaml
@@ -1,0 +1,3 @@
+creation_rules:
+  - encrypted_regex: '^(data|stringData)$'
+    pgp: '0508677DD04952D06A943D5B4DC4116D360E3276'

--- a/odh/overlays/moc/monitoring/secrets/github-secret.enc.yaml
+++ b/odh/overlays/moc/monitoring/secrets/github-secret.enc.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: github-secrets
+type: Opaque
+data:
+    auth-token: ENC[AES256_GCM,data:SWRL1vCDY83GzKXPwOe1rODu2GF90t8kB9V94JJp3gnwcKi4VM77mCTmEG3Rvr0N/L3TBz0IlaA=,iv:gPjQgSEU3M/nUJSdA05pSFRLS6CTUVznSy78meOgaCs=,tag:67WZLxKzMjpvd/h3tAgewQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-01-07T19:52:55Z'
+    mac: ENC[AES256_GCM,data:ZW/CpsJNZWhu7LPngRG4At3D1Zq598ChwaFtTZRlK1ysViNDCDgtW7J+8KOsybDLkjlqn4SKhnz45hQ0JGcRXUQNrEe15b8IV9UlHjV1dbcJkgpBHYMNMt5n0U8R5wPKTFOlPCpz7eBhgvH98swEHvdYt9bj1pDBHyczIL007o0=,iv:3WZUH4ePG/tbNhq5dCaAmZzyxkTrse4XEacPLEJhIsw=,tag:4jpq36SApPAqRJ6Z0AwOow==,type:str]
+    pgp:
+    -   created_at: '2021-01-07T19:52:54Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA9aKBcudqifiAQ/+PKloT6uUFVLe6yuG7ix2hP0wffV0ff879ib01iVxkTrz
+            4G4aMIQIgsLzadgqzdi9Uwnhs8w3ElfQj6VSa9V5MmU517o03Kjy4iwoR4uupL4k
+            duH/FtVZuF2u39Zg9dQFi4m6hCxg1dYlMzJh8jpggbc1y7Y4uPWeYgta/VI7e3ks
+            PIoM+IUwB6JT84wAtRgjwTb4kOpMTwTALZL/6u5/dtwdKJ1DcOTmxPip0t2IX/wL
+            KE2x4w4j+KzkZOL5iC2h6mlawfiEoqPaR+5sfpvgMba4Um1mTL+6Pk71oRGsdcAi
+            yUInx8Qe9r6QAcIRCJG6UlRFwZU4QNDL5O+4nE2d1e2RUPSh+KvcZgupShl4X2X0
+            vtNrfCs4mCJsSZ4EhGmfeXE5B8J70R7Hq0eL6YrTwSr8iWxMa6OmJH60IzSfax6M
+            pqA7ko5XF+7jiRec84z+Wox+S4kxfew4ybw3mmmaE25vdqy7vicBpbUzcY2yGtkd
+            Or6hxa3aUdALy42BqKxs5ZcV3Mz27h5omt/6yX+IXUfJCkFpNMbPxq+MZzeIHBDZ
+            MuNxlYomz3LXIcmAaZ5J0AcyjoqKDMF7waQiwSInW+RjQmt1CH47ES5Fzpe+9V4O
+            5tpl+BdUlLfqnBKTx4xmQh+jMVJCSc/Cx8zIP2g/ILwJmOTEL2vS8u5HmwR9NT/S
+            XgHizHGeUNw0JdIo+QDtzVLLLK3CCjBiZtcOa9KBqbgTsvXt7TNlKgvwSjtwaRp8
+            8bG869+Ogql2WIzC6esRUbR+1L3sLQ1+FkEc5IwF87PQ21FbCvXnnXec6Tj+7I4=
+            =WE6a
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^(data|stringData)$
+    version: 3.6.1

--- a/odh/overlays/moc/monitoring/secrets/secret-generator.yaml
+++ b/odh/overlays/moc/monitoring/secrets/secret-generator.yaml
@@ -1,0 +1,6 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: github-secret-generator
+files:
+  - ./secrets/github-secret.enc.yaml

--- a/odh/overlays/quicklab/monitoring/example-github-secret.yaml
+++ b/odh/overlays/quicklab/monitoring/example-github-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-secrets
+type: Opaque
+data:
+  auth-token: GITHUB-AUTH-TOKEN

--- a/odh/overlays/quicklab/monitoring/kustomization.yaml
+++ b/odh/overlays/quicklab/monitoring/kustomization.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
+namespace: opf-monitoring
 resources:
   - ../../../base/monitoring
+  - example-github-secret.yaml


### PR DESCRIPTION
Adding [GitHub Alertmanager](https://github.com/m-lab/alertmanager-github-receiver) for incident management. The GitHub alertmanager receiver will create new issues in a given repository for triggered Prometheus alerts. See https://github.com/operate-first/SRE/issues/19 for more details.