### PR TITLE
feat: ODH v1.0.0 upgrade: Jupyterhub

### DIFF
--- a/odh/base/jupyterhub/kfdef.yaml
+++ b/odh/base/jupyterhub/kfdef.yaml
@@ -30,5 +30,5 @@ spec:
       name: notebook-images
   repos:
     - name: manifests
-      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v0.9.0"
-  version: v0.9.0
+      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.0"
+  version: v1.0.0


### PR DESCRIPTION
The only important difference in `jupyterhub/jupyterhub` app is image change from https://github.com/opendatahub-io/odh-manifests/pull/245

```diff
547c547
<       name: quay.io/odh-jupyterhub/jupyterhub-img:3.0.7-b7db22b
---
>       name: quay.io/odh-jupyterhub/jupyterhub-img:v0.1.4
```
Part of: https://github.com/operate-first/apps/issues/231
