### PR TITLE
Add basic up alerts for opf services

### DIFF
--- a/odh/base/monitoring/overrides/prometheus-operator/overlays/alerts/prometheus-rules.yaml
+++ b/odh/base/monitoring/overrides/prometheus-operator/overlays/alerts/prometheus-rules.yaml
@@ -11,14 +11,74 @@ spec:
     - name: Operate First Availability
       rules:
         - alert: Prometheus Service Down
-          expr: up{service="prometheus-operated"} == 0
+          expr: count(up{service="prometheus-operated", pod=~"prometheus-odh-monitoring.*"} == 0) > 1
           for: 5m
           annotations:
             summary: "Prometheus service is no longer available"
             severity: "HIGH"
         - alert: Prometheus Alertmanager Down
-          expr: up{service="alert-manager"} == 0
+          expr: absent(up{service="alert-manager"} == 1)
           for: 5m
           annotations:
             summary: "Prometheus Alertmanager is no longer available"
+            severity: "HIGH"
+        - alert: Grafana Service Down
+          expr: absent(up{service="grafana-service"} == 1)
+          for: 5m
+          annotations:
+            summary: "Grafana service is no longer available"
+            severity: "HIGH"
+        - alert: Grafana Operator
+          expr: absent(up{service="grafana-operator-metrics"} == 1)
+          for: 5m
+          annotations:
+            summary: "Grafana operator metrics not available"
+            severity: "LOW"
+        - alert: JupyterHub Service Down
+          expr: absent(up{service="jupyterhub"} == 1)
+          for: 5m
+          annotations:
+            summary: "JupyterHub service is no longer available"
+            severity: "HIGH"
+        - alert: ArgoCD Repo Server Down
+          expr: absent(up{service="argocd-repo-server"} == 1)
+          for: 5m
+          annotations:
+            summary: "ArgoCD repo server is no longer available"
+            severity: "HIGH"
+        - alert: ArgoCD Server Down
+          expr: absent(up{service="argocd-server-metrics"} == 1)
+          for: 5m
+          annotations:
+            summary: "ArgoCD server is no longer available"
+            severity: "HIGH"
+        - alert: ArgoCD Application Controller Down
+          expr: absent(up{service="argocd-metrics"} == 1)
+          for: 5m
+          annotations:
+            summary: "ArgoCD application controller is no longer available"
+            severity: "HIGH"
+        - alert: Observatorium Loki Ingester Down
+          expr: absent(up{service="opf-observatorium-loki-ingester-http"} == 1)
+          for: 5m
+          annotations:
+            summary: "Loki ingester is no longer available"
+            severity: "HIGH"
+        - alert: Observatorium Loki Distributor Down
+          expr: absent(up{service="opf-observatorium-loki-distributor-http"} == 1)
+          for: 5m
+          annotations:
+            summary: "Loki distributor is no longer available"
+            severity: "HIGH"
+        - alert: Observatorium Loki Querier Down
+          expr: absent(up{service="opf-observatorium-loki-querier-http"} == 1)
+          for: 5m
+          annotations:
+            summary: "Loki querier is no longer available"
+            severity: "HIGH"
+        - alert: Observatorium Loki Query Frontend Down
+          expr: absent(up{service="opf-observatorium-loki-query-frontend-http"} == 1)
+          for: 5m
+          annotations:
+            summary: "Loki query frontend is no longer available"
             severity: "HIGH"

--- a/odh/base/monitoring/overrides/prometheus-operator/overlays/alerts/prometheus-rules.yaml
+++ b/odh/base/monitoring/overrides/prometheus-operator/overlays/alerts/prometheus-rules.yaml
@@ -11,7 +11,7 @@ spec:
     - name: Operate First Availability
       rules:
         - alert: Prometheus Service Down
-          expr: count(up{service="prometheus-operated", pod=~"prometheus-odh-monitoring.*"} == 0) > 1
+          expr: absent(up{service="prometheus-operated", pod=~"prometheus-odh-monitoring.*"} > 0)
           for: 5m
           annotations:
             summary: "Prometheus service is no longer available"


### PR DESCRIPTION
Adding basic "up" alerts for available opf services, based on grafana dashboard created [here](https://grafana-route-opf-monitoring.apps.cnv.massopen.cloud/d/r7WqgaBMk/operatefirst-availability?orgId=1&refresh=1m)

This closes https://github.com/operate-first/SRE/issues/33