### PR TITLE
Added moc infra members to owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -13,3 +13,6 @@ reviewers:
   - HumairAK
   - tumido
   - martinpovolny
+  - larsks
+  - ipolonsk
+  - naved001


### PR DESCRIPTION
As per discussion [here](https://github.com/open-infrastructure-labs/ops-issues/issues/16#issuecomment-769881670). We are storing various cluster manifests here, so it stands to reason the environment owners should be reviewers as well.