### PR TITLE
Update prom cluster metrics timeout

### DIFF
--- a/odh/overlays/moc/monitoring/servicemonitors/cluster-metrics-servicemonitor.yaml
+++ b/odh/overlays/moc/monitoring/servicemonitors/cluster-metrics-servicemonitor.yaml
@@ -19,8 +19,8 @@ spec:
       scheme: https
       tlsConfig:
         insecureSkipVerify: true
-      scrapeTimeout: 50s
-      interval: 60s
+      scrapeTimeout: 130s
+      interval: 150s
   namespaceSelector:
     matchNames:
       - openshift-monitoring


### PR DESCRIPTION
Currently the scrape time exceeds the scrape time-out.  

[Related](https://github.com/operate-first/SRE/issues/80)