### PR TITLE
feat: ODH v1.0.0 upgrade: Monitoring

### DIFF
--- a/odh/base/monitoring/kfdef.yaml
+++ b/odh/base/monitoring/kfdef.yaml
@@ -49,7 +49,7 @@ spec:
       name: grafana-operator
   repos:
     - name: manifests
-      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v0.9.0"
+      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.0"
     - name: opf
       uri: "https://github.com/operate-first/apps/tarball/master"
-  version: v0.9.0
+  version: v1.0.0


### PR DESCRIPTION
Part of: https://github.com/operate-first/apps/issues/231

The only difference in the manifests is:
- change in `odh-kafka` dashboard (https://github.com/opendatahub-io/odh-manifests/pull/272)
- removed `jupyterhub-metrics` service monitor (https://github.com/opendatahub-io/odh-manifests/pull/271)