### PR TITLE
Add operate-first project admin rbac to as components

### DIFF
--- a/observatorium/components/rbac/kustomization.yaml
+++ b/observatorium/components/rbac/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - rolebinding.yaml

--- a/observatorium/components/rbac/rolebinding.yaml
+++ b/observatorium/components/rbac/rolebinding.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: admin-rolebinding
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: operate-first
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin

--- a/observatorium/overlays/moc/kustomization.yaml
+++ b/observatorium/overlays/moc/kustomization.yaml
@@ -1,7 +1,9 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
+namespace: opf-observatorium
+components:
+  - ../../components/rbac
 resources:
   - ../../base/instance
   - ./grafana-data-sources

--- a/odh/components/rbac/kustomization.yaml
+++ b/odh/components/rbac/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - rolebinding.yaml

--- a/odh/components/rbac/rolebinding.yaml
+++ b/odh/components/rbac/rolebinding.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: admin-rolebinding
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: operate-first
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin

--- a/odh/overlays/moc/argo/kustomization.yaml
+++ b/odh/overlays/moc/argo/kustomization.yaml
@@ -1,6 +1,8 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
+namespace: opf-argo
+components:
+  - ../../../components/rbac
 resources:
   - ../../../base/argo

--- a/odh/overlays/moc/dashboard/kustomization.yaml
+++ b/odh/overlays/moc/dashboard/kustomization.yaml
@@ -1,6 +1,8 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
+namespace: opf-dashboard
+components:
+  - ../../../components/rbac
 resources:
   - ../../../base/dashboard

--- a/odh/overlays/moc/datacatalog/kustomization.yaml
+++ b/odh/overlays/moc/datacatalog/kustomization.yaml
@@ -1,10 +1,11 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
+namespace: opf-datacatalog
+components:
+  - ../../../components/rbac
 resources:
   - ../../../base/datacatalog
-
 patchesJson6902:
   - patch: |
       - op: add

--- a/odh/overlays/moc/jupyterhub/kustomization.yaml
+++ b/odh/overlays/moc/jupyterhub/kustomization.yaml
@@ -1,10 +1,11 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
+namespace: opf-jupyterhub
+components:
+  - ../../../components/rbac
 resources:
   - ../../../base/jupyterhub
-
 patchesJson6902:
   - patch: |
       - op: add

--- a/odh/overlays/moc/kafka/kustomization.yaml
+++ b/odh/overlays/moc/kafka/kustomization.yaml
@@ -1,10 +1,11 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
+namespace: opf-kafka
+components:
+  - ../../../components/rbac
 resources:
   - ../../../base/kafka
-
 patchesJson6902:
   - patch: |
       - op: add

--- a/odh/overlays/moc/monitoring/kustomization.yaml
+++ b/odh/overlays/moc/monitoring/kustomization.yaml
@@ -1,6 +1,8 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
+namespace: opf-monitoring
+components:
+  - ../../../components/rbac
 resources:
   - ../../../base/monitoring

--- a/odh/overlays/moc/superset/kustomization.yaml
+++ b/odh/overlays/moc/superset/kustomization.yaml
@@ -1,10 +1,11 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
+namespace: opf-superset
+components:
+  - ../../../components/rbac
 resources:
   - ../../../base/superset
-
 patchesJson6902:
   - patch: |
       - op: add


### PR DESCRIPTION
Fixes #97 

I'm using components here so I don't have to copy paste the same rolebinding everywhere. However, I do copy/paste it once for observatorium and odh, as they seem like different entities, open to changing this however and having a broader shared components folder at the root. 