### PR TITLE
Add route for elasticsearch external access.

### DIFF
--- a/cluster-logging/overlays/moc/.sops.yaml
+++ b/cluster-logging/overlays/moc/.sops.yaml
@@ -1,0 +1,3 @@
+creation_rules:
+  - encrypted_regex: '^destinationCACertificate$'
+    pgp: "0508677DD04952D06A943D5B4DC4116D360E3276"

--- a/cluster-logging/overlays/moc/kustomization.yaml
+++ b/cluster-logging/overlays/moc/kustomization.yaml
@@ -7,3 +7,6 @@ namespace: openshift-logging
 resources:
   - ../../base
   - configmaps
+
+generators:
+  - routes/secret-generator.yaml

--- a/cluster-logging/overlays/moc/routes/route.enc.yaml
+++ b/cluster-logging/overlays/moc/routes/route.enc.yaml
@@ -1,0 +1,43 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+    name: elasticsearch
+    namespace: openshift-logging
+spec:
+    host: null
+    to:
+        kind: Service
+        name: elasticsearch
+    tls:
+        termination: reencrypt
+        destinationCACertificate: ENC[AES256_GCM,data:ZDu/7x07tLC6rmte264X1wM+eRIfsRCyC15xYMVMQv0gmspBhROC8/BUASwxOTCjVaI1IKtlB/7KsFJYIEElWOmIt25UnMOpZuIK8Kpu+wTBYoWK3htqULrEWKTGV6BWGDLjT4XbnzEZ5i1QxAQIY/Pr5xjyv41wFEqHTOMxs3b1v0gxec68UYL5pkgwGGhLQ7wWsasxXqbytAVjzHXddWtv86cg1/YWLBI90mMjQ1ML5vbDVkYnWVuQffSUeq/BK+GqLVD+vlw5M0dlJ3QxnFaATUPLpab7nuU5PykeS20zJa1CM5jf2lCimDfZH2zV5pCHUPmvHrvoWToRflhgptjfsqEcGlUDePTLM087Gh6CvhDxHgorscN4jqvJopVgAQFTX31EwGVg1ABVt6Jj92vearRpDQjIYh7oIgl5bWfyZrJf944835qNRTvgaIZAjAp4n5BwxqEsxe8IVz5y2Fbtai5aSPtv87KgAe8N7qlfTW+U6tCeLP2dh120WapZFvjAGWoOnNmXuOwKniqzoWH7p0xci4UjkshmK9CdhW3LReT6A4Je9TxtjS4F1G52qnm59vZqXV36et/pNDxDmQdCBiAuqKz1j+oP+ZbrZmRv3hdD3LE9p1wWwVQEV60TFG80cjCWYTIEdT7CICO47azcy+dpOwirgBqAC4jtmyhsQ3LCs+TF1QrXd6sQWrrbsmy3RN7weHQHkpDqkrSyJlLBN/0kevzET+oAYIg6T3YmE5sBy0ps9hFOb0TkikvMtpqrUHIg4w/NLv/LlPIJykojBan88H/0KM0X3KD2fwG6xIF79WaEbp8+FaRDT6uYuNKZ25IKUEWczCQk6rpL55CNB9qo3k/sCOvssUiGGUwBKoUlkLsA6bI4rT93ThhXpMY+iyfbwIdSzOqJmXce7hL6Zce79rQ/mtzDGQsk6N6kigcJWtnxcqWm0miz85GJTmJXx0lVdPnfzO2d9d3TqAFdX9Ix2kZuzXhLtPa/4WnjHPkhJsiNM4E7oWNhUHQx7ZiGAR841KGmuAO2VTRiKJ19BPRUDG9sqG5bYfMmzsJdFBspGAfTxWzmJc6Nf21thSlIPlPuKAxfp2Hyk2Zs5ZSr/pubimUDZ/Jm7e9aGFn6wSajfl4kLzNZ8FxS7EhVzAIdjYkeZVV0OZuZJl54GuUQ5/0D6Ejm2t9Ji3xhwgI6L+cy0m4ya88pvz2UefNPaMJAvhTXrNRSD2EcQwQVDBuFqbrOQxBX/twAHdfBZtrM5N4SjteC8kGEhXF3S0xtrcloQTDF9lR2fvjXHLnTW7fp/6dHOgyJtPaxkacBmk5uBJjYdcnGfoE3wh7hdZVCcmEoY+tBBUmscIcT++myMJ1K8nXeDyYi41PwYXpODEqfQN79DhJAzlykCTishlHy/Axv79noPfl1DL1ninJC/nnxCv3x0gA4SVocHWfVoV3lo0Rui2dyL17kQTBzbVBEbijeOLBNDaefze7SlS3j2Ya6wNbe9xP7mgKzl55PsrX7kjM/MSCsC1ytaQRLrQnJbZSfEGntfwyTkdCgFwhG2AGzVlgeU1K4ZlmqE3GRRrzg9ZdvHW1FjchWOrKQFQd+rZb6WnwcjtDmxS+wshWhhGO4X/+W1NTjuTgX4agymPkZuEHiud8rAf+1pdzXnfHcsWJCRoYLeop0ow896WRed22H/Zem5cZjZECPU0AjhFM6OIofYXnd4T+6zJ3CZLEygKFrWCe5UzlWu2N7Pfj1/w5oGsnNqSR/j7dkroOutvMM4oIrYbGx7vW7altnL7GvCVfL6yKH5f6LuXE6p9Itvo+OImG1hqQCRZBY1g8xD2vcoctpKpX59JfYKkPedKgUAUFBXxC7T5yhkcJdYfqybGaYG4inBOdqrQQNYCPPwk16ItexRk/Fgoq1FxOVOYZkrpNe2mqdLnXKqc3CsN1W2bkQb6yMgrb66RTMfiZPBHWi+zyYAairCOIxIZ4GDfemoDNPLSenPYyBmvHI++HgtLKsV66Oldm39JybVz1VvSHIKrKltDj1poDa+IrlZUJbX6l+cHfNt1Vt9SH1x1u6FOoCKtJmg1aEOZq28Wc6JUAcKfE5Lpzh+GEya/D8JqR0r8jvf070FWdIvcLg+o68xXRofnxjm79Z8EmX2z+k9pxFrkazBQxWL27XxRejJHn1dnJBEDRV5MMuxpn3UnueDOHQjYZje+IQuvJHfn2ZHIoqbg/pW6ChxQL1z4I5vvdhPgNJOWQ/SIWnGQbhOJX/NXF0ilzvn0RItZAgdp9MX+Tkto5giR3KCPCIo/ci1RYndZD8tPjIAyXPhmXscUV7Rhk+csRQT7FxiTEPZY/oyH3g/cRplltMfO1hRp9Qs9M2gem6GKI2ckiCFBTl+zFFOWMIWUAPTjAlC8h9RzY8h3EhD00WgdI/BxXbvlGqCG23P8G/BPXYs0YinuBYBj27FO8LpmscuvYqbSQ=,iv:uOqrZtIDGm74VrhLYInsPT9t2OreaHfulTpLK86IRes=,tag:bhubYz25xBQOzbu/oc7p1g==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-02-16T23:32:57Z'
+    mac: ENC[AES256_GCM,data:9GVU4tUYaq8DAf0ltl54EelQ9nJ3VdIcUYeozqGy6XsWgzztrXSlVTzQK3BsCNTupC4ZPckP1DhD0S7zjpyS29QRmJ8LnGjB2heemAStG4Z7ChEEvQxLyjKKD3i+36825FWVPDfVIswbPcrbXdvuVXX7HiHEar7FpVKUGRI9Z40=,iv:tP1faFUTnzQpHLbqz2m0FveW3XMGc1Ds6sCHZyeRU+I=,tag:24sBjkiDA+wl2mXtK1QUHA==,type:str]
+    pgp:
+    -   created_at: '2021-02-16T23:32:56Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA9aKBcudqifiARAApP00L3WMptdelEH00+49Yj0DIzLS5Luayo98tWMeblGp
+            ncMh3U6y6wlMOQ9hxqiR5lkQDmFpyxN7+rLOYKjltlZsLIBZgOnKrwo7D08HrZOA
+            8GV2HLEzzRAKmJG4VDmV1eBomBo2/TC6Pg+kddWwB4qDs1E+4VDpVlaGYSOzxD66
+            VjqLJxiJ9OfJlux9L8GEYOVzrR/nR8KwzWaVfA0lxHqfbgxkmcHMOPF2RQNWJ19P
+            bv231SXcPHSYtVbw363G3niLmhQKfXriMJkwF3Xr+UkX0ars4THleXomZqrP+ROM
+            mbcJGlRDFgXmf2Vs7JRASrOR1xtTWsTeflV2HERXwIkhHb/A0+pcH3eXvB1dvAvz
+            WxpjcTb+UzZsx5lztRJUb2kN1GogQXbwGI7TEbdJbpyVgW13QnG9cv5WX64Lq1A6
+            xKdURgHcMgRSyAyixqeEwagCCDlzkQffRfO7yzKzWilScY7edz/YtLAyD3b8hIs7
+            A001+fUVcPPIdSxFURTLWCdH7ae7uQnm3u+9UetImVBUyix8BIUEm74r2DhaEVw1
+            +2JQSN5pPgDr7piKQ2TKP9kN6UHAY8glJl6Pvr8OBmc6yzivY8LFMryjkMiOprKS
+            G/o5I6AyKSg5nJ+SLr6jbSbAlwqQM6kCvisq7JteeEnvcc9BUtsJ68Zk4LwbrPXS
+            XgGK6JoFcQgn93JY+AmMk3qlALq0eKyTLrHvGt+qoMYcyknSAAQ7xiu98PlUA5rn
+            DgqH7dToDzysBSGcUpg+Fkfb3rCEVmST5wtPSmqBsC5DxNFbrV8hKy9tAtQ5rQc=
+            =YSRa
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^destinationCACertificate$
+    version: 3.6.1

--- a/cluster-logging/overlays/moc/routes/secret-generator.yaml
+++ b/cluster-logging/overlays/moc/routes/secret-generator.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: secret-generator
+files:
+  - ./routes/route.enc.yaml


### PR DESCRIPTION
This is related to the issue [here](https://github.com/operate-first/apps/issues/229). Though more work needs to be done to allow individual users that are not cluster-admin to be able to use it.