### PR TITLE
Remove unused Prometheus from opf-jupyterhub

### DIFF
--- a/odh/base/jupyterhub/kfdef.yaml
+++ b/odh/base/jupyterhub/kfdef.yaml
@@ -13,16 +13,6 @@ spec:
           path: odh-common
       name: odh-common
     - kustomizeConfig:
-        repoRef:
-          name: manifests
-          path: prometheus/cluster
-      name: prometheus-cluster
-    - kustomizeConfig:
-        repoRef:
-          name: manifests
-          path: prometheus/operator
-      name: prometheus-operator
-    - kustomizeConfig:
         overlays: []
         parameters:
           - name: s3_endpoint_url


### PR DESCRIPTION
these changes are related to #123 