### PR TITLE
Add argocd admins

### DIFF
--- a/namespaces/overlays/moc/argocd/kustomization.yaml
+++ b/namespaces/overlays/moc/argocd/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: argocd
+
+resources:
+  - rbac.yaml

--- a/namespaces/overlays/moc/argocd/rbac.yaml
+++ b/namespaces/overlays/moc/argocd/rbac.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: argocd-admins


### PR DESCRIPTION
I've intentionally left out the group/namespace for now. I don't have permissions to see the namespace so I can't see what the current annotations (and other fields) are there just yet, once I have permissions to do that I will update with the namespace. 

I've left the group out because, I'd like argocd to create these permissions first so I can add secret management capabilities, as it stands argocd won't be able to decrypt this group.

[Related](https://github.com/open-infrastructure-labs/moc-cnv-sandbox/issues/1)