### PR TITLE
feat: Introduce declarative namespace and ClusterRole RBAC management

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,3 @@
+creation_rules:
+  - encrypted_regex: "^users$"
+    pgp: "0508677DD04952D06A943D5B4DC4116D360E3276"

--- a/namespaces/base/observatorium-operator/kustomization.yaml
+++ b/namespaces/base/observatorium-operator/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: observatorium-operator
+
+resources:
+  - namespace.yaml
+  - rbac.yaml

--- a/namespaces/base/observatorium-operator/namespace.yaml
+++ b/namespaces/base/observatorium-operator/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Operate First: Observatorium operator"
+    openshift.io/requester: operate-first
+  name: observatorium-operator
+spec: {}

--- a/namespaces/base/observatorium-operator/rbac.yaml
+++ b/namespaces/base/observatorium-operator/rbac.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: operate-first

--- a/namespaces/base/odh-operator/kustomization.yaml
+++ b/namespaces/base/odh-operator/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: odh-operator
+
+resources:
+  - namespace.yaml
+  - rbac.yaml

--- a/namespaces/base/odh-operator/namespace.yaml
+++ b/namespaces/base/odh-operator/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Operate First: ODH Operator"
+    openshift.io/requester: operate-first
+  name: odh-operator
+spec: {}

--- a/namespaces/base/odh-operator/rbac.yaml
+++ b/namespaces/base/odh-operator/rbac.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: operate-first

--- a/namespaces/base/opf-argo/kustomization.yaml
+++ b/namespaces/base/opf-argo/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: opf-argo
+
+resources:
+  - namespace.yaml
+  - rbac.yaml

--- a/namespaces/base/opf-argo/namespace.yaml
+++ b/namespaces/base/opf-argo/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Operate First: Argo"
+    openshift.io/requester: operate-first
+  name: opf-argo
+spec: {}

--- a/namespaces/base/opf-argo/rbac.yaml
+++ b/namespaces/base/opf-argo/rbac.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: operate-first

--- a/namespaces/base/opf-dashboard/kustomization.yaml
+++ b/namespaces/base/opf-dashboard/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: opf-dashboard
+
+resources:
+  - namespace.yaml
+  - rbac.yaml

--- a/namespaces/base/opf-dashboard/namespace.yaml
+++ b/namespaces/base/opf-dashboard/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Operate First: ODH Dashboard"
+    openshift.io/requester: operate-first
+  name: opf-dashboard
+spec: {}

--- a/namespaces/base/opf-dashboard/rbac.yaml
+++ b/namespaces/base/opf-dashboard/rbac.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: operate-first

--- a/namespaces/base/opf-datacatalog/kustomization.yaml
+++ b/namespaces/base/opf-datacatalog/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: opf-datacatalog
+
+resources:
+  - namespace.yaml
+  - rbac.yaml

--- a/namespaces/base/opf-datacatalog/namespace.yaml
+++ b/namespaces/base/opf-datacatalog/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Operate First: ODH Datacatalog"
+    openshift.io/requester: operate-first
+  name: opf-datacatalog
+spec: {}

--- a/namespaces/base/opf-datacatalog/rbac.yaml
+++ b/namespaces/base/opf-datacatalog/rbac.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: operate-first

--- a/namespaces/base/opf-jupyterhub/kustomization.yaml
+++ b/namespaces/base/opf-jupyterhub/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: opf-jupyterhub
+
+resources:
+  - namespace.yaml
+  - rbac.yaml

--- a/namespaces/base/opf-jupyterhub/namespace.yaml
+++ b/namespaces/base/opf-jupyterhub/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Operate First: JupyterHub"
+    openshift.io/requester: operate-first
+  name: opf-jupyterhub
+spec: {}

--- a/namespaces/base/opf-jupyterhub/rbac.yaml
+++ b/namespaces/base/opf-jupyterhub/rbac.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: operate-first

--- a/namespaces/base/opf-kafka/kustomization.yaml
+++ b/namespaces/base/opf-kafka/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: opf-kafka
+
+resources:
+  - namespace.yaml
+  - rbac.yaml

--- a/namespaces/base/opf-kafka/namespace.yaml
+++ b/namespaces/base/opf-kafka/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Operate First: Kafka"
+    openshift.io/requester: operate-first
+  name: opf-kafka
+spec: {}

--- a/namespaces/base/opf-kafka/rbac.yaml
+++ b/namespaces/base/opf-kafka/rbac.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: operate-first

--- a/namespaces/base/opf-monitoring/kustomization.yaml
+++ b/namespaces/base/opf-monitoring/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: opf-monitoring
+
+resources:
+  - namespace.yaml
+  - rbac.yaml

--- a/namespaces/base/opf-monitoring/namespace.yaml
+++ b/namespaces/base/opf-monitoring/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Operate First: Monitoring"
+    openshift.io/requester: operate-first
+  name: opf-monitoring
+spec: {}

--- a/namespaces/base/opf-monitoring/rbac.yaml
+++ b/namespaces/base/opf-monitoring/rbac.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: operate-first

--- a/namespaces/base/opf-observatorium/kustomization.yaml
+++ b/namespaces/base/opf-observatorium/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: opf-observatorium
+
+resources:
+  - namespace.yaml
+  - rbac.yaml

--- a/namespaces/base/opf-observatorium/namespace.yaml
+++ b/namespaces/base/opf-observatorium/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Operate First: Observatorium"
+    openshift.io/requester: operate-first
+  name: opf-observatorium
+spec: {}

--- a/namespaces/base/opf-observatorium/rbac.yaml
+++ b/namespaces/base/opf-observatorium/rbac.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: operate-first

--- a/namespaces/base/opf-superset/kustomization.yaml
+++ b/namespaces/base/opf-superset/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: opf-superset
+
+resources:
+  - namespace.yaml
+  - rbac.yaml

--- a/namespaces/base/opf-superset/namespace.yaml
+++ b/namespaces/base/opf-superset/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Operate First: Superset"
+    openshift.io/requester: operate-first
+  name: opf-superset
+spec: {}

--- a/namespaces/base/opf-superset/rbac.yaml
+++ b/namespaces/base/opf-superset/rbac.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: operate-first

--- a/namespaces/overlays/crc/kustomization.yaml
+++ b/namespaces/overlays/crc/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - observatorium-operator
+  - odh-operator
+  - opf-argo
+  - opf-dashboard
+  - opf-datacatalog
+  - opf-jupyterhub
+  - opf-kafka
+  - opf-monitoring
+  - opf-observatorium
+  - opf-superset

--- a/namespaces/overlays/crc/observatorium-operator/kustomization.yaml
+++ b/namespaces/overlays/crc/observatorium-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/observatorium-operator

--- a/namespaces/overlays/crc/odh-operator/kustomization.yaml
+++ b/namespaces/overlays/crc/odh-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/odh-operator

--- a/namespaces/overlays/crc/opf-argo/kustomization.yaml
+++ b/namespaces/overlays/crc/opf-argo/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-argo

--- a/namespaces/overlays/crc/opf-dashboard/kustomization.yaml
+++ b/namespaces/overlays/crc/opf-dashboard/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-dashboard

--- a/namespaces/overlays/crc/opf-datacatalog/kustomization.yaml
+++ b/namespaces/overlays/crc/opf-datacatalog/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-datacatalog

--- a/namespaces/overlays/crc/opf-jupyterhub/kustomization.yaml
+++ b/namespaces/overlays/crc/opf-jupyterhub/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-jupyterhub

--- a/namespaces/overlays/crc/opf-kafka/kustomization.yaml
+++ b/namespaces/overlays/crc/opf-kafka/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-kafka

--- a/namespaces/overlays/crc/opf-monitoring/kustomization.yaml
+++ b/namespaces/overlays/crc/opf-monitoring/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-monitoring

--- a/namespaces/overlays/crc/opf-observatorium/kustomization.yaml
+++ b/namespaces/overlays/crc/opf-observatorium/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-observatorium

--- a/namespaces/overlays/crc/opf-superset/kustomization.yaml
+++ b/namespaces/overlays/crc/opf-superset/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-superset

--- a/namespaces/overlays/moc/kustomization.yaml
+++ b/namespaces/overlays/moc/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - mesh-for-data
+  - observatorium-operator
+  - odh-operator
+  - open-aiops
+  - opf-argo
+  - opf-dashboard
+  - opf-datacatalog
+  - opf-jupyterhub
+  - opf-kafka
+  - opf-monitoring
+  - opf-observatorium
+  - opf-superset

--- a/namespaces/overlays/moc/mesh-for-data/group.enc.yaml
+++ b/namespaces/overlays/moc/mesh-for-data/group.enc.yaml
@@ -1,0 +1,36 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+    name: mesh-for-data
+users:
+- ENC[AES256_GCM,data:8HvU8oDI/DWt5+cifBDghKmqQGI3hq4=,iv:vUdUvLTzil6CEmhaWrW0mEI1DhXpN63c7W0fT5sxHkE=,tag:Sp5nygeRRV8gONwHnkA8FA==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-01-12T17:23:37Z'
+    mac: ENC[AES256_GCM,data:TjNLiiChQMEHUNqrDvHo2DHuhRpZa7b0hoUZoE1ClviDYGQuP1odp2uVkmR2KI5Nfbee9XAvxeOkM3/7+WyrvZRzD2I07lFq+zNBgIvMfZD8fRnlz7pyVsJ9zjmW9ERE1SnFvFefrw+l9zImdKZLF0ZKPQ1xyNhw9/2sW1PNC50=,iv:06qD6Xwn1QR85H7STN7hTKay/dWusDUsbH+jwaiJBxg=,tag:2Yshjuv0yh6X/21MxV4Arw==,type:str]
+    pgp:
+    -   created_at: '2021-01-12T17:23:36Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA9aKBcudqifiAQ/+PepxvF9p1NrK1qx3moCEs6OcPCmFid1le5QbyezGcl0i
+            AzxTCw1t9MTDoLQGpPCcm33kX2euar5421rPMkXFsTkQFq4HcH0OzpGA8OXkNUN6
+            PZ9K57tWKNjmdulJaHNWwn/c5NR+el9awYwWVT7Z//OFqU1fFYM8wE7JnSnahNpB
+            LMvqqDrv/FPIBySUO8shdThWekCnZ0JKXD5e7kPSDrizqkdx3yLnbR/TT952bsLl
+            9dWtN9ti8hvKIQG9i1S/tKt4rOnOeq6Z2U512AGvduGCBsUu6DfFON3GfyBgwN/J
+            Q7N9LLI18Kw71UadFpRbKVrpaD0Tf3TLiz8XnFsiG0A8HFyP65HbhVHblgToONpc
+            5TCaZB3lMFHZiddxmr48qn1bwOwKfTw8U65BBLV8+IVPLfmVWIGRdDlFbN5u+bcJ
+            jHimSXlox97USXeSPy78dbdilhaJ3+G/GMr+jSjGRsvZGBZC0+oLmFIZxkpA/ekn
+            oRfjxoxK2DupVw4zLinwJ3r2HxX+QIBq3hmuj7keRUCpnj+i77UVSzgwJNR/SETV
+            8BmHPnOV3Has1wVAL+Oyr8vFXz0PoRU2wjERqCuPXR+H7TU/8JnrNhVexyFXikb9
+            hr5bh7eu5vLq5/jtbEmcouK+atrAsITr6Ju9+24Zs7TbTRTfDO6SukRIULsNq/rS
+            XgHulYpd7xOWRuCHbOvvBC9Cv55GAoMVSLWprG4vsenJlvWXpz3oA0dOgm0k5jf2
+            zk8c83on4IYcJgwAJGg4shQTUOiqPTRAFhA1KHpKgc2JEbb5fdjIg+VFKYiATzc=
+            =1HSb
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^users$
+    version: 3.6.1

--- a/namespaces/overlays/moc/mesh-for-data/kustomization.yaml
+++ b/namespaces/overlays/moc/mesh-for-data/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: mesh-for-data
+
+resources:
+  - namespace.yaml
+  - rbac.yaml
+
+generators:
+  - secret-generator.yaml

--- a/namespaces/overlays/moc/mesh-for-data/namespace.yaml
+++ b/namespaces/overlays/moc/mesh-for-data/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "IBM Research Team: Mesh for data"
+    openshift.io/requester: mesh-for-data
+  labels:
+    issue: https://github.com/open-infrastructure-labs/moc-cnv-sandbox/issues/7
+  name: mesh-for-data
+spec: {}

--- a/namespaces/overlays/moc/mesh-for-data/rbac.yaml
+++ b/namespaces/overlays/moc/mesh-for-data/rbac.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: operate-first
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: mesh-for-data

--- a/namespaces/overlays/moc/mesh-for-data/secret-generator.yaml
+++ b/namespaces/overlays/moc/mesh-for-data/secret-generator.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: secret-generator
+files:
+  - group.enc.yaml

--- a/namespaces/overlays/moc/observatorium-operator/kustomization.yaml
+++ b/namespaces/overlays/moc/observatorium-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/observatorium-operator

--- a/namespaces/overlays/moc/odh-operator/kustomization.yaml
+++ b/namespaces/overlays/moc/odh-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/odh-operator

--- a/namespaces/overlays/moc/open-aiops/group.enc.yaml
+++ b/namespaces/overlays/moc/open-aiops/group.enc.yaml
@@ -1,0 +1,39 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+    name: open-aiops
+users:
+- ENC[AES256_GCM,data:+9zH1EipHdU5yaFckx80tEj9,iv:lZ1OwbT6VYFkpzbT/Mpt7TKF+YQ5Z2DRiNIxYZidsY4=,tag:XlbEzeoAIJyvTLRSD36o9w==,type:str]
+- ENC[AES256_GCM,data:rsoS9KPI9rIPSReZbVrTH/4ZzxCFy78B,iv:Aj/jRJrRDu+3chBgx+iekNc3q9V6q+o8QnEdC0YRY5I=,tag:ws+PaPNKOKvBHqedUs6eGQ==,type:str]
+- ENC[AES256_GCM,data:yNxcQwolqdqkg533vKtVEe9YtrihoYM=,iv:EJUOE2R6T7Gw3v4bR3oXbYpOcCpBErUlSFOQmr3D3yE=,tag:sOYPIOsNE8RCalglBVmKaA==,type:str]
+- ENC[AES256_GCM,data:FzoihabAMTv1f0wRyNBD8Ja7BVe8RRvQcQs=,iv:TBxdx6kq+U+NDQikwiYVBCAmDnK/fbpJDe8FaGSgsDQ=,tag:rb7IOe2Ctvfm5W8HEEctFg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-01-12T17:24:03Z'
+    mac: ENC[AES256_GCM,data:/r42XNmxFZzMTxT0uf2Y0AkGZIKDzEYBGz4V0UVYgykcqXJiu2apZXBjoQnNzMuhHfmKPZKS7Q9gAZHKAQMgDm6in7MvhoOaaiSXtimVH1pCm27O0yuQ25sF+Cd2OaLKs0OvxSxMOKRA0Ve5A+A7saM10b1eCzYGoqlhABFyN9A=,iv:vWILYEHd4OP/ipLIuflE7l12E2WDIs+dKoXqYNBA2vs=,tag:u9BC+0BiGazm+nCAhWxOyg==,type:str]
+    pgp:
+    -   created_at: '2021-01-12T17:24:03Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA9aKBcudqifiARAAi/GO8MN537ZdryTUgpW5StR42wQfZGqFy89scZweqHST
+            evz+6HfSRsGBeaezjZk+vNU+rMtm36+IRbiyhRlOlHP3e3sQI0RxycOkgDjIS4DS
+            2ACg/fJ82jRG62rFVegCBf6f8+BlxFUAQ4QMF07vjats3DaMCcNzNNNuA2HxmcLr
+            EaBXIk5sTw3sas5hPDwqMxmw4snzvG7P3OYxYihe4XYKMrAnAoEq9yB0ISfqWErV
+            jfJ/7gtIVIGwkmvzqXwA4PRUkodzkl7gR+lrCMrAL/5gq4rhqaVk5zW4/uLWKVKf
+            PopAUHJUk37pV/tb8LkmJCAEeKDh8pBtJXBgEMwXoLaOLDzbKtA4KLOTm0SRb8Um
+            L6pKyvZrskS6LJs87eortHMI4u8EINr/w1fJ18Z5CjFlVtETjYcs/DOGqEqC9SuP
+            tgFsiIJgAdaOxu5nplEz4IZyFsQHI4IMEBf/fyn23r/btjiQ2AWgwKhEVyNkxLKz
+            fTHQc7NWRFfqDmrHk3zAOpR7bx4aU2f9R9atR6xX0sa7RVT9dcffPQQlrTmpHl0n
+            9woTQem4lMsB2+Y5iCOAaW2lKiB/wAq5lhK8m13oIxzx1OblaYuz5xyrTo1IuJ8Q
+            Z2PhiL1iroKjlUDsTWbk3fUukl+URQAxIwpOqu84gVHR9A/sFFz0rAh0C01++qDS
+            XgGE8wm8pua1KS19Xq4tZEZpEV3JQSBoLEepLrp/6zmmfpufIjhjV7Wns8orSPWF
+            mTMxDEbRir9u+jcI1TWTEivaa8HbUVf+rmKDqPr2HvGx58uXDa7jmmSD/lfXFFo=
+            =QCW3
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^users$
+    version: 3.6.1

--- a/namespaces/overlays/moc/open-aiops/kustomization.yaml
+++ b/namespaces/overlays/moc/open-aiops/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: open-aiops
+
+resources:
+  - namespace.yaml
+  - rbac.yaml
+
+generators:
+  - secret-generator.yaml

--- a/namespaces/overlays/moc/open-aiops/namespace.yaml
+++ b/namespaces/overlays/moc/open-aiops/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Open AIOps"
+    openshift.io/requester: open-aiops
+  labels:
+    issue: https://github.com/open-infrastructure-labs/moc-cnv-sandbox/issues/8
+  name: open-aiops
+spec: {}

--- a/namespaces/overlays/moc/open-aiops/rbac.yaml
+++ b/namespaces/overlays/moc/open-aiops/rbac.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: operate-first
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: open-aiops

--- a/namespaces/overlays/moc/open-aiops/secret-generator.yaml
+++ b/namespaces/overlays/moc/open-aiops/secret-generator.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: secret-generator
+files:
+  - group.enc.yaml

--- a/namespaces/overlays/moc/opf-argo/kustomization.yaml
+++ b/namespaces/overlays/moc/opf-argo/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-argo

--- a/namespaces/overlays/moc/opf-dashboard/kustomization.yaml
+++ b/namespaces/overlays/moc/opf-dashboard/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-dashboard

--- a/namespaces/overlays/moc/opf-datacatalog/kustomization.yaml
+++ b/namespaces/overlays/moc/opf-datacatalog/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-datacatalog

--- a/namespaces/overlays/moc/opf-jupyterhub/kustomization.yaml
+++ b/namespaces/overlays/moc/opf-jupyterhub/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-jupyterhub

--- a/namespaces/overlays/moc/opf-kafka/kustomization.yaml
+++ b/namespaces/overlays/moc/opf-kafka/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-kafka

--- a/namespaces/overlays/moc/opf-monitoring/kustomization.yaml
+++ b/namespaces/overlays/moc/opf-monitoring/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-monitoring

--- a/namespaces/overlays/moc/opf-observatorium/kustomization.yaml
+++ b/namespaces/overlays/moc/opf-observatorium/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-observatorium

--- a/namespaces/overlays/moc/opf-superset/kustomization.yaml
+++ b/namespaces/overlays/moc/opf-superset/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-superset

--- a/namespaces/overlays/quicklab/kustomization.yaml
+++ b/namespaces/overlays/quicklab/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - observatorium-operator
+  - odh-operator
+  - opf-argo
+  - opf-dashboard
+  - opf-datacatalog
+  - opf-jupyterhub
+  - opf-kafka
+  - opf-monitoring
+  - opf-observatorium
+  - opf-superset

--- a/namespaces/overlays/quicklab/observatorium-operator/kustomization.yaml
+++ b/namespaces/overlays/quicklab/observatorium-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/observatorium-operator

--- a/namespaces/overlays/quicklab/odh-operator/kustomization.yaml
+++ b/namespaces/overlays/quicklab/odh-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/odh-operator

--- a/namespaces/overlays/quicklab/opf-argo/kustomization.yaml
+++ b/namespaces/overlays/quicklab/opf-argo/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-argo

--- a/namespaces/overlays/quicklab/opf-dashboard/kustomization.yaml
+++ b/namespaces/overlays/quicklab/opf-dashboard/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-dashboard

--- a/namespaces/overlays/quicklab/opf-datacatalog/kustomization.yaml
+++ b/namespaces/overlays/quicklab/opf-datacatalog/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-datacatalog

--- a/namespaces/overlays/quicklab/opf-jupyterhub/kustomization.yaml
+++ b/namespaces/overlays/quicklab/opf-jupyterhub/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-jupyterhub

--- a/namespaces/overlays/quicklab/opf-kafka/kustomization.yaml
+++ b/namespaces/overlays/quicklab/opf-kafka/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-kafka

--- a/namespaces/overlays/quicklab/opf-monitoring/kustomization.yaml
+++ b/namespaces/overlays/quicklab/opf-monitoring/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-monitoring

--- a/namespaces/overlays/quicklab/opf-observatorium/kustomization.yaml
+++ b/namespaces/overlays/quicklab/opf-observatorium/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-observatorium

--- a/namespaces/overlays/quicklab/opf-superset/kustomization.yaml
+++ b/namespaces/overlays/quicklab/opf-superset/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base/opf-superset


### PR DESCRIPTION
Resolves: https://github.com/open-infrastructure-labs/moc-cnv-sandbox/issues/8, https://github.com/open-infrastructure-labs/moc-cnv-sandbox/issues/7, https://github.com/open-infrastructure-labs/ops-issues/issues/1

Introduces a new Argo CD application that would take care of deploying namespaces and the `admin` `ClusterRole` bindings for them, as well as some generic user management via `Group`s.

Adds admin permissions to the `operate-first` group as well as creates 2 new namespaces:
- `mesh-for-data` (https://github.com/open-infrastructure-labs/moc-cnv-sandbox/issues/8) with a `mesh-for-data` user group
- `open-aiops` (https://github.com/open-infrastructure-labs/moc-cnv-sandbox/issues/7) with `open-aiops` user group

The user stories/request tickets are linked as a label in the `Namespace` resource as well. 