### PR TITLE
Enable anonymous access to grafana

### DIFF
--- a/odh/base/monitoring/kfdef.yaml
+++ b/odh/base/monitoring/kfdef.yaml
@@ -43,6 +43,7 @@ spec:
     - kustomizeConfig:
         overlays:
           - dashboards
+          - datasources
         repoRef:
           name: opf
           path: odh/base/monitoring/overrides/grafana-operator

--- a/odh/base/monitoring/overrides/grafana-operator/base/grafana.yaml
+++ b/odh/base/monitoring/overrides/grafana-operator/base/grafana.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: integreatly.org/v1alpha1
 kind: Grafana
 metadata:
@@ -15,9 +16,11 @@ spec:
         users:
             allow_sign_up: false
             auto_assign_org: true
-            auto_assign_org_role: Admin
+            auto_assign_org_role: Viewer
+            viewers_can_edit: true
         auth.anonymous:
-            enabled: false
+            enabled: true
+            org_role: Viewer
         log:
             level: warn
             mode: console

--- a/odh/base/monitoring/overrides/grafana-operator/overlays/datasources/kustomization.yaml
+++ b/odh/base/monitoring/overrides/grafana-operator/overlays/datasources/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - odh-datasource.yaml

--- a/odh/base/monitoring/overrides/grafana-operator/overlays/datasources/odh-datasource.yaml
+++ b/odh/base/monitoring/overrides/grafana-operator/overlays/datasources/odh-datasource.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDataSource
+metadata:
+  name: odh-grafanadatasource
+spec:
+  datasources:
+    - access: proxy
+      editable: false
+      isDefault: true
+      jsonData:
+        timeInterval: 5s
+        tlsSkipVerify: true
+      name: opendatahub
+      type: prometheus
+      url: 'http://prometheus-operated:9090'
+      version: 1
+  name: odh-prometheus.yaml


### PR DESCRIPTION
Add odh grafana datasource
This will enable anonymous users to see our dashboards and edit them, but they won't be able to save their changes.
So no need for people to login to view existing dashboards.

Closes #59 