### PR TITLE
Add the Observatorium CR to deploy Loki 

### DIFF
--- a/observatorium/base/instance/example-loki-objectstorage-secret.yaml
+++ b/observatorium/base/instance/example-loki-objectstorage-secret.yaml
@@ -1,0 +1,8 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: loki-objectstorage
+stringData:
+  endpoint: http://ACCESS_KEY_ID:ACCESS_SECRET_KEY@S3_HOST:S3_PORT/BUCKET_NAME
+type: Opaque

--- a/observatorium/base/instance/grafana-data-sources/kustomization.yaml
+++ b/observatorium/base/instance/grafana-data-sources/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - opf-test-loki-source.yaml

--- a/observatorium/base/instance/grafana-data-sources/opf-test-loki-source.yaml
+++ b/observatorium/base/instance/grafana-data-sources/opf-test-loki-source.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDataSource
+metadata:
+    name: loki-opf-example
+spec:
+    name: loki-opf-example
+    datasources:
+        - name: loki-opf-example
+          type: loki
+          access: proxy
+          url: http://opf-observatorium-loki-query-frontend-http.opf-observatorium.svc.cluster.local:3100
+          version: 1
+          editable: false
+          jsonData:
+              httpHeaderName1: 'X-Scope-OrgID'
+          secureJsonData:
+              httpHeaderValue1: 'opf-example'

--- a/observatorium/base/instance/grafana.yaml
+++ b/observatorium/base/instance/grafana.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: integreatly.org/v1alpha1
+kind: Grafana
+metadata:
+    name: grafana
+spec:
+    baseImage: quay.io/app-sre/grafana:7.1.1
+    config:
+        users:
+            viewers_can_edit: true
+            allow_sign_up: false
+            auto_assign_org: true
+            auto_assign_org_role: Viewer
+        auth:
+            disable_login_form: true
+        auth.anonymous:
+            enabled: true
+            org_role: Viewer
+        log:
+            level: warn
+            mode: console
+    dashboardLabelSelector:
+    -   matchExpressions:
+        -   key: app
+            operator: In
+            values:
+            - grafana
+    ingress:
+        enabled: true

--- a/observatorium/base/instance/kfdef.yaml
+++ b/observatorium/base/instance/kfdef.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  annotations:
+    kfctl.kubeflow.io/force-delete: "false"
+  name: opendatahub
+spec:
+  applications:
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-common
+      name: odh-common
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: grafana/cluster
+      name: grafana-cluster
+  repos:
+    - name: manifests
+      uri: 'https://github.com/opendatahub-io/odh-manifests/tarball/v0.9.0'
+  version: v0.9.0

--- a/observatorium/base/instance/kustomization.yaml
+++ b/observatorium/base/instance/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: opf-observatorium
+commonLabels:
+  app.kubernetes.io/instance: opf-observatorium
+  app.kubernetes.io/part-of: observatorium
+resources:
+  - observatorium.yaml
+  - kfdef.yaml
+  - grafana.yaml
+  - ./grafana-data-sources

--- a/observatorium/base/instance/observatorium.yaml
+++ b/observatorium/base/instance/observatorium.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: core.observatorium.io/v1alpha1
+kind: Observatorium
+metadata:
+  labels:
+    app.kubernetes.io/name: observatorium-cr
+  name: opf-observatorium
+spec:
+  # Only Loki Components are scaled up
+  loki:
+    image: quay.io/app-sre/loki:1.6.1
+    replicas:
+      distributor: 1
+      ingester: 1
+      querier: 1
+      query_frontend: 1
+      table_manager: 1
+    version: 1.6.1
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 250Mi
+  objectStorageConfig:
+    objectStorageConfig:
+    loki:
+      # FIXME: Most of the following values are not used, yet they are required to be defined
+      # See: https://github.com/observatorium/operator/issues/31
+      accessKeyIdKey: ""
+      bucketsKey: ""
+      endpointKey: endpoint
+      regionKey: ""
+      secretAccessKeyKey: ""
+      secretName: loki-objectstorage
+    thanos:
+      key: thanos.yaml
+      name: thanos-objectstorage
+  # All other Thanos and Observatorium components are scaled down
+  api:
+    rbac:
+      roleBindings: []
+      roles: []
+    tenants: []
+    replicas: 0
+  compact:
+    replicas: 0
+    retentionResolution1h: 1s
+    retentionResolution5m: 1s
+    retentionResolutionRaw: 14d
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+  hashrings:
+  - hashring: default
+  receivers:
+    replicas: 0
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+  rule:
+    replicas: 0
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+  store:
+    cache:
+      replicas: 0
+    shards: 0
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+  query:
+    replicas: 0
+  queryFrontend:
+    replicas: 0

--- a/observatorium/base/operator/kustomization.yaml
+++ b/observatorium/base/operator/kustomization.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# If changing the namespace, also update the namespace in patch below.
+namespace: observatorium-operator
+resources:
+- https://raw.githubusercontent.com/observatorium/operator/03be03063a5cfebb0bf4fbbc8faca3f252bf5006/manifests/crds/core.observatorium.io_observatoria.yaml
+- https://raw.githubusercontent.com/observatorium/operator/03be03063a5cfebb0bf4fbbc8faca3f252bf5006/manifests/cluster_role.yaml
+- https://raw.githubusercontent.com/observatorium/operator/03be03063a5cfebb0bf4fbbc8faca3f252bf5006/manifests/cluster_role_binding.yaml
+- https://raw.githubusercontent.com/observatorium/operator/03be03063a5cfebb0bf4fbbc8faca3f252bf5006/manifests/service_account.yaml
+- https://raw.githubusercontent.com/observatorium/operator/03be03063a5cfebb0bf4fbbc8faca3f252bf5006/manifests/operator.yaml
+
+patchesStrategicMerge:
+- |-
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: observatorium-operator
+  subjects:
+  - kind: ServiceAccount
+    name: observatorium-operator
+    namespace: observatorium-operator                  # <-- Update this namespace


### PR DESCRIPTION
Add Grafana deployment using ODH 
Add example Grafana Datasource for Loki 
Trim down the Observatorium CR to just loki and required component values
This disables the Observatorium API and we can interact with Loki directly 
Later we can update it to deploy Observatorium and API and Thanos