### PR TITLE
service monitor added for metrics scraping from thoth-deployment-examples

### DIFF
--- a/odh/overlays/moc/monitoring/servicemonitors/thoth-station-servicemonitor.yaml
+++ b/odh/overlays/moc/monitoring/servicemonitors/thoth-station-servicemonitor.yaml
@@ -20,4 +20,5 @@ spec:
       - thoth-graph-prod
       - thoth-amun-inspection-prod
       - thoth-amun-api-prod
+      - thoth-deployment-examples
   selector: {}


### PR DESCRIPTION
service monitor added for metrics scraping from thoth-deployment-examples
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Related-to: https://github.com/thoth-station/elyra-aidevsecops-tutorial/issues/43