### PR TITLE
reconfgured CI/CD to use prow and aicoe-ci

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,3 +1,1 @@
 ---
-check:
-  - thoth-precommit

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,0 +1,17 @@
+presubmits:
+  - name: pre-commit
+    decorate: true
+    skip_report: false
+    always_run: true
+    context: aicoe-ci/prow/pre-commit
+    spec:
+      containers:
+        - image: quay.io/thoth-station/thoth-precommit-py38:v0.12.5
+          command:
+            - "pre-commit"
+            - "run"
+            - "--all-files"
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "2"


### PR DESCRIPTION
This uses Prow to run the unit tests.

Signed-off-by: Christoph Görn <goern@redhat.com>