### PR TITLE
Add argocd to moc cluster-scope overlay

### DIFF
--- a/cluster-scope/overlays/moc/kustomization.yaml
+++ b/cluster-scope/overlays/moc/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ../../base/groups/operate-first
   - ../../base/groups/rekor
   - ../../base/groups/thoth
+  - ../../base/namespaces/argocd
   - ../../base/namespaces/mesh-for-data
   - ../../base/namespaces/observatorium-operator
   - ../../base/namespaces/odh-operator


### PR DESCRIPTION
this enables sync for the [argocd namespace](https://github.com/operate-first/apps/tree/master/cluster-scope/base/namespaces/argocd)