### PR TITLE
Remove odh-operator namespace from crc/quicklab

### DIFF
--- a/cluster-scope/overlays/crc/kustomization.yaml
+++ b/cluster-scope/overlays/crc/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - ../../base/groups/cluster-admins
   - ../../base/groups/operate-first
   - ../../base/namespaces/observatorium-operator
-  - ../../base/namespaces/odh-operator
   - ../../base/namespaces/opf-argo
   - ../../base/namespaces/opf-dashboard
   - ../../base/namespaces/opf-datacatalog

--- a/cluster-scope/overlays/quicklab/kustomization.yaml
+++ b/cluster-scope/overlays/quicklab/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - ../../base/groups/cluster-admins
   - ../../base/groups/operate-first
   - ../../base/namespaces/observatorium-operator
-  - ../../base/namespaces/odh-operator
   - ../../base/namespaces/opf-argo
   - ../../base/namespaces/opf-dashboard
   - ../../base/namespaces/opf-datacatalog


### PR DESCRIPTION
Atm these builds are broken due to the odh-operator being recently removed.