### PR TITLE
JH exclude path /metrics from being protected by the proxy

### DIFF
--- a/odh/base/jupyterhub/overrides/jupyterhub/base/jupyterhub-configmap.yaml
+++ b/odh/base/jupyterhub/overrides/jupyterhub/base/jupyterhub-configmap.yaml
@@ -6,7 +6,9 @@ metadata:
     app: jupyterhub
   name: jupyterhub-cfg
 data:
-  jupyterhub_config.py: "c.OpenShiftOAuthenticator.validate_cert = False"
+  jupyterhub_config.py: |
+    c.OpenShiftOAuthenticator.validate_cert = False;
+    c.JupyterHub.authenticate_prometheus = False;
   jupyterhub_admins: "admin"
   gpu_mode: ""
   singleuser_pvc_size: 2Gi


### PR DESCRIPTION
Related https://github.com/operate-first/SRE/issues/59

After this is merged, let's wait for the https://github.com/operate-first/SRE/issues/60 issue to close automatically by the alertmanager