### PR TITLE
Adjust grafana dashboards and documentation

### DIFF
--- a/docs/odh/grafana/add_grafana_dashboard.md
+++ b/docs/odh/grafana/add_grafana_dashboard.md
@@ -18,9 +18,9 @@ spec:
 ```
 
 In this template, all you need to do is update:
+
 1. `metadata.name` - the dashboard name
-2. `spec.name` - the dashboard JSON file name
-3. `spec.url` - the URL pointing to the location of your dashboard JSON file
+2. `spec.url` - the URL pointing to the location of your dashboard JSON file
 
 Pick a suitable `metadata.name`, ensure that its unique in the [`odh/base/monitoring/overrides/grafana-operator/overlays/dashboards`](https://github.com/operate-first/apps/tree/master/odh/base/monitoring/overrides/grafana-operator/overlays/dashboards) folder.
 

--- a/odh/base/monitoring/overrides/grafana-operator/overlays/dashboards/jupyterhub-sli-slo.yaml
+++ b/odh/base/monitoring/overrides/grafana-operator/overlays/dashboards/jupyterhub-sli-slo.yaml
@@ -5,5 +5,4 @@ metadata:
   labels:
     app: grafana
 spec:
-  name: jupyterhub-sli-slo
   url: https://raw.githubusercontent.com/operate-first/SRE/master/dashboards/jupyterhub-sli-slo.json

--- a/odh/overlays/moc/monitoring/dashboards/operate-first/argocd.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/operate-first/argocd.yaml
@@ -3852,4 +3852,3 @@ spec:
       "uid": "97AYZMTGk",
       "version": 1
     }
-  name: argocd.json

--- a/odh/overlays/moc/monitoring/dashboards/operate-first/jupyterhub-usage.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/operate-first/jupyterhub-usage.yaml
@@ -6,5 +6,4 @@ metadata:
   name: jupyterhub-usage
 spec:
   customFolderName: Operate-First
-  name: jupyterhub-usage
   url: https://raw.githubusercontent.com/operate-first/SRE/master/dashboards/jupyterhub-usage.json

--- a/odh/overlays/moc/monitoring/dashboards/operate-first/opf-availability.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/operate-first/opf-availability.yaml
@@ -6,5 +6,4 @@ metadata:
   name: opf-availability
 spec:
   customFolderName: Operate-First
-  name: opf-availability
   url: https://github.com/operate-first/SRE/blob/master/dashboards/opf-availability.json

--- a/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-kafka-argo-metrics.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-kafka-argo-metrics.yaml
@@ -6,5 +6,4 @@ metadata:
     app: grafana
     component: thoth-station
 spec:
-  name: thoth-kafka-argo-metrics
   url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/cnv-prod/thoth-kafka-argo-metrics.json

--- a/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-knowledge-graph-content-metrics.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-knowledge-graph-content-metrics.yaml
@@ -6,5 +6,4 @@ metadata:
     app: grafana
     component: thoth-station
 spec:
-  name: thoth-knowledge-graph-content-metrics
   url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/cnv-prod/thoth-knowledge-graph-content-metrics.json

--- a/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-postgresql-metrics.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-postgresql-metrics.yaml
@@ -6,5 +6,4 @@ metadata:
     app: grafana
     component: thoth-station
 spec:
-  name: thoth-postgresql-metrics
   url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/cnv-prod/thoth-postgresql-metrics.json

--- a/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-service-metrics.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-service-metrics.yaml
@@ -6,5 +6,4 @@ metadata:
     app: grafana
     component: thoth-station
 spec:
-  name: thoth-service-metrics
   url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/cnv-prod/thoth-service-metrics.json

--- a/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-sli-slo.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-sli-slo.yaml
@@ -6,5 +6,4 @@ metadata:
     app: grafana
     component: thoth-station
 spec:
-  name: thoth-sli-slo
   url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/cnv-prod/thoth-sli-slo.json

--- a/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-user-api-metrics.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-user-api-metrics.yaml
@@ -6,5 +6,4 @@ metadata:
     app: grafana
     component: thoth-station
 spec:
-  name: thoth-user-api-metrics
   url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/cnv-prod/thoth-user-api-metrics.json

--- a/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-workflow-controllers-metrics.yaml
+++ b/odh/overlays/moc/monitoring/dashboards/thoth-station/thoth-workflow-controllers-metrics.yaml
@@ -6,5 +6,4 @@ metadata:
     app: grafana
     component: thoth-station
 spec:
-  name: thoth-workflow-controllers-metrics
   url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/cnv-prod/thoth-workflow-controllers-metrics.json


### PR DESCRIPTION
Remove `spec.name` from dashboards and docs, as it is not used in grafana operator `GrafanaDashboard` CRDs.

Related-To: https://github.com/integr8ly/grafana-operator/pull/344