### PR TITLE
Add monitoring dashboards

### DIFF
--- a/odh/overlays/moc/monitoring/dashboards/operate-first/jupyterhub-usage.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/operate-first/jupyterhub-usage.yaml
@@ -1,0 +1,10 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  labels:
+    app: grafana
+  name: jupyterhub-usage
+spec:
+  customFolderName: Operate-First
+  name: jupyterhub-usage
+  url: https://raw.githubusercontent.com/operate-first/SRE/master/dashboards/jupyterhub-usage.json

--- a/odh/overlays/moc/monitoring/dashboards/operate-first/kustomization.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/operate-first/kustomization.yaml
@@ -3,3 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - argocd.yaml
+  - jupyterhub-usage.yaml
+  - opf-availability.yaml

--- a/odh/overlays/moc/monitoring/dashboards/operate-first/opf-availability.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/operate-first/opf-availability.yaml
@@ -1,0 +1,10 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  labels:
+    app: grafana
+  name: opf-availability
+spec:
+  customFolderName: Operate-First
+  name: opf-availability
+  url: https://github.com/operate-first/SRE/blob/master/dashboards/opf-availability.json


### PR DESCRIPTION
Adding the following dashboards:

1. [JupyterHub usage dashboard](https://grafana-route-opf-monitoring.apps.cnv.massopen.cloud/d/YuYfkHYMk/jupyterhub-usage?orgId=1) (related to https://github.com/operate-first/support/issues/61)
2. [Opf availability dashboard](https://grafana-route-opf-monitoring.apps.cnv.massopen.cloud/d/r7WqgaBMk/operatefirst-availability?orgId=1)