### PR TITLE
feat: Enable public access to ws-ml-prague namespace

### DIFF
--- a/cluster-scope/base/namespaces/ws-ml-prague/kustomization.yaml
+++ b/cluster-scope/base/namespaces/ws-ml-prague/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 
 components:
   - ../../../components/project-admin-rolebindings/workshops
+  - ../../../components/project-view-public

--- a/cluster-scope/components/project-view-public/kustomization.yaml
+++ b/cluster-scope/components/project-view-public/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+- ./rbac.yaml

--- a/cluster-scope/components/project-view-public/rbac.yaml
+++ b/cluster-scope/components/project-view-public/rbac.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-view-public
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:unauthenticated


### PR DESCRIPTION
Part of: https://github.com/operate-first/support/issues/77

Grants public view access to a namespace via a reusable component.