### PR TITLE
feat: Use OCS bucket for Data catalog on MOC

### DIFF
--- a/odh/base/datacatalog/kfdef.yaml
+++ b/odh/base/datacatalog/kfdef.yaml
@@ -18,24 +18,7 @@ spec:
           path: odh-common
       name: odh-common
     - kustomizeConfig:
-        repoRef:
-          name: manifests
-          path: ceph/object-storage/scc
-      name: ceph-nano-scc
-    - kustomizeConfig:
-        repoRef:
-          name: manifests
-          path: ceph/object-storage/nano
-      name: ceph-nano
-    - kustomizeConfig:
-        overlays: []
-        parameters:
-          - name: s3_endpoint_url
-            value: ceph-nano-0
-          - name: s3_is_secure
-            value: "false"
-          - name: s3_credentials_secret
-            value: ceph-nano-credentials
+        parameters: []
         repoRef:
           name: manifests
           path: hue/hue
@@ -43,11 +26,7 @@ spec:
     - kustomizeConfig:
         overlays:
           - create-spark-cluster
-        parameters:
-          - name: s3_endpoint_url
-            value: ceph-nano-0
-          - name: s3_credentials_secret
-            value: ceph-nano-credentials
+        parameters: []
         repoRef:
           name: manifests
           path: thriftserver/thriftserver

--- a/odh/overlays/crc/datacatalog/kfdef_patch.yaml
+++ b/odh/overlays/crc/datacatalog/kfdef_patch.yaml
@@ -1,0 +1,35 @@
+- op: add
+  path: /spec/applications/2/kustomizeConfig/parameters
+  value:
+    - name: s3_endpoint_url
+      value: ceph-nano-0
+    - name: s3_is_secure
+      value: "false"
+    - name: s3_credentials_secret
+      value: ceph-nano-credentials
+
+- op: add
+  path: /spec/applications/3/kustomizeConfig/parameters
+  value:
+    - name: s3_endpoint_url
+      value: ceph-nano-0
+    - name: s3_credentials_secret
+      value: ceph-nano-credentials
+
+- op: add
+  path: /spec/applications/-
+  value:
+    kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: ceph/object-storage/scc
+    name: ceph-nano-scc
+
+- op: add
+  path: /spec/applications/-
+  value:
+    kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: ceph/object-storage/nano
+    name: ceph-nano

--- a/odh/overlays/crc/datacatalog/kustomization.yaml
+++ b/odh/overlays/crc/datacatalog/kustomization.yaml
@@ -1,6 +1,15 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: opf-datacatalog
 
 resources:
   - ../../../base/datacatalog
+
+patchesJson6902:
+  - path: kfdef_patch.yaml
+    target:
+      group: kfdef.apps.kubeflow.org
+      kind: KfDef
+      name: opendatahub
+      version: v1

--- a/odh/overlays/moc/datacatalog/bucket.yaml
+++ b/odh/overlays/moc/datacatalog/bucket.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: opf-datacatalog-bucket
+spec:
+  generateBucketName: opf-datacatalog-
+  storageClassName: ocs-storagecluster-ceph-rgw
+  additionalConfig:
+    maxObjects: "100000"
+    maxSize: 10G

--- a/odh/overlays/moc/datacatalog/kfdef_patch.yaml
+++ b/odh/overlays/moc/datacatalog/kfdef_patch.yaml
@@ -1,0 +1,15 @@
+- op: add
+  path: /spec/applications/2/kustomizeConfig/parameters
+  value:
+    - name: s3_endpoint_url
+      value: rook-ceph-rgw-ocs-storagecluster-cephobjectstore.openshift-storage.svc.cluster.local
+    - name: s3_credentials_secret
+      value: opf-datacatalog-bucket
+
+- op: add
+  path: /spec/applications/3/kustomizeConfig/parameters
+  value:
+    - name: s3_endpoint_url
+      value: rook-ceph-rgw-ocs-storagecluster-cephobjectstore.openshift-storage.svc.cluster.local
+    - name: s3_credentials_secret
+      value: opf-datacatalog-bucket

--- a/odh/overlays/moc/datacatalog/kustomization.yaml
+++ b/odh/overlays/moc/datacatalog/kustomization.yaml
@@ -5,24 +5,10 @@ namespace: opf-datacatalog
 
 resources:
   - ../../../base/datacatalog
+  - bucket.yaml
+
 patchesJson6902:
-  - patch: |
-      - op: add
-        path: /spec/applications/4/kustomizeConfig/overlays/-
-        value: storage-class
-      - op: add
-        path: /spec/applications/4/kustomizeConfig/parameters/-
-        value:
-          name: storage_class
-          value: ocs-storagecluster-cephfs
-      - op: add
-        path: /spec/applications/5/kustomizeConfig/overlays/-
-        value: storage-class
-      - op: add
-        path: /spec/applications/5/kustomizeConfig/parameters/-
-        value:
-          name: storage_class
-          value: ocs-storagecluster-cephfs
+  - path: kfdef_patch.yaml
     target:
       group: kfdef.apps.kubeflow.org
       kind: KfDef

--- a/odh/overlays/quicklab/datacatalog/kfdef_patch.yaml
+++ b/odh/overlays/quicklab/datacatalog/kfdef_patch.yaml
@@ -1,0 +1,35 @@
+- op: add
+  path: /spec/applications/2/kustomizeConfig/parameters
+  value:
+    - name: s3_endpoint_url
+      value: ceph-nano-0
+    - name: s3_is_secure
+      value: "false"
+    - name: s3_credentials_secret
+      value: ceph-nano-credentials
+
+- op: add
+  path: /spec/applications/3/kustomizeConfig/parameters
+  value:
+    - name: s3_endpoint_url
+      value: ceph-nano-0
+    - name: s3_credentials_secret
+      value: ceph-nano-credentials
+
+- op: add
+  path: /spec/applications/-
+  value:
+    kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: ceph/object-storage/scc
+    name: ceph-nano-scc
+
+- op: add
+  path: /spec/applications/-
+  value:
+    kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: ceph/object-storage/nano
+    name: ceph-nano

--- a/odh/overlays/quicklab/datacatalog/kustomization.yaml
+++ b/odh/overlays/quicklab/datacatalog/kustomization.yaml
@@ -1,6 +1,15 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: opf-datacatalog
 
 resources:
   - ../../../base/datacatalog
+
+patchesJson6902:
+  - path: kfdef_patch.yaml
+    target:
+      group: kfdef.apps.kubeflow.org
+      kind: KfDef
+      name: opendatahub
+      version: v1


### PR DESCRIPTION
Resolves: https://github.com/operate-first/apps/issues/143
Related to: https://github.com/operate-first/support/issues/23

CRC and Quicklab:
- No functional difference in the manifetst
- In `kfdef`, the order of application is now changed: ceph nano is added to the end in the overlay, instead of being in the middle

MOC:
- A OCS bucket is created via `opf-datacatalog-bucket` claim
- Ceph nano is not used anymore
- Hue and Thriftserver points to Rook endpoint and use the bucket's credentials

MOC setup was not tested, since I don't have a cluster with Rook available, we'll see how it works...