### PR TITLE
Add monitoring rbc for openshift-monitoring namespace

### DIFF
--- a/cluster-scope/base/clusterrolebindings/metrics/kustomization.yaml
+++ b/cluster-scope/base/clusterrolebindings/metrics/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - metrics-clusterrolebinding.yaml

--- a/cluster-scope/base/clusterrolebindings/metrics/metrics-clusterrolebinding.yaml
+++ b/cluster-scope/base/clusterrolebindings/metrics/metrics-clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metrics
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: opf-monitoring

--- a/cluster-scope/base/clusterroles/metrics/kustomization.yaml
+++ b/cluster-scope/base/clusterroles/metrics/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - metrics-clusterrole.yaml

--- a/cluster-scope/base/clusterroles/metrics/metrics-clusterrole.yaml
+++ b/cluster-scope/base/clusterroles/metrics/metrics-clusterrole.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: metrics
+rules:
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]

--- a/cluster-scope/base/namespaces/openshift-monitoring/kustomization.yaml
+++ b/cluster-scope/base/namespaces/openshift-monitoring/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-monitoring
+
+components:
+  - ../../../components/monitoring-rbac

--- a/cluster-scope/overlays/moc/kustomization.yaml
+++ b/cluster-scope/overlays/moc/kustomization.yaml
@@ -32,6 +32,7 @@ resources:
   - ../../base/namespaces/opf-jupyterhub
   - ../../base/namespaces/opf-kafka
   - ../../base/namespaces/opf-monitoring
+  - ../../base/namespaces/openshift-monitoring
   - ../../base/namespaces/opf-observatorium
   - ../../base/namespaces/opf-superset
   - ../../base/namespaces/thoth-amun-api-prod

--- a/cluster-scope/overlays/moc/kustomization.yaml
+++ b/cluster-scope/overlays/moc/kustomization.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 resources:
   - ../../base/clusterroles/prow.k8s.io
   - ../../base/clusterloggings
+  - ../../base/clusterroles/metrics
+  - ../../base/clusterrolebindings/metrics
   - ../../base/crds/prow.k8s.io
   - ../../base/groups/approved-users
   - ../../base/groups/argocd-admins


### PR DESCRIPTION
Closes #160 

once this is pushed, we can add servicemonitors to monitor kube-state-metrics and node-exporter metrics

ping @tumido @larsks 