### PR TITLE
feat: Update ODH Argo to latest

### DIFF
--- a/odh/base/argo/kfdef.yaml
+++ b/odh/base/argo/kfdef.yaml
@@ -14,15 +14,17 @@ spec:
         name: odh-common
     - kustomizeConfig:
         repoRef:
-          name: manifests
+          name: master
           path: odhargo/cluster
       name: odhargo-cluster
     - kustomizeConfig:
         repoRef:
-          name: manifests
+          name: master
           path: odhargo/odhargo
       name: odhargo
   repos:
     - name: manifests
       uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v0.9.0"
+    - name: master
+      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/master"
   version: v0.9.0


### PR DESCRIPTION
Updates Argo to 2.12.3

Requires: https://github.com/opendatahub-io/odh-manifests/pull/208 and https://github.com/operate-first/odh-dashboard/pull/4