### PR TITLE
feat: Add a Rook/Noobaa standalone application

### DIFF
--- a/ceph/README.md
+++ b/ceph/README.md
@@ -1,0 +1,3 @@
+# Rook and Noobaa deployment
+
+This application provides Rook and Nooba deployment spec. Depends on the `local-storage` application.

--- a/ceph/base/kustomization.yaml
+++ b/ceph/base/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+resources:
+  - storagecluster.yaml

--- a/ceph/base/storagecluster.yaml
+++ b/ceph/base/storagecluster.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+  name: ocs-storagecluster
+spec:
+  manageNodes: false
+  monDataDirHostPath: /var/lib/rook
+  storageDeviceSets:
+    - count: 3
+      dataPVCTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 500Gi
+          storageClassName: localblock
+          volumeMode: Block
+      name: ocs-deviceset
+      placement: {}
+      portable: false
+      replica: 3
+      resources: {}

--- a/ceph/overlays/crc/kustomization.yaml
+++ b/ceph/overlays/crc/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base

--- a/ceph/overlays/moc/kustomization.yaml
+++ b/ceph/overlays/moc/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base

--- a/ceph/overlays/quicklab/kustomization.yaml
+++ b/ceph/overlays/quicklab/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base


### PR DESCRIPTION
Related to: https://github.com/operate-first/apps/pull/131

Syncs down the Ceph provider from MOC CNV in `openshift-storage` namespace