### PR TITLE
Add PVC manifest for user mcli

### DIFF
--- a/odh/overlays/moc/jupyterhub/.sops.yaml
+++ b/odh/overlays/moc/jupyterhub/.sops.yaml
@@ -1,0 +1,3 @@
+creation_rules:
+  - encrypted_regex: "^annotations|name$"
+    pgp: "0508677DD04952D06A943D5B4DC4116D360E3276"

--- a/odh/overlays/moc/jupyterhub/kustomization.yaml
+++ b/odh/overlays/moc/jupyterhub/kustomization.yaml
@@ -5,6 +5,10 @@ namespace: opf-jupyterhub
 
 resources:
   - ../../../base/jupyterhub
+
+generators:
+  - pvcs/secret-generator.yaml
+
 patchesJson6902:
   - patch: |
       - op: add

--- a/odh/overlays/moc/jupyterhub/pvcs/secret-generator.yaml
+++ b/odh/overlays/moc/jupyterhub/pvcs/secret-generator.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: jupyterhub-pvc-secret-generator
+files:
+  - ./pvcs/user-mcli-pvc.enc.yaml

--- a/odh/overlays/moc/jupyterhub/pvcs/user-mcli-pvc.enc.yaml
+++ b/odh/overlays/moc/jupyterhub/pvcs/user-mcli-pvc.enc.yaml
@@ -1,0 +1,43 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+    annotations:
+        hub.jupyter.org/username: ENC[AES256_GCM,data:kU7tO4pXu6xeJM73niX2hqiQag==,iv:Ucn1hpls4rMCGPzjKBGhf6Ib6W+SVtbo1rX29hBZsVY=,tag:S9yvcurXByQ1JWjW65/5Ag==,type:str]
+    name: ENC[AES256_GCM,data:kPQXozhK1CfXntEpQpq8bkkMOQITOqfyqTcfRoHT6FX8nKpIlw1aKRA=,iv:NSy2eUhRUj9S573vXbFr+thViHlVkaDMwdVsPjhKFD0=,tag:5zN9lSDmubYuCueLL+sQXw==,type:str]
+    labels:
+        app: jupyterhub
+        component: singleuser-storage
+spec:
+    resources:
+        requests:
+            storage: 20Gi
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-02-09T03:50:28Z'
+    mac: ENC[AES256_GCM,data:m1FJ+qhXn4GVz6vlb6X+uD/QEpJjEIDYK4SxMRBDHTLFp4Bfv3m+2zCZL8zwXJ4vbX02MKbgHJcX2GxFVtlfjzsbmujx3C9Xiz8lbx0w3ki+nJSKGtjLiyev0NfknCaapM+kqYb/5JW4d9NsWwYekrTmGYpotTO5ir6QzFAS8Ws=,iv:fbiuqKOhtm32HHZoC62pLJk+7edIQwuhdbkC0nrePW8=,tag:6D4budM1JzyMNo6cMauJjQ==,type:str]
+    pgp:
+    -   created_at: '2021-02-09T03:50:27Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA9aKBcudqifiARAAjbAzYOBBYUfYdNxz6DJYhGZTaF/aAdyw0/X0DIpJGu1J
+            NzFoodf51fM/Wqy4CNujIfYDqx0De53iK8mYcopbfRpOEv3fAqdHF1jWdvGE7dUS
+            ZzrqIC7OyttAHz7sQ7+IAbv5YRmE45oSPkJV3UMF4OfiFgnWCBCHY/zMnXXZ8KvJ
+            CiFEP95bkwk858vH2sAoPfBk+2B90wMV9xnCNx+rGNrQmD9oBzCl+8vg42P8egoL
+            eR2ODkM8VmSY8JET5Kv5Mjrep+/rFzoFHQ5XtRxfOj007eHqotyIFdEkN/EaZXeI
+            AR13Pwo9ws26wQkr2yjW8nWlTIT+GOYbu5xSoT6uUGa22/sbx8/OWy3R2bcztmVy
+            S9sXpm7jnGWlM+myfLOuvKmuEtULbB52QvIc9G1A9ezsnOXPQJN3Z4K9K7wVsrTt
+            oss5JFMFWNXXi6P2HN6IdGANIeu7T2XGmOWm9Y2jGw/2HJnEWC9yqcLvluUYmIMI
+            pLfM2Zm/dxPm19uwYZwEwrMrY/uUZ7yBi10uW0SpyeCFnxTDG4o9IRiG2DleiiDi
+            ir/HCiolayNeFe3LwOfGP0g6Cz+FuqeGvm+85GZayH9Brlvjucx2aEu1gY4rOmXi
+            v5B4F3327U+JByN/9nfnh/zb4aQUA8/XDb/bnwPdbqCKKdmWuIn/jGKgxiQ+BcnS
+            XgEyhRdxorf2t0a+2i5xi5Mesr2B7cxUHA0VrBsWbkQKK/YiTmkxvl7FeN+yP47p
+            rzeCYvWqVbi2wSxMkl+TQYSiy1aIwhjAXfWSzxDCehH3QNJJctwXVSHFFGvidJ4=
+            =3gyS
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^annotations|name$
+    version: 3.6.1


### PR DESCRIPTION
Adds an encrypted PVC manifest to be used in the `opf-jupyterhub` namespace by Jupyterhub.

Closes https://github.com/operate-first/support/issues/79