### PR TITLE
Fix alerting

### DIFF
--- a/odh/base/monitoring/alertmanager-config.yaml
+++ b/odh/base/monitoring/alertmanager-config.yaml
@@ -8,7 +8,7 @@ stringData:
     global:
       resolve_timeout: 5m
     route:
-      group_by: ['job']
+      group_by: ['job', 'alertname']
       group_wait: 30s
       group_interval: 5m
       repeat_interval: 3h

--- a/odh/base/monitoring/github-receiver.yaml
+++ b/odh/base/monitoring/github-receiver.yaml
@@ -32,6 +32,7 @@ spec:
             - --label=in progress
             - --enable-inmemory=false
             - --enable-auto-close=true
+            - --label-on-resolved=resolved
           ports:
             - containerPort: 9393
               name: receiver


### PR DESCRIPTION
This addresses:

- https://github.com/operate-first/SRE/issues/37 - ensuring proper issue title gets added when an alert is triggered, based on the suggestions discussed here: https://github.com/m-lab/alertmanager-github-receiver/issues/50#issuecomment-769996613
- adds a `resolved` label to the issue once the alert is resolved

