### PR TITLE
modify subscriptions to set installPlanApproval to Manual

### DIFF
--- a/cluster-scope/base/subscriptions/advanced-cluster-management/subscription.yaml
+++ b/cluster-scope/base/subscriptions/advanced-cluster-management/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: acm-operator-subscription
 spec:
   channel: release-2.2
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: advanced-cluster-management
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/subscriptions/cluster-logging-operator/subscription.yaml
+++ b/cluster-scope/base/subscriptions/cluster-logging-operator/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: cluster-logging
 spec:
   channel: DEFINED_IN_OVERLAY
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: cluster-logging
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/subscriptions/elastic-operator/subscription.yaml
+++ b/cluster-scope/base/subscriptions/elastic-operator/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: elasticsearch-operator
 spec:
   channel: DEFINED_IN_OVERLAY
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: elasticsearch-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/subscriptions/local-storage-operator/subscription.yaml
+++ b/cluster-scope/base/subscriptions/local-storage-operator/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: local-storage-operator
 spec:
   channel: DEFINED_IN_OVERLAY
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: local-storage-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/subscriptions/metering-ocp/subscription.yaml
+++ b/cluster-scope/base/subscriptions/metering-ocp/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: metering-operator
 spec:
   channel: DEFINED_IN_OVERLAY
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: metering-ocp
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/subscriptions/ocs-operator/subscription.yaml
+++ b/cluster-scope/base/subscriptions/ocs-operator/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ocs-operator
 spec:
   channel: DEFINED_IN_OVERLAY
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: ocs-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/subscriptions/opendatahub-operator/subscription.yaml
+++ b/cluster-scope/base/subscriptions/opendatahub-operator/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: opendatahub-operator
 spec:
   channel: beta
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: opendatahub-operator
   source: community-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/subscriptions/openshift-pipelines-operator-rh/subscription.yaml
+++ b/cluster-scope/base/subscriptions/openshift-pipelines-operator-rh/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: openshift-pipelines-operator-rh
 spec:
   channel: DEFINED_IN_OVERLAY
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: openshift-pipelines-operator-rh
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
This prevents situations in which the running cluster ends up
out-of-sync with our repository due to automatic updates. We've seen
at least one situation where the interaction between the automatic
updates and argocd prevented the successful installation of an
operator.

Closes #227
