### PR TITLE
Increase Prometheus Storage and reduce Metrics Retention

### DIFF
--- a/odh/base/monitoring/overrides/prometheus-operator/base/prometheus.yaml
+++ b/odh/base/monitoring/overrides/prometheus-operator/base/prometheus.yaml
@@ -22,10 +22,10 @@ spec:
       prometheus: odh-monitoring
       role: alert-rules
   replicas: 2
-  retention: 14d
+  retention: 7d
   storage:
     volumeClaimTemplate:
       spec:
         resources:
           requests:
-            storage: 10Gi
+            storage: 50Gi


### PR DESCRIPTION
This should resolve issues:
https://github.com/operate-first/SRE/issues/38 to https://github.com/operate-first/SRE/issues/49

The reason these issues were created is because the current Prometheus instance is out of storage and cannot collect new metrics. Because the metrics for the services are absent, the alerts are triggered.