### PR TITLE
fix gh receiver auth-token arg

### DIFF
--- a/odh/base/monitoring/github-receiver.yaml
+++ b/odh/base/monitoring/github-receiver.yaml
@@ -26,7 +26,7 @@ spec:
                   name: github-secrets
                   key: auth-token
           args:
-            - --auth-token=$GITHUB_AUTH_TOKEN
+            - --auth-token=$(GITHUB_AUTH_TOKEN)
             - --org=operate-first
             - --repo=SRE
             - --label="in progress"


### PR DESCRIPTION
Should fix the error:
`flag provided but not defined: -auth-token`