### PR TITLE
include thoth grafana dashboard to the moc monitoring

### DIFF
--- a/odh/overlays/moc/monitoring/dashboards/kustomization.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - thoth-station

--- a/odh/overlays/moc/monitoring/dashboards/thoth-station/common-patch.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/thoth-station/common-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/customFolderName
+  value: Thoth-Station

--- a/odh/overlays/moc/monitoring/dashboards/thoth-station/kustomization.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/thoth-station/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - thoth-kafka-argo-metrics.yaml
+  - thoth-knowledge-graph-content-metrics.yaml
+  - thoth-postgresql-metrics.yaml
+  - thoth-sli-slo.yaml
+  - thoth-user-api-metrics.yaml
+  - thoth-workflow-controllers-metrics.yaml
+patches:
+  - path: common-patch.yaml
+    target:
+      group: integreatly.org
+      version: v1alpha1
+      kind: GrafanaDashboard

--- a/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-kafka-argo-metrics.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-kafka-argo-metrics.yaml
@@ -1,0 +1,10 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: thoth-kafka-argo-metrics
+  labels:
+    app: grafana
+    component: thoth-station
+spec:
+  name: thoth-kafka-argo-metrics
+  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/cnv-prod/thoth-kafka-argo-metrics.json

--- a/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-knowledge-graph-content-metrics.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-knowledge-graph-content-metrics.yaml
@@ -1,0 +1,10 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: thoth-knowledge-graph-content-metrics
+  labels:
+    app: grafana
+    component: thoth-station
+spec:
+  name: thoth-knowledge-graph-content-metrics
+  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/cnv-prod/thoth-knowledge-graph-content-metrics.json

--- a/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-postgresql-metrics.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-postgresql-metrics.yaml
@@ -1,0 +1,10 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: thoth-postgresql-metrics
+  labels:
+    app: grafana
+    component: thoth-station
+spec:
+  name: thoth-postgresql-metrics
+  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/cnv-prod/thoth-postgresql-metrics.json

--- a/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-sli-slo.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-sli-slo.yaml
@@ -1,0 +1,10 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: thoth-sli-slo
+  labels:
+    app: grafana
+    component: thoth-station
+spec:
+  name: thoth-sli-slo
+  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/cnv-prod/thoth-sli-slo.json

--- a/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-user-api-metrics.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-user-api-metrics.yaml
@@ -1,0 +1,10 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: thoth-user-api-metrics
+  labels:
+    app: grafana
+    component: thoth-station
+spec:
+  name: thoth-user-api-metrics
+  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/cnv-prod/thoth-user-api-metrics.json

--- a/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-workflow-controllers-metrics.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-workflow-controllers-metrics.yaml
@@ -1,0 +1,10 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: thoth-workflow-controllers-metrics
+  labels:
+    app: grafana
+    component: thoth-station
+spec:
+  name: thoth-workflow-controllers-metrics
+  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/cnv-prod/thoth-workflow-controllers-metrics.json

--- a/odh/overlays/moc/monitoring/datasource/kustomization.yaml
+++ b/odh/overlays/moc/monitoring/datasource/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - thoth-station-datasource.yaml

--- a/odh/overlays/moc/monitoring/datasource/thoth-station-datasource.yaml
+++ b/odh/overlays/moc/monitoring/datasource/thoth-station-datasource.yaml
@@ -1,0 +1,17 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDataSource
+metadata:
+  name: thoth-station-grafanadatasource
+  labels:
+    app: grafana-datasources
+    component: thoth-station
+spec:
+  datasources:
+    - name: thoth-station
+      type: prometheus
+      url: http://prometheus-portal-thoth-infra-prod.apps.cnv.massopen.cloud/
+      version: 1
+      editable: true
+      jsonData:
+        tlsSkipVerify: true
+        timeInterval: "5s"

--- a/odh/overlays/moc/monitoring/kustomization.yaml
+++ b/odh/overlays/moc/monitoring/kustomization.yaml
@@ -7,3 +7,5 @@ components:
 resources:
   - ../../../base/monitoring
   - ./servicemonitors
+  - dashboards
+  - datasource


### PR DESCRIPTION
 include thoth grafana dashboard to the moc monitoring
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Depends-On: https://github.com/thoth-station/thoth-application/pull/752
Related-to: https://github.com/operate-first/apps/issues/108


Questions:
How to introduce the datasource along with this? 
Referencing this https://github.com/operate-first/apps/issues/59, should i also include the datasource manifest along with these.