### PR TITLE
Add opf-observatorium loki monitoring

### DIFF
--- a/observatorium/base/instance/kfdef.yaml
+++ b/observatorium/base/instance/kfdef.yaml
@@ -17,6 +17,12 @@ spec:
           name: manifests
           path: grafana/cluster
       name: grafana-cluster
+    # Deploying Prometheus Operator for monitoring
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: prometheus/cluster
+      name: prometheus-cluster
   repos:
     - name: manifests
       uri: 'https://github.com/opendatahub-io/odh-manifests/tarball/v0.9.0'

--- a/observatorium/base/instance/kustomization.yaml
+++ b/observatorium/base/instance/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - kfdef.yaml
   - grafana.yaml
   - ./grafana-data-sources
+  - ./monitoring

--- a/observatorium/base/instance/monitoring/kustomization.yaml
+++ b/observatorium/base/instance/monitoring/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  observatorium-component: monitoring
+resources:
+  - loki-servicemonitor.yaml
+  - prometheus.yaml

--- a/observatorium/base/instance/monitoring/loki-servicemonitor.yaml
+++ b/observatorium/base/instance/monitoring/loki-servicemonitor.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: loki-metrics
+spec:
+  jobLabel: observatorium-loki
+  endpoints:
+    - port: metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-frontend
+      app.kubernetes.io/name: loki
+  targetLabels:
+    - app.kubernetes.io/component
+    - app.kubernetes.io/instance
+    - app.kubernetes.io/name
+    - app.kubernetes.io/part-of
+    - app.kubernetes.io/version

--- a/observatorium/base/instance/monitoring/prometheus.yaml
+++ b/observatorium/base/instance/monitoring/prometheus.yaml
@@ -10,6 +10,6 @@ spec:
   serviceAccountName: prometheus-k8s
   securityContext: {}
   serviceMonitorSelector:
-      matchLabels:
-        observatorium-component: monitoring
+    matchLabels:
+      observatorium-component: monitoring
   ruleSelector: {}

--- a/observatorium/base/instance/monitoring/prometheus.yaml
+++ b/observatorium/base/instance/monitoring/prometheus.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: prometheus
+  labels:
+    prometheus: k8s
+spec:
+  replicas: 1
+  serviceAccountName: prometheus-k8s
+  securityContext: {}
+  serviceMonitorSelector:
+      matchLabels:
+        observatorium-component: monitoring
+  ruleSelector: {}

--- a/odh/base/monitoring/prometheus.yaml
+++ b/odh/base/monitoring/prometheus.yaml
@@ -13,6 +13,9 @@ spec:
   securityContext: {}
   ruleSelector: {}
   replicas: 2
+  retention: 7d
   remoteRead:
     - url: "http://prometheus-operated.opf-jupyterhub.svc.cluster.local:9090\
+            /api/v1/read"
+    - url: "http://prometheus-operated.opf-observatorium.svc.cluster.local:9090\
             /api/v1/read"


### PR DESCRIPTION
Add Prometheus and Prometheus Operator deployment  using ODH
Add ServiceMonitor for Loki
Update opf-monitoring Prometheus to monitor opf-observatorium prometheus
Update opf-monitoring metric retention to 7d from default (24H)

Closes #75 