### PR TITLE
Add openshift-anomaly-detection notebook image to notebook-images

### DIFF
--- a/odh/base/jupyterhub/notebook-images/kustomization.yaml
+++ b/odh/base/jupyterhub/notebook-images/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ceph-drive-failure.yaml
   - configuration-files-analysis.yaml
   - cloud-price-analysis.yaml
+  - openshift-anomaly-detection.yaml

--- a/odh/base/jupyterhub/notebook-images/openshift-anomaly-detection.yaml
+++ b/odh/base/jupyterhub/notebook-images/openshift-anomaly-detection.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url:
+      "https://github.com/aicoe-aiops/openshift-anomaly-detection"
+    opendatahub.io/notebook-image-name:
+      "OpenShift Anomaly Detection Notebook Image"
+    opendatahub.io/notebook-image-desc:
+      "Image with jupyter notebooks for anomaly detection and diagnosis discovery in OCP clusters"
+  name: openshift-anomaly-detection
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        openshift.io/imported-from: quay.io/aicoe/openshift-anomaly-detection
+      from:
+        kind: DockerImage
+        name: quay.io/aicoe/openshift-anomaly-detection:latest
+      importPolicy:
+        scheduled: true
+      name: "latest"


### PR DESCRIPTION
This PR defines an ImageStream in a yaml and adds it as a resource to jupyterhub kustomization.yaml. This image is of the public facing (no customer data) version of the [openshift-anomaly-detection](https://github.com/aicoe-aiops/openshift-anomaly-detection) project.