### PR TITLE
feat: Grant cluster-logs-reader ClusterRole to user groups

### DIFF
--- a/cluster-scope/base/clusterrolebindings/cluster-logs-readers/clusterrolebinding.yaml
+++ b/cluster-scope/base/clusterrolebindings/cluster-logs-readers/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-logs-readers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-logs-reader
+subjects:
+  - kind: Group
+    name: operate-first
+  - kind: Group
+    name: open-aiops

--- a/cluster-scope/base/clusterrolebindings/cluster-logs-readers/kustomization.yaml
+++ b/cluster-scope/base/clusterrolebindings/cluster-logs-readers/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/clusterroles/cluster-logs-reader/clusterrole.yaml
+++ b/cluster-scope/base/clusterroles/cluster-logs-reader/clusterrole.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-logs-reader
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+      - pods
+    verbs:
+      - get
+      - list
+      - watch

--- a/cluster-scope/base/clusterroles/cluster-logs-reader/kustomization.yaml
+++ b/cluster-scope/base/clusterroles/cluster-logs-reader/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - clusterrole.yaml

--- a/cluster-scope/overlays/moc/kustomization.yaml
+++ b/cluster-scope/overlays/moc/kustomization.yaml
@@ -6,8 +6,10 @@ resources:
   - ../../base/clusterroles/prow-aggregate-to-admin
   - ../../base/clusterroles/prow-aggregate-to-edit
   - ../../base/clusterroles/prow-aggregate-to-view
+  - ../../base/clusterroles/cluster-logs-reader
   - ../../base/clusterroles/metrics
   - ../../base/clusterroles/observatorium-operator
+  - ../../base/clusterrolebindings/cluster-logs-readers
   - ../../base/clusterrolebindings/cluster-metrics-federation
   - ../../base/clusterrolebindings/metrics
   - ../../base/crds/prow.k8s.io


### PR DESCRIPTION
Replaces: https://github.com/operate-first/apps/pull/175
Related: https://github.com/operate-first/apps/issues/193
Resolves: https://github.com/operate-first/apps/issues/171

Grants read access to all `pods` and `pods/log` in all namespaces on a cluster. This PR unblocks @eranra and team to access `infra-*` and other apps in cluster logging ElasticSearch and [Kibana](https://kibana-openshift-logging.apps.cnv.massopen.cloud/)

~~Question is if we care that people have `cluster-reader` access... I vote "I don't care, let people see things".~~

I've end up creating a new clusterrole - in the end it turned out that it only requires `pods` and `pods/log` access on `default`, `kube-*` and `openshift-*` namespaces. Since there's no easy way how to take into account all these namespaces via `Role`s, I'm for granting this access on the cluster level.