### PR TITLE
Add jupyterhub grafana dashboard resource

### DIFF
--- a/odh/base/monitoring/overrides/dashboards/jupyterhub-dashboard.yaml
+++ b/odh/base/monitoring/overrides/dashboards/jupyterhub-dashboard.yaml
@@ -1,0 +1,10 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: Jupyterhub
+  labels:
+    app: grafana
+spec:
+  name: Jupyterhub-dashboard.json
+  url: https://raw.githubusercontent.com/operate-first/SRE/master/dashboards/Jupyterhub-dashboard.json
+  json:


### PR DESCRIPTION
Adding `GrafanaDashboard` resource to include the Jupyterhub dashboard created at: https://github.com/operate-first/SRE/pull/17.
