### PR TITLE
integrate ray into MOC ODH

### DIFF
--- a/odh/base/jupyterhub/notebook-images/kustomization.yaml
+++ b/odh/base/jupyterhub/notebook-images/kustomization.yaml
@@ -11,4 +11,5 @@ resources:
   - ml-prague-workshop.yaml
   - ocp-ci-analysis.yaml
   - openshift-anomaly-detection.yaml
+  - ray-ml-notebook.yaml
   - time-series.yaml

--- a/odh/base/jupyterhub/notebook-images/ray-ml-notebook.yaml
+++ b/odh/base/jupyterhub/notebook-images/ray-ml-notebook.yaml
@@ -1,0 +1,16 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: ray-ml-notebook
+  labels:
+    opendatahub.io/notebook-image: 'true'
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    # This ray integration is being provided on an experimental basis
+    - name: experimental
+      from:
+        kind: DockerImage
+        # can rebuild with newer nightly SHAs periodically
+        name: 'quay.io/erikerlandson/ray-ml-notebook:py-3.6-ray-43570553'


### PR DESCRIPTION
This PR will address https://github.com/operate-first/support/issues/102, by porting the following integration onto MOC ODH:
https://github.com/erikerlandson/ray-odh-demo

The following components will need to be added to the overlays:
- [x] ray-ml-notebook image
- [ ] ray-operator image
- [ ] ray-operator CRD
- [ ] ray singleuser profile
- [ ] ray cluster template
- [ ] ray-ml worker image
