### PR TITLE
Add network interfaces on crc provisioning network

### DIFF
--- a/cluster-scope/overlays/moc/infra/crc-provisioning-vlan.yaml
+++ b/cluster-scope/overlays/moc/infra/crc-provisioning-vlan.yaml
@@ -1,0 +1,68 @@
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: crc-provisioning-vlan-ctrl-0
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: os-ctrl-0
+  desiredState:
+    interfaces:
+      - name: eno1.307
+        description: crc cluster provisioning network
+        type: vlan
+        state: up
+        vlan:
+          base-iface: eno1
+          id: 307
+        ipv4:
+          enabled: true
+          dhcp: false
+          address:
+            - ip: 172.22.1.250
+              prefix-length: 24
+---
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: crc-provisioning-vlan-ctrl-1
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: os-ctrl-1
+  desiredState:
+    interfaces:
+      - name: eno1.307
+        description: crc cluster provisioning network
+        type: vlan
+        state: up
+        vlan:
+          base-iface: eno1
+          id: 307
+        ipv4:
+          enabled: true
+          dhcp: false
+          address:
+            - ip: 172.22.1.251
+              prefix-length: 24
+---
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: crc-provisioning-vlan-ctrl-2
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: os-ctrl-2
+  desiredState:
+    interfaces:
+      - name: eno1.307
+        description: crc cluster provisioning network
+        type: vlan
+        state: up
+        vlan:
+          base-iface: eno1
+          id: 307
+        ipv4:
+          enabled: true
+          dhcp: false
+          address:
+            - ip: 172.22.1.252
+              prefix-length: 24

--- a/cluster-scope/overlays/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/moc/infra/kustomization.yaml
@@ -17,6 +17,8 @@ resources:
   - ../../../base/operatorgroups/openshift-cnv
   - ../../../base/subscriptions/kubevirt-hyperconverged
 
+  - crc-provisioning-vlan.yaml
+
 generators:
   - secret-generator.yaml
 

--- a/cluster-scope/overlays/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/moc/infra/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - ../../../base/subscriptions/kubevirt-hyperconverged
 
   - crc-provisioning-vlan.yaml
+  - zero-provisioning-vlan.yaml
 
 generators:
   - secret-generator.yaml

--- a/cluster-scope/overlays/moc/infra/zero-provisioning-vlan.yaml
+++ b/cluster-scope/overlays/moc/infra/zero-provisioning-vlan.yaml
@@ -1,0 +1,68 @@
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: zero-provisioning-vlan-ctrl-0
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: os-ctrl-0
+  desiredState:
+    interfaces:
+      - name: eno1.294
+        description: zero cluster provisioning network
+        type: vlan
+        state: up
+        vlan:
+          base-iface: eno1
+          id: 294
+        ipv4:
+          enabled: true
+          dhcp: false
+          address:
+            - ip: 172.22.2.250
+              prefix-length: 24
+---
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: zero-provisioning-vlan-ctrl-1
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: os-ctrl-1
+  desiredState:
+    interfaces:
+      - name: eno1.294
+        description: zero cluster provisioning network
+        type: vlan
+        state: up
+        vlan:
+          base-iface: eno1
+          id: 294
+        ipv4:
+          enabled: true
+          dhcp: false
+          address:
+            - ip: 172.22.2.251
+              prefix-length: 24
+---
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: zero-provisioning-vlan-ctrl-2
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: os-ctrl-2
+  desiredState:
+    interfaces:
+      - name: eno1.294
+        description: zero cluster provisioning network
+        type: vlan
+        state: up
+        vlan:
+          base-iface: eno1
+          id: 294
+        ipv4:
+          enabled: true
+          dhcp: false
+          address:
+            - ip: 172.22.2.252
+              prefix-length: 24


### PR DESCRIPTION
Creates eno1.307 on all nodes and configures a different static
address for each node.

ACM requires access to the provisioning network of the target cluster
in order to communicate with the Ironic API. In 4.8 (and in future 4.7
releases) this communication will happen on the API network and these
cross-cluster links will no longer be necessary.
