### PR TITLE
Add prometheus availability alerts

### DIFF
--- a/odh/base/monitoring/overrides/prometheus-operator/base/prometheus-rules.yaml
+++ b/odh/base/monitoring/overrides/prometheus-operator/base/prometheus-rules.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: odh-monitoring
+    role: alert-rules
+  name: prometheus-alerting-rules
+spec:
+  groups:
+    - name: Operate First Availability
+      rules:
+        - alert: Prometheus Service Down
+          expr: up{service="prometheus-operated"} == 0
+          for: 5m
+          annotations:
+            summary: "Prometheus service is no longer available"
+            severity: "HIGH"
+        - alert: Prometheus Alertmanager Down
+          expr: up{service="alert-manager"} == 0
+          for: 5m
+          annotations:
+            summary: "Prometheus Alertmanager is no longer available"
+            severity: "HIGH"

--- a/odh/base/monitoring/overrides/prometheus-operator/base/prometheus.yaml
+++ b/odh/base/monitoring/overrides/prometheus-operator/base/prometheus.yaml
@@ -17,7 +17,10 @@ spec:
   serviceAccountName: prometheus-k8s
   serviceMonitorSelector: {}
   securityContext: {}
-  ruleSelector: {}
+  ruleSelector:
+    matchLabels:
+      prometheus: odh-monitoring
+      role: alert-rules
   replicas: 2
   remoteRead:
     - url: "http://prometheus-operated.opf-jupyterhub.svc.cluster.local:9090\


### PR DESCRIPTION
Adding basic availability alerts for the operate first services (currently, we have the `up` metric available only for the prometheus service)
This closes #101