### PR TITLE
feat: Prepare subscription for MOC CNV 4.7 upgrade

### DIFF
--- a/cluster-scope/base/subscriptions/cluster-logging-operator/subscription.yaml
+++ b/cluster-scope/base/subscriptions/cluster-logging-operator/subscription.yaml
@@ -4,7 +4,7 @@ kind: Subscription
 metadata:
   name: cluster-logging
 spec:
-  channel: "4.5"
+  channel: DEFINED_IN_OVERLAY
   installPlanApproval: Automatic
   name: cluster-logging
   source: redhat-operators

--- a/cluster-scope/base/subscriptions/elastic-operator/subscription.yaml
+++ b/cluster-scope/base/subscriptions/elastic-operator/subscription.yaml
@@ -4,7 +4,7 @@ kind: Subscription
 metadata:
   name: elasticsearch-operator
 spec:
-  channel: "4.5"
+  channel: DEFINED_IN_OVERLAY
   installPlanApproval: Automatic
   name: elasticsearch-operator
   source: redhat-operators

--- a/cluster-scope/base/subscriptions/kubevirt-hyperconverged/subscription.yaml
+++ b/cluster-scope/base/subscriptions/kubevirt-hyperconverged/subscription.yaml
@@ -4,9 +4,8 @@ kind: Subscription
 metadata:
   name: kubevirt-hyperconverged
 spec:
-  channel: "stable"
+  channel: DEFINED_IN_OVERLAY
   installPlanApproval: Manual
   name: kubevirt-hyperconverged
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: "kubevirt-hyperconverged-operator.v2.5.4"

--- a/cluster-scope/base/subscriptions/local-storage-operator/subscription.yaml
+++ b/cluster-scope/base/subscriptions/local-storage-operator/subscription.yaml
@@ -4,7 +4,7 @@ kind: Subscription
 metadata:
   name: local-storage-operator
 spec:
-  channel: "4.5"
+  channel: DEFINED_IN_OVERLAY
   installPlanApproval: Automatic
   name: local-storage-operator
   source: redhat-operators

--- a/cluster-scope/base/subscriptions/metering-ocp/subscription.yaml
+++ b/cluster-scope/base/subscriptions/metering-ocp/subscription.yaml
@@ -4,7 +4,7 @@ kind: Subscription
 metadata:
   name: metering-operator
 spec:
-  channel: "4.5"
+  channel: DEFINED_IN_OVERLAY
   installPlanApproval: Automatic
   name: metering-ocp
   source: redhat-operators

--- a/cluster-scope/base/subscriptions/ocs-operator/subscription.yaml
+++ b/cluster-scope/base/subscriptions/ocs-operator/subscription.yaml
@@ -4,9 +4,8 @@ kind: Subscription
 metadata:
   name: ocs-operator
 spec:
-  channel: stable-4.5
+  channel: DEFINED_IN_OVERLAY
   installPlanApproval: Automatic
   name: ocs-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: ocs-operator.v4.5.2

--- a/cluster-scope/base/subscriptions/openshift-pipelines-operator-rh/subscription.yaml
+++ b/cluster-scope/base/subscriptions/openshift-pipelines-operator-rh/subscription.yaml
@@ -4,7 +4,7 @@ kind: Subscription
 metadata:
   name: openshift-pipelines-operator-rh
 spec:
-  channel: ocp-4.5
+  channel: DEFINED_IN_OVERLAY
   installPlanApproval: Automatic
   name: openshift-pipelines-operator-rh
   source: redhat-operators

--- a/cluster-scope/overlays/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/moc/infra/kustomization.yaml
@@ -22,3 +22,4 @@ generators:
 
 patchesStrategicMerge:
   - oauths/cluster_patch.yaml
+  - subscriptions/kubevirt-hyperconverged_patch.yaml

--- a/cluster-scope/overlays/moc/infra/subscriptions/kubevirt-hyperconverged_patch.yaml
+++ b/cluster-scope/overlays/moc/infra/subscriptions/kubevirt-hyperconverged_patch.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+spec:
+  channel: "stable"
+  startingCSV: "kubevirt-hyperconverged-operator.v2.5.4"

--- a/cluster-scope/overlays/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/moc/zero/kustomization.yaml
@@ -89,3 +89,9 @@ generators:
 patchesStrategicMerge:
   - oauths/cluster_patch.yaml
   - imageregistryconfigs/image-registry-storage_patch.yaml
+  - subscriptions/cluster-logging-operator_patch.yaml
+  - subscriptions/elastic-operator_patch.yaml
+  - subscriptions/kubevirt-hyperconverged_patch.yaml
+  - subscriptions/metering-ocp_patch.yaml
+  - subscriptions/ocs-operator_patch.yaml
+  - subscriptions/openshift-pipelines-operator-rh_patch.yaml

--- a/cluster-scope/overlays/moc/zero/subscriptions/cluster-logging-operator_patch.yaml
+++ b/cluster-scope/overlays/moc/zero/subscriptions/cluster-logging-operator_patch.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  # https://docs.openshift.com/container-platform/4.7/logging/cluster-logging-deploying.html#cluster-logging-deploy-cli_cluster-logging-deploying
+  # For OpenShift 4.7 the channel should be "stable" or "5.0"
+  channel: stable

--- a/cluster-scope/overlays/moc/zero/subscriptions/elastic-operator_patch.yaml
+++ b/cluster-scope/overlays/moc/zero/subscriptions/elastic-operator_patch.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: elasticsearch-operator
+  namespace: openshift-operators-redhat
+spec:
+  # https://docs.openshift.com/container-platform/4.7/logging/cluster-logging-deploying.html#cluster-logging-deploy-cli_cluster-logging-deploying
+  # For OpenShift 4.7 the channel should be "stable" or "5.0"
+  channel: stable

--- a/cluster-scope/overlays/moc/zero/subscriptions/kubevirt-hyperconverged_patch.yaml
+++ b/cluster-scope/overlays/moc/zero/subscriptions/kubevirt-hyperconverged_patch.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+spec:
+  # https://www.openshift.com/blog/whats-new-in-openshift-virtualization-in-ocp-4.7
+  # As of 2021-03-01 there's no docs available for OpenShift Virtualization on Openshift 4.7. Guessing the proper channel from blogpost above.
+  channel: "2.6"

--- a/cluster-scope/overlays/moc/zero/subscriptions/local-storage-operator_patch.yaml
+++ b/cluster-scope/overlays/moc/zero/subscriptions/local-storage-operator_patch.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: local-storage-operator
+  namespace: local-storage
+spec:
+  # As of 2021-03-01 the docs for Local Storage doesn't specify channel.
+  # https://docs.openshift.com/container-platform/4.7/storage/persistent_storage/persistent-storage-local.html
+  # Guessing channel.
+  channel: "4.7"

--- a/cluster-scope/overlays/moc/zero/subscriptions/metering-ocp_patch.yaml
+++ b/cluster-scope/overlays/moc/zero/subscriptions/metering-ocp_patch.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: metering-operator
+  namespace: openshift-metering
+spec:
+  # https://docs.openshift.com/container-platform/4.7/metering/metering-installing-metering.html#metering-install-cli_installing-metering
+  channel: "4.7"

--- a/cluster-scope/overlays/moc/zero/subscriptions/ocs-operator_patch.yaml
+++ b/cluster-scope/overlays/moc/zero/subscriptions/ocs-operator_patch.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ocs-operator
+  namespace: openshift-storage
+spec:
+  # As of 2021-03-01 it seems the latest OCS version released is 4.6, it's confusing though.
+  channel: "stable-4.6"

--- a/cluster-scope/overlays/moc/zero/subscriptions/openshift-pipelines-operator-rh_patch.yaml
+++ b/cluster-scope/overlays/moc/zero/subscriptions/openshift-pipelines-operator-rh_patch.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-pipelines-operator-rh
+  namespace: openshift-operators
+spec:
+  # https://docs.openshift.com/container-platform/4.7/cicd/pipelines/installing-pipelines.html#op-installing-pipelines-operator-in-web-console_installing-pipelines
+  channel: stable


### PR DESCRIPTION
We need to prepare CNV manifests to be deployable on OpenShift 4.7

**Do not merge while: 1) autosync on cluster-resources is on, 2) CNV cluster is not yet on OCP 4.7**

Part of: https://github.com/open-infrastructure-labs/ops-issues/issues/21

/hold

Update: Resolves https://github.com/operate-first/apps/issues/323