### PR TITLE
Add clusterrolebinding for observatorium operator

### DIFF
--- a/cluster-scope/base/clusterrolebindings/observatorium-operator/clusterrolebinding.yaml
+++ b/cluster-scope/base/clusterrolebindings/observatorium-operator/clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: observatorium-operator
+    app.kubernetes.io/version: v0.1
+  name: observatorium-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: observatorium-operator
+subjects:
+  - kind: ServiceAccount
+    name: observatorium-operator
+    namespace: observatorium-operator

--- a/cluster-scope/base/clusterrolebindings/observatorium-operator/kustomization.yaml
+++ b/cluster-scope/base/clusterrolebindings/observatorium-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - clusterrolebinding.yaml

--- a/cluster-scope/overlays/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/moc/zero/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - ../../../base/clusterrolebindings/cluster-logs-readers
   - ../../../base/clusterrolebindings/cluster-metrics-federation
   - ../../../base/clusterrolebindings/metrics
+  - ../../../base/clusterrolebindings/observatorium-operator
   - ../../../base/clusterrolebindings/scc-privileged-opf-ci-pipelines-aicoe-ci
   - ../../../base/crds/prow.k8s.io
   - ../../../base/crds/observatorium.io

--- a/observatorium/base/operator/deployment.yaml
+++ b/observatorium/base/operator/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: observatorium-operator
       containers:
         - name: observatorium-operator
-          image: quay.io/observatorium/observatorium-operator:latest
+          image: quay.io/observatorium/observatorium-operator:master-2020-11-04-acb908d
           imagePullPolicy: IfNotPresent
           args:
             - "--log-level=debug"


### PR DESCRIPTION
Once the clusterrolebinding is pushed, we need to create a argocd app to deploy [the operator](https://github.com/operate-first/apps/tree/master/observatorium/base/operator).

Fix the operator deployment to an older tested image. This is because I was facing issues testing the newer versions.