### PR TITLE
Update github receiver

### DIFF
--- a/odh/base/monitoring/github-receiver-service.yaml
+++ b/odh/base/monitoring/github-receiver-service.yaml
@@ -7,6 +7,8 @@ spec:
   ports:
     - port: 9393
       targetPort: receiver
+    - port: 9990
+      targetPort: metrics
   selector:
     # Pods with labels matching this key/value pair will be publically
     # accessible through the service IP and port.

--- a/odh/base/monitoring/github-receiver.yaml
+++ b/odh/base/monitoring/github-receiver.yaml
@@ -25,11 +25,13 @@ spec:
                 secretKeyRef:
                   name: github-secrets
                   key: auth-token
-          args: ["--authtoken=$(GITHUB_AUTH_TOKEN)",
-                 "--org=operate-first",
-                 "--repo=SRE",
-                 "--label=in progress",
-                 "--enable-inmemory=false"]
+          args:
+            - --auth-token=$GITHUB_AUTH_TOKEN
+            - --org=operate-first
+            - --repo=SRE
+            - --label="in progress"
+            - --enable-inmemory="false"
+            - --enable-auto-close="true"
           ports:
             - containerPort: 9393
               name: receiver


### PR DESCRIPTION
This will:
1. Update the github receiver to enable auto closing of issues for resolved alerts
2. Add the metrics port for the github receiver service so that prometheus can monitor it