### PR TITLE
feat: Add a local storage standalone application

### DIFF
--- a/local-storage/README.md
+++ b/local-storage/README.md
@@ -1,0 +1,1 @@
+# Local storage deployment

--- a/local-storage/base/kustomization.yaml
+++ b/local-storage/base/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: local-storage
+
+resources:
+  - localstorage.yaml

--- a/local-storage/base/localstorage.yaml
+++ b/local-storage/base/localstorage.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: localblock
+spec:
+  logLevel: Normal
+  managementState: Managed
+  nodeSelector:
+    nodeSelectorTerms:
+      - matchExpressions:
+          - key: cluster.ocs.openshift.io/openshift-storage
+            operator: In
+            values:
+              - ""
+  storageClassDevices: []

--- a/local-storage/overlays/crc/kustomization.yaml
+++ b/local-storage/overlays/crc/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base

--- a/local-storage/overlays/moc/kustomization.yaml
+++ b/local-storage/overlays/moc/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patchesStrategicMerge:
+  - localstorage_patch.yaml

--- a/local-storage/overlays/moc/localstorage_patch.yaml
+++ b/local-storage/overlays/moc/localstorage_patch.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: localblock
+spec:
+  storageClassDevices:
+    - devicePaths:
+        - /dev/disk/by-id/scsi-36c81f660d0a47e0026e3bc8686d39c5d
+        - /dev/disk/by-id/scsi-36c81f660d0a47e0026e3bc9e883ffe75
+        - /dev/disk/by-id/scsi-36c81f660d0a47e0026e3bcae892d8595
+        - /dev/disk/by-id/scsi-36848f690eec9800026e3bc517b93813e
+        - /dev/disk/by-id/scsi-36848f690eec9800026e3bc687cf0d1c8
+        - /dev/disk/by-id/scsi-36848f690eec9800026e3bc737d9afd22
+        - /dev/disk/by-id/scsi-36d4ae520a8d2c20026e3bcbe919f97c7
+        - /dev/disk/by-id/scsi-36d4ae520a8d2c20026e3bcc692136ac9
+        - /dev/disk/by-id/scsi-36d4ae520a8d2c20026e3bcce92911b58
+      storageClassName: localblock
+      volumeMode: Block

--- a/local-storage/overlays/quicklab/kustomization.yaml
+++ b/local-storage/overlays/quicklab/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base


### PR DESCRIPTION
Related to: https://github.com/operate-first/apps/pull/131

Syncs down the local storage provider from MOC CNV in `local-storage` namespace