### PR TITLE
fix gh alert receiver service port names

### DIFF
--- a/odh/base/monitoring/github-receiver-service.yaml
+++ b/odh/base/monitoring/github-receiver-service.yaml
@@ -7,8 +7,10 @@ spec:
   ports:
     - port: 9393
       targetPort: receiver
+      name: receiver
     - port: 9990
       targetPort: metrics
+      name: metrics
   selector:
     # Pods with labels matching this key/value pair will be publically
     # accessible through the service IP and port.


### PR DESCRIPTION
should fix `Service "github-receiver-service" is invalid: [spec.ports[0].name: Required value, spec.ports[1].name: Required value]`