### PR TITLE
Add storage to opf prometheus to retain metrics for 2 weeks

### DIFF
--- a/odh/base/monitoring/overrides/prometheus-operator/base/prometheus.yaml
+++ b/odh/base/monitoring/overrides/prometheus-operator/base/prometheus.yaml
@@ -22,3 +22,10 @@ spec:
       prometheus: odh-monitoring
       role: alert-rules
   replicas: 2
+  retention: 14d
+  storage:
+    volumeClaimTemplate:
+      spec:
+        resources:
+          requests:
+            storage: 10Gi


### PR DESCRIPTION
This should enable metrics to persist for 2 weeks

Just to be clear because the number of replicas are set to 2, this will create 2 10gig PVCs

I am planning to let this run over the weekend and see how much storage is used by these metrics for 2 days. Using that information, we can adjust the size of the PVC