### PR TITLE
Update Jupytyerhub kfdef manifest version to 1.0.1

### DIFF
--- a/odh/base/jupyterhub/kfdef.yaml
+++ b/odh/base/jupyterhub/kfdef.yaml
@@ -35,7 +35,7 @@ spec:
       name: notebook-images
   repos:
     - name: manifests
-      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.0"
+      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.1"
     - name: opf-manifests
       uri: "https://github.com/operate-first/apps/tarball/master"
-  version: v1.0.0
+  version: v1.0.1

--- a/odh/base/jupyterhub/overrides/jupyterhub/base/jupyterhub-configmap.yaml
+++ b/odh/base/jupyterhub/overrides/jupyterhub/base/jupyterhub-configmap.yaml
@@ -7,7 +7,6 @@ metadata:
   name: jupyterhub-cfg
 data:
   jupyterhub_config.py: |
-    c.OpenShiftOAuthenticator.validate_cert = False;
     c.JupyterHub.authenticate_prometheus = False;
   jupyterhub_admins: "admin"
   gpu_mode: ""


### PR DESCRIPTION
The 1.0.1 release updates the jupyterhub image so we no longer need to
skip cert validation. More context at https://github.com/opendatahub-io/odh-manifests/pull/312

Signed-off-by: Anish Asthana <anishasthana1@gmail.com>