### PR TITLE
Update path for kafka/superset for override in zero cluster.

### DIFF
--- a/odh/overlays/moc/zero/kafka/kustomization.yaml
+++ b/odh/overlays/moc/zero/kafka/kustomization.yaml
@@ -15,7 +15,7 @@ patchesJson6902:
               - topics
             repoRef:
               name: opf
-              path: odh/overlays/moc/kafka/overrides/kafka
+              path: odh/overlays/moc/zero/kafka/overrides/kafka
           name: kafka-cluster
       - op: add
         path: /spec/repos/-

--- a/odh/overlays/moc/zero/superset/kustomization.yaml
+++ b/odh/overlays/moc/zero/superset/kustomization.yaml
@@ -13,7 +13,7 @@ patchesJson6902:
           kustomizeConfig:
             repoRef:
               name: opf
-              path: odh/overlays/moc/superset/overrides
+              path: odh/overlays/moc/zero/superset/overrides
           name: superset
       - op: add
         path: /spec/repos/-


### PR DESCRIPTION
Due to the restructuring, the location of these overrides change, we need to update the kfdefs to reflect that.