### PR TITLE
Adding github secret to kustomize

### DIFF
--- a/odh/overlays/moc/monitoring/kustomization.yaml
+++ b/odh/overlays/moc/monitoring/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
   - ./servicemonitors
   - dashboards
   - datasource
+generators:
+  - secrets/secret-generator.yaml


### PR DESCRIPTION
Including the GitHub alertmanager receiver secret in kustomize, as secret management is now in place

Related to #77