### PR TITLE
fix: ClusterRole api group for cluster logs reader

### DIFF
--- a/cluster-scope/base/clusterroles/cluster-logs-reader/clusterrole.yaml
+++ b/cluster-scope/base/clusterroles/cluster-logs-reader/clusterrole.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cluster-logs-reader


### PR DESCRIPTION
Fixes: #194 