### PR TITLE
Add routes to access loki distributor and frontend api

### DIFF
--- a/observatorium/base/instance/kustomization.yaml
+++ b/observatorium/base/instance/kustomization.yaml
@@ -7,6 +7,7 @@ commonLabels:
   app.kubernetes.io/part-of: observatorium
 resources:
   - observatorium.yaml
+  - loki-routes.yaml
   - kfdef.yaml
   - grafana.yaml
   - ./grafana-data-sources

--- a/observatorium/base/instance/loki-routes.yaml
+++ b/observatorium/base/instance/loki-routes.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: loki-distributor
+spec:
+  to:
+    kind: Service
+    name: opf-observatorium-loki-distributor-http
+  port:
+    targetPort: metrics
+
+
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: loki-frontend
+spec:
+  to:
+    kind: Service
+    name: opf-observatorium-loki-query-frontend-http
+  port:
+    targetPort: metrics


### PR DESCRIPTION
This will expose the loki frontend and distributor services
Frontend is to query logs from loki
Distributor is to push logs into loki