### PR TITLE
Fix jh dashboard name

### DIFF
--- a/odh/base/monitoring/overrides/grafana-operator/overlays/dashboards/jupyterhub-dashboard.yaml
+++ b/odh/base/monitoring/overrides/grafana-operator/overlays/dashboards/jupyterhub-dashboard.yaml
@@ -1,10 +1,10 @@
 apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
-  name: Jupyterhub
+  name: jupyterhub
   labels:
     app: grafana
 spec:
-  name: Jupyterhub-dashboard.json
+  name: jupyterhub-dashboard.json
   url: https://raw.githubusercontent.com/operate-first/SRE/master/dashboards/Jupyterhub-dashboard.json
   json:


### PR DESCRIPTION
Fix jupyterhub dashboard name to follow the correct format:

`metadata.name: Invalid value: \"Jupyterhub\": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`