### PR TITLE
Add time series notebook imagestream to notebook-images

### DIFF
--- a/odh/base/jupyterhub/notebook-images/kustomization.yaml
+++ b/odh/base/jupyterhub/notebook-images/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - configuration-files-analysis.yaml
   - cloud-price-analysis.yaml
   - openshift-anomaly-detection.yaml
+  - time-series.yaml

--- a/odh/base/jupyterhub/notebook-images/time-series.yaml
+++ b/odh/base/jupyterhub/notebook-images/time-series.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url:
+      "https://github.com/aicoe-aiops/time-series"
+    opendatahub.io/notebook-image-name:
+      "Time Series Notebook Image"
+    opendatahub.io/notebook-image-desc:
+      "Image with jupyter notebooks for time series experiments"
+  name: time-series
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        openshift.io/imported-from: quay.io/aicoe/time-series
+      from:
+        kind: DockerImage
+        name: quay.io/aicoe/time-series:latest
+      importPolicy:
+        scheduled: true
+      name: "latest"


### PR DESCRIPTION
In this PR, I add the [time-series project](https://github.com/aicoe-aiops/time-series) [image](https://quay.io/repository/aicoe/time-series) to the notebook-images.
Confirmed locally, the image runs without any errors.