### PR TITLE
Add kubeflow component namespaces

### DIFF
--- a/cluster-scope/base/namespaces/cert-manager/kustomization.yaml
+++ b/cluster-scope/base/namespaces/cert-manager/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: cert-manager
+
+components:
+  - ../../../components/project-admin-rolebindings/operate-first

--- a/cluster-scope/base/namespaces/istio-system/kustomization.yaml
+++ b/cluster-scope/base/namespaces/istio-system/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: istio-system
+
+resources:
+  - namespace.yaml
+
+components:
+  - ../../../components/project-admin-rolebindings/operate-first
+  - ../../../components/monitoring-rbac

--- a/cluster-scope/base/namespaces/istio-system/namespace.yaml
+++ b/cluster-scope/base/namespaces/istio-system/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Operate First: Istio"
+    openshift.io/requester: operate-first
+  name: istio-system
+spec: {}

--- a/cluster-scope/base/namespaces/knative-serving/kustomization.yaml
+++ b/cluster-scope/base/namespaces/knative-serving/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: knative-serving
+
+resources:
+  - namespace.yaml
+
+components:
+  - ../../../components/project-admin-rolebindings/operate-first
+  - ../../../components/monitoring-rbac

--- a/cluster-scope/base/namespaces/knative-serving/namespace.yaml
+++ b/cluster-scope/base/namespaces/knative-serving/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Operate First: Kubeflow Knative Serving"
+    openshift.io/requester: operate-first
+  name: knative-serving
+spec: {}

--- a/cluster-scope/base/namespaces/kube-system/kustomization.yaml
+++ b/cluster-scope/base/namespaces/kube-system/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kube-system
+
+components:
+  - ../../../components/project-admin-rolebindings/operate-first

--- a/cluster-scope/base/namespaces/kubeflow/kustomization.yaml
+++ b/cluster-scope/base/namespaces/kubeflow/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kubeflow
+
+resources:
+  - namespace.yaml
+
+components:
+  - ../../../components/project-admin-rolebindings/operate-first
+  - ../../../components/monitoring-rbac

--- a/cluster-scope/base/namespaces/kubeflow/namespace.yaml
+++ b/cluster-scope/base/namespaces/kubeflow/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Operate First: Kubeflow Components"
+    openshift.io/requester: operate-first
+  name: kubeflow
+spec: {}

--- a/cluster-scope/base/namespaces/tekton-pipelines/kustomization.yaml
+++ b/cluster-scope/base/namespaces/tekton-pipelines/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: tekton-pipelines
+
+resources:
+  - namespace.yaml
+
+components:
+  - ../../../components/project-admin-rolebindings/operate-first
+  - ../../../components/monitoring-rbac

--- a/cluster-scope/base/namespaces/tekton-pipelines/namespace.yaml
+++ b/cluster-scope/base/namespaces/tekton-pipelines/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Operate First: Kubeflow Tekton Pipelines"
+    openshift.io/requester: operate-first
+  name: tekton-pipelines
+spec: {}

--- a/cluster-scope/overlays/moc/kustomization.yaml
+++ b/cluster-scope/overlays/moc/kustomization.yaml
@@ -20,6 +20,11 @@ resources:
   - ../../base/groups/rekor
   - ../../base/groups/thoth
   - ../../base/namespaces/argocd
+  - ../../base/namespaces/cert-manager
+  - ../../base/namespaces/istio-system
+  - ../../base/namespaces/knative-serving
+  - ../../base/namespaces/kube-system
+  - ../../base/namespaces/kubeflow
   - ../../base/namespaces/m4d-blueprints
   - ../../base/namespaces/m4d-system
   - ../../base/namespaces/mesh-for-data
@@ -39,6 +44,7 @@ resources:
   - ../../base/namespaces/openshift-monitoring
   - ../../base/namespaces/opf-observatorium
   - ../../base/namespaces/opf-superset
+  - ../../base/namespaces/tekton-pipelines
   - ../../base/namespaces/thoth-amun-api-prod
   - ../../base/namespaces/thoth-amun-inspection-prod
   - ../../base/namespaces/thoth-backend-prod


### PR DESCRIPTION
This will create 4 new namespaces:
1. kubeflow
2. knative-serving
3. tekton-pipelines
4. istio-systems

And add 2 existing namespaces:
1. cert-manager
2. kube-system

These namespaces are intended for installation of kubeflow and it's components: kubeflow-pipeline, istio, Tekton pipelines, knative

Related: https://github.com/operate-first/support/issues/62 https://github.com/operate-first/support/issues/63