### PR TITLE
Give ArgoCD SA argocd-manager cluster admin

### DIFF
--- a/cluster-scope/base/clusterrolebindings/argocd-manager/clusterrolebinding.yaml
+++ b/cluster-scope/base/clusterrolebindings/argocd-manager/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argocd-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: argocd-manager
+    namespace: argocd

--- a/cluster-scope/base/clusterrolebindings/argocd-manager/kustomization.yaml
+++ b/cluster-scope/base/clusterrolebindings/argocd-manager/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - clusterrolebinding.yaml

--- a/cluster-scope/overlays/moc-infra/kustomization.yaml
+++ b/cluster-scope/overlays/moc-infra/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - ../../base/clusterrolebindings/argocd-manager
   - ../../base/clusterrolebindings/cluster-admins-rb
   - ../../base/groups/cluster-admins
   - ../../base/oauths/cluster

--- a/cluster-scope/overlays/moc/kustomization.yaml
+++ b/cluster-scope/overlays/moc/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ../../base/clusterroles/cluster-logs-reader
   - ../../base/clusterroles/metrics
   - ../../base/clusterroles/observatorium-operator
+  - ../../base/clusterrolebindings/argocd-manager
   - ../../base/clusterrolebindings/cluster-admins-rb
   - ../../base/clusterrolebindings/cluster-logs-readers
   - ../../base/clusterrolebindings/cluster-metrics-federation


### PR DESCRIPTION
The `argocd-manager` SA is what argocd will be using to deploy apps to both `moc-cnv` and `moc-infra` clusters, as such this SA exists in both clusters and will require cluster admin in both of these clusters.

[Related](https://github.com/operate-first/SRE/issues/83). 