### PR TITLE
Update CLO nodecount to 3 (odd number)

### DIFF
--- a/cluster-logging/base/clusterlogging.yaml
+++ b/cluster-logging/base/clusterlogging.yaml
@@ -19,7 +19,7 @@ spec:
         requests:
           cpu: 6
           memory: 16Gi
-      nodeCount: 2
+      nodeCount: 3
       storage:
         # TODO: manually set the storageClassName
         # Upstream Issue:


### PR DESCRIPTION
As @HumairAK suggested we should have a odd number of nodes to prevent complexities during master/worker elections.
I have updated the CLO elasticsearch nodecount to 3