### PR TITLE
add cnv to infra cluster for nmstate support

### DIFF
--- a/cluster-scope/overlays/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/moc/infra/kustomization.yaml
@@ -12,6 +12,11 @@ resources:
   - ../../../base/operatorgroups/acm
   - ../../../base/subscriptions/advanced-cluster-management
 
+  # install cnv for nmstate support in 4.6
+  - ../../../base/namespaces/openshift-cnv
+  - ../../../base/operatorgroups/openshift-cnv
+  - ../../../base/subscriptions/kubevirt-hyperconverged
+
 generators:
   - secret-generator.yaml
 


### PR DESCRIPTION
this subscribes to the cnv operator in order to get nmstate [1]
support, which gives us a declarative mechanism for describing network
interface configuration. It looks like nmstate will be available by
defaultin 4.7 [2].

[1]: https://docs.openshift.com/container-platform/4.6/virt/node_network/virt-updating-node-network-config.html

[2]: https://docs.openshift.com/container-platform/4.7/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html
