### PR TITLE
Remove kubeflow managed namespaces.

### DIFF
--- a/cluster-scope/base/namespaces/istio-system/kustomization.yaml
+++ b/cluster-scope/base/namespaces/istio-system/kustomization.yaml
@@ -4,9 +4,6 @@ kind: Kustomization
 
 namespace: istio-system
 
-resources:
-  - namespace.yaml
-
 components:
   - ../../../components/project-admin-rolebindings/operate-first
   - ../../../components/monitoring-rbac

--- a/cluster-scope/base/namespaces/istio-system/namespace.yaml
+++ b/cluster-scope/base/namespaces/istio-system/namespace.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    openshift.io/display-name: "Operate First: Istio"
-    openshift.io/requester: operate-first
-  name: istio-system
-spec: {}

--- a/cluster-scope/base/namespaces/knative-serving/kustomization.yaml
+++ b/cluster-scope/base/namespaces/knative-serving/kustomization.yaml
@@ -4,9 +4,6 @@ kind: Kustomization
 
 namespace: knative-serving
 
-resources:
-  - namespace.yaml
-
 components:
   - ../../../components/project-admin-rolebindings/operate-first
   - ../../../components/monitoring-rbac

--- a/cluster-scope/base/namespaces/knative-serving/namespace.yaml
+++ b/cluster-scope/base/namespaces/knative-serving/namespace.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    openshift.io/display-name: "Operate First: Kubeflow Knative Serving"
-    openshift.io/requester: operate-first
-  name: knative-serving
-spec: {}

--- a/cluster-scope/base/namespaces/tekton-pipelines/kustomization.yaml
+++ b/cluster-scope/base/namespaces/tekton-pipelines/kustomization.yaml
@@ -4,9 +4,6 @@ kind: Kustomization
 
 namespace: tekton-pipelines
 
-resources:
-  - namespace.yaml
-
 components:
   - ../../../components/project-admin-rolebindings/operate-first
   - ../../../components/monitoring-rbac

--- a/cluster-scope/base/namespaces/tekton-pipelines/namespace.yaml
+++ b/cluster-scope/base/namespaces/tekton-pipelines/namespace.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    openshift.io/display-name: "Operate First: Kubeflow Tekton Pipelines"
-    openshift.io/requester: operate-first
-  name: tekton-pipelines
-spec: {}


### PR DESCRIPTION
Currently kubeflow will over-write these apps, thus fighting with argocd to sync them. We cannot keep an exact copy because argocd will always add a new label which it uses to match what argocd app the resource belongs to. So just removing them all together for now.

![image](https://user-images.githubusercontent.com/10904967/108733873-de97c100-74fc-11eb-8742-4bc17d083839.png)
