### PR TITLE
Add curator config for CLO

### DIFF
--- a/cluster-logging/overlays/moc/configmaps/curator.yaml
+++ b/cluster-logging/overlays/moc/configmaps/curator.yaml
@@ -1,0 +1,79 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: curator
+data:
+  actions.yaml: |
+    # ---
+    # Remember, leave a key empty if there is no value.  None will be a string,
+    # not a Python "NoneType"
+    #
+    # Also remember that all examples have 'disable_action' set to True.  If you
+    # want to use this action as a template, be sure to set this to False after
+    # copying it.
+    # actions:
+    #   1:
+    #     action: delete_indices
+    #     description: >-
+    #       Delete .operations indices older than 30 days.
+    #       Ignore the error if the filter does not
+    #       result in an actionable list of indices (ignore_empty_list).
+    #       See https://www.elastic.co/guide/en/elasticsearch/client/curator/5.2/ex_delete_indices.html
+    #     options:
+    #       # Swallow curator.exception.NoIndices exception
+    #       ignore_empty_list: True
+    #       # In seconds, default is 300
+    #       timeout_override: ${CURATOR_TIMEOUT}
+    #       # Don't swallow any other exceptions
+    #       continue_if_exception: False
+    #       # Optionally disable action, useful for debugging
+    #       disable_action: False
+    #     # All filters are bound by logical AND
+    #     filters:
+    #     - filtertype: pattern
+    #       kind: regex
+    #       value: '^\.operations\..*$'
+    #       exclude: False
+    #     - filtertype: age
+    #       # Parse timestamp from index name
+    #       source: name
+    #       direction: older
+    #       timestring: '%Y.%m.%d'
+    #       unit: days
+    #       unit_count: 30
+    #       exclude: False
+  config.yaml: |
+    # Logging example curator config file
+
+    # uncomment and use this to override the defaults from env vars
+    .defaults:
+     delete:
+       days: 7
+
+    # to keep ops logs for a different duration:
+    #.operations:
+    #  delete:
+    #    weeks: 8
+
+    # example for a normal project
+    #myapp:
+    #  delete:
+    #    weeks: 1
+  curator5.yaml: |
+    ---
+    client:
+      hosts:
+      - ${ES_HOST}
+      port: ${ES_PORT}
+      use_ssl: True
+      certificate: ${ES_CA}
+      client_cert: ${ES_CLIENT_CERT}
+      client_key: ${ES_CLIENT_KEY}
+      ssl_no_validate: False
+      timeout: ${CURATOR_TIMEOUT}
+      master_only: False
+    logging:
+      loglevel: ${CURATOR_LOG_LEVEL}
+      logformat: default
+      blacklist: ['elasticsearch', 'urllib3']

--- a/cluster-logging/overlays/moc/configmaps/kustomization.yaml
+++ b/cluster-logging/overlays/moc/configmaps/kustomization.yaml
@@ -2,8 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: openshift-logging
-
 resources:
-  - ../../base
-  - configmaps
+  - curator.yaml


### PR DESCRIPTION
Set default log retention to 7 days. 
Docs: https://docs.openshift.com/container-platform/4.5/logging/config/cluster-logging-curator.html#cluster-logging-curator-yaml_cluster-logging-curator

Currently the 200Gig PVC for cluster logging is at >90% usage. This is resulting in Elasticsearch not pushing in any new logs.

Related #https://github.com/operate-first/support/issues/83