### PR TITLE
[CLO] Increase the ES node count to 5

### DIFF
--- a/cluster-logging/base/clusterlogging.yaml
+++ b/cluster-logging/base/clusterlogging.yaml
@@ -19,7 +19,8 @@ spec:
         requests:
           cpu: 6
           memory: 16Gi
-      nodeCount: 3
+      # it's better to keep nodeCount to a odd number for leader election issues
+      nodeCount: 5
       storage:
         # TODO: manually set the storageClassName
         # Upstream Issue:


### PR DESCRIPTION
This is in order to prevent a networking bottleneck and hopefully solve network timeout issues with Elasticsearch.

Related https://github.com/operate-first/SRE/issues/98