### PR TITLE
feat: Update ODH Dashboard downstream to latest

### DIFF
--- a/odh/base/dashboard/overrides/overlays/custom-image/kustomization.yaml
+++ b/odh/base/dashboard/overrides/overlays/custom-image/kustomization.yaml
@@ -7,4 +7,4 @@ bases:
 images:
   - name: quay.io/opendatahub/odh-dashboard:v0.9
     newName: quay.io/operate-first/odh-dashboard
-    newTag: v0.9
+    newTag: latest


### PR DESCRIPTION
This will allow us to apply https://github.com/operate-first/odh-dashboard/pull/4 which is already available as: `quay.io/operate-first/odh-dashboard:latest`

https://quay.io/repository/operate-first/odh-dashboard/manifest/sha256:fe8ee3c51b922bf7a4f1b242d4b9ed727a017cd3c9b85804c746210f10e32ad0