### PR TITLE
servicemonitor setup for thoth-station component monitoring

### DIFF
--- a/odh/overlays/moc/monitoring/servicemonitors/kustomization.yaml
+++ b/odh/overlays/moc/monitoring/servicemonitors/kustomization.yaml
@@ -6,3 +6,4 @@ commonLabels:
 resources:
   - observatorium-servicemonitor.yaml
   - argocd-servicemonitor.yaml
+  - thoth-station-servicemonitor.yaml

--- a/odh/overlays/moc/monitoring/servicemonitors/thoth-station-servicemonitor.yaml
+++ b/odh/overlays/moc/monitoring/servicemonitors/thoth-station-servicemonitor.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: thoth-station-monitor
+  labels:
+    monitor-component: thoth-station
+spec:
+  endpoints:
+    - targetPort: 8080
+    - targetPort: 6066
+    - targetPort: 9187
+    - targetPort: 2746
+  namespaceSelector:
+    matchNames:
+      - thoth-frontend-prod
+      - thoth-backend-prod
+      - thoth-middletier-prod
+      - thoth-infra-prod
+      - thoth-graph-prod
+      - thoth-amun-inspection-prod
+      - thoth-amun-api-prod
+  selector: {}


### PR DESCRIPTION
servicemonitor setup for thoth-station component monitoring
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


Related-to: https://github.com/operate-first/apps/issues/108