### PR TITLE
fix: Move ODH JH params and overlays to the overriding app

### DIFF
--- a/odh/base/jupyterhub/kfdef.yaml
+++ b/odh/base/jupyterhub/kfdef.yaml
@@ -13,15 +13,15 @@ spec:
           path: odh-common
       name: odh-common
     - kustomizeConfig:
-        overlays: []
-        parameters:
-          - name: s3_endpoint_url
-            value: s3.odh.com
         repoRef:
           name: manifests
           path: jupyterhub/jupyterhub
       name: jupyterhub
     - kustomizeConfig:
+        overlays: []
+        parameters:
+          - name: s3_endpoint_url
+            value: s3.odh.com
         repoRef:
           name: opf-manifests
           path: odh/base/jupyterhub/overrides/jupyterhub

--- a/odh/overlays/moc/jupyterhub/kustomization.yaml
+++ b/odh/overlays/moc/jupyterhub/kustomization.yaml
@@ -12,10 +12,10 @@ generators:
 patchesJson6902:
   - patch: |
       - op: add
-        path: /spec/applications/1/kustomizeConfig/overlays/-
+        path: /spec/applications/2/kustomizeConfig/overlays/-
         value: storage-class
       - op: add
-        path: /spec/applications/1/kustomizeConfig/parameters/-
+        path: /spec/applications/2/kustomizeConfig/parameters/-
         value:
           name: storage_class
           value: ocs-storagecluster-cephfs


### PR DESCRIPTION
Fixes storage class issue from: https://github.com/operate-first/apps/pull/241#issuecomment-777565070