### PR TITLE
Add servicemonitor to monitor ODH deployed components

### DIFF
--- a/odh/base/monitoring/overrides/prometheus-operator/base/prometheus.yaml
+++ b/odh/base/monitoring/overrides/prometheus-operator/base/prometheus.yaml
@@ -22,6 +22,3 @@ spec:
       prometheus: odh-monitoring
       role: alert-rules
   replicas: 2
-  remoteRead:
-    - url: "http://prometheus-operated.opf-jupyterhub.svc.cluster.local:9090\
-            /api/v1/read"

--- a/odh/base/monitoring/overrides/prometheus-operator/base/servicemonitor.yaml
+++ b/odh/base/monitoring/overrides/prometheus-operator/base/servicemonitor.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: odhservicemonitor
+spec:
+  endpoints:
+    - port: web             # odh-operator, Argo, Prometheus
+    - port: grafana         # grafana
+    - port: http-metrics    # grafana-operator
+    - port: 8080-tcp        # Jupyterhub
+      path: "/metrics"
+  selector: {}
+  namespaceSelector:
+    matchNames:
+      - opf-jupyterhub
+      - opf-argo
+      - opf-monitoring


### PR DESCRIPTION
Override the [odh servicemonitor](https://github.com/opendatahub-io/odh-manifests/blob/master/prometheus/operator/base/servicemonitor.yaml) to include opf namespaces

Also remove the remote read config from Prometheus since we won't need it after the JH service monitor is available