### PR TITLE
feat: Add a kubevirt standalone application

### DIFF
--- a/kubevirt-hyperconverged/README.md
+++ b/kubevirt-hyperconverged/README.md
@@ -1,0 +1,3 @@
+# Openshift CNV deployment
+
+https://github.com/kubevirt/hyperconverged-cluster-operator

--- a/kubevirt-hyperconverged/base/hyperconverged.yaml
+++ b/kubevirt-hyperconverged/base/hyperconverged.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: hco.kubevirt.io/v1alpha1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec: {}

--- a/kubevirt-hyperconverged/base/kustomization.yaml
+++ b/kubevirt-hyperconverged/base/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-cnv
+
+resources:
+  - hyperconverged.yaml

--- a/kubevirt-hyperconverged/overlays/crc/kustomization.yaml
+++ b/kubevirt-hyperconverged/overlays/crc/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base

--- a/kubevirt-hyperconverged/overlays/moc/kustomization.yaml
+++ b/kubevirt-hyperconverged/overlays/moc/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base

--- a/kubevirt-hyperconverged/overlays/quicklab/kustomization.yaml
+++ b/kubevirt-hyperconverged/overlays/quicklab/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base


### PR DESCRIPTION
Related to: https://github.com/operate-first/apps/pull/131

Syncs down the Kubevirt deployment and resources in `openshift-cnv` namespace