### PR TITLE
feat: Scale down and always fetch ODH Dashboard 

### DIFF
--- a/odh/base/dashboard/overrides/overlays/custom-image/deployment.yaml
+++ b/odh/base/dashboard/overrides/overlays/custom-image/deployment.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: odh-dashboard
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: odh-dashboard
+          imagePullPolicy: Always

--- a/odh/base/dashboard/overrides/overlays/custom-image/kustomization.yaml
+++ b/odh/base/dashboard/overrides/overlays/custom-image/kustomization.yaml
@@ -8,3 +8,6 @@ images:
   - name: quay.io/opendatahub/odh-dashboard:v0.9
     newName: quay.io/operate-first/odh-dashboard
     newTag: latest
+
+patchesStrategicMerge:
+  - deployment.yaml


### PR DESCRIPTION
This scale down the ODH Dashboard from unnecessary 2 replicas to a single one for now. I don't think there's any need for 2, they are idle all the time anyways.

Also specifies a `ImagePullPolicy` to `Always` so in case we update the `quay.io/operate-first/odh-dashboard:latest` openshift can update the image on a new pod rollout.