### PR TITLE
Add clusterrolebinding for opf prometheus to get clustermetrics

### DIFF
--- a/cluster-scope/base/clusterrolebindings/metrics/cluster-metrics-federation-clusterrolebinding.yaml
+++ b/cluster-scope/base/clusterrolebindings/metrics/cluster-metrics-federation-clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-metrics-federation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: opf-monitoring

--- a/cluster-scope/base/clusterrolebindings/metrics/kustomization.yaml
+++ b/cluster-scope/base/clusterrolebindings/metrics/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 
 resources:
   - metrics-clusterrolebinding.yaml
+  - cluster-metrics-federation-clusterrolebinding.yaml


### PR DESCRIPTION
According to the [openshift monitoring docs](https://docs.openshift.com/container-platform/4.5/monitoring/cluster_monitoring/prometheus-alertmanager-and-grafana.html#monitoring-accessing-prometheus-alertmanager-grafana-directly_accessing-prometheus), we need to add a clusterrolebinding for opf prometheus to be able to access (federate) metrics from openshift-monitoring prometheus