### PR TITLE
Update CPU requests for Elasticsearch to 6 cpus

### DIFF
--- a/cluster-logging/base/clusterlogging.yaml
+++ b/cluster-logging/base/clusterlogging.yaml
@@ -15,6 +15,10 @@ spec:
       audit:
         maxAge: 7d
     elasticsearch:
+      resources:
+        requests:
+          cpu: 6
+          memory: 16Gi
       nodeCount: 2
       storage:
         # TODO: manually set the storageClassName


### PR DESCRIPTION
We found that fluentd was facing issues when pushing logs 
Error:
```
2021-02-10 22:00:37 +0000 [warn]: [retry_clo_default_output_es] failed to flush the buffer. retry_time=3 next_retry_seconds=2021-02-10 22:00:40 +0000 chunk="5bb000f818cb4d2b2de49ad5112baf1c" error_class=Fluent::Plugin::ElasticsearchOutput::RecoverableRequestFailure error="could not push logs to Elasticsearch cluster ({:host=>\"elasticsearch.openshift-logging.svc.cluster.local\", :port=>9200, :scheme=>\"https\", :user=>\"fluentd\", :password=>\"obfuscated\"}): Server returned nothing (no headers, no data)"
```
These errors were reduced when we increased the CPU resources for elasticsearch. We were also able to see more recent logs using kibana

Related: https://github.com/operate-first/support/issues/83