### PR TITLE
add ray operator objects to ofp-jupyterhub

### DIFF
--- a/odh/base/jupyterhub/kustomization.yaml
+++ b/odh/base/jupyterhub/kustomization.yaml
@@ -5,3 +5,4 @@ namespace: opf-jupyterhub
 resources:
   - kfdef.yaml
   - ./notebook-images
+  - ./ray-odh-integration

--- a/odh/base/jupyterhub/ray-odh-integration/kustomization.yaml
+++ b/odh/base/jupyterhub/ray-odh-integration/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+namespace: opf-jupyterhub
+resources:
+  - ray-operator-serviceaccount.yaml
+  - ray-operator-role.yaml
+  - ray-operator-rolebinding.yaml
+  - ray-operator-imagestream.yaml
+  - ray-operator-deployment.yaml

--- a/odh/base/jupyterhub/ray-odh-integration/ray-operator-deployment.yaml
+++ b/odh/base/jupyterhub/ray-odh-integration/ray-operator-deployment.yaml
@@ -1,0 +1,37 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: ray-operator
+spec:
+  # Do not change: currently only 1 replica is supported
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ray-operator
+  template:
+    metadata:
+      labels:
+        app: ray-operator
+    spec:
+      restartPolicy: Always
+      serviceAccountName: ray-operator
+      containers:
+        - name: ray-operator
+          imagePullPolicy: Always
+          image: 'ray-operator:experimental'
+          command: ['/bin/bash', '-c', '--', 'cd /opt/ray && pipenv run ray-operator']
+          env:
+            - name: RAY_CONFIG_DIR
+              value: '/tmp/ray_cluster_configs'
+            - name: RAY_OPERATOR_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            requests:
+              cpu: 1
+              memory: 1Gi
+            limits:
+              cpu: 1
+              memory: 2Gi

--- a/odh/base/jupyterhub/ray-odh-integration/ray-operator-imagestream.yaml
+++ b/odh/base/jupyterhub/ray-odh-integration/ray-operator-imagestream.yaml
@@ -1,0 +1,13 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: ray-operator
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: experimental
+      from:
+        kind: DockerImage
+        # can rebuild with newer nightly SHAs periodically
+        name: 'quay.io/erikerlandson/ray-operator-ubi:py-3.6-ray-43570553'

--- a/odh/base/jupyterhub/ray-odh-integration/ray-operator-role.yaml
+++ b/odh/base/jupyterhub/ray-odh-integration/ray-operator-role.yaml
@@ -1,0 +1,9 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ray-operator
+rules:
+  - apiGroups: ["", "cluster.ray.io"]
+    resources: ["rayclusters", "rayclusters/finalizers", "rayclusters/status", "pods", "pods/exec", "services"]
+    verbs: ["get", "watch", "list", "create", "delete", "patch", "update"]

--- a/odh/base/jupyterhub/ray-odh-integration/ray-operator-rolebinding.yaml
+++ b/odh/base/jupyterhub/ray-odh-integration/ray-operator-rolebinding.yaml
@@ -1,0 +1,12 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ray-operator
+subjects:
+  - kind: ServiceAccount
+    name: ray-operator
+roleRef:
+  kind: Role
+  name: ray-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/odh/base/jupyterhub/ray-odh-integration/ray-operator-serviceaccount.yaml
+++ b/odh/base/jupyterhub/ray-odh-integration/ray-operator-serviceaccount.yaml
@@ -1,0 +1,5 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: ray-operator


### PR DESCRIPTION
Adds ray operator components to the jupyterhub namespace. This should merge after #321.
