### PR TITLE
Update CLO nodeCount to 2 and PVC size to 300Gig

### DIFF
--- a/cluster-logging/base/clusterlogging.yaml
+++ b/cluster-logging/base/clusterlogging.yaml
@@ -15,13 +15,13 @@ spec:
       audit:
         maxAge: 7d
     elasticsearch:
-      nodeCount: 1
+      nodeCount: 2
       storage:
         # TODO: manually set the storageClassName
         # Upstream Issue:
         # https://github.com/openshift/cluster-logging-operator/issues/869
         storageClassName: "ocs-storagecluster-cephfs"
-        size: 200G
+        size: 300G
       redundancyPolicy: "ZeroRedundancy"
   visualization:
     type: "kibana"


### PR DESCRIPTION
This will create 2 nodes for elasticsearch and create 2 PVCs (size 300Gig) for each node.
With `ZeroRedundancy` policy, there won't be any copies of data. ([Docs](https://github.com/openshift/cluster-logging-operator/blob/master/docs/configuration.md#data-redundancy))