### PR TITLE
Add web terminal operator to zero cluster

### DIFF
--- a/cluster-scope/base/subscriptions/web-terminal/kustomization.yaml
+++ b/cluster-scope/base/subscriptions/web-terminal/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-operators
+
+resources:
+  - subscription.yaml

--- a/cluster-scope/base/subscriptions/web-terminal/subscription.yaml
+++ b/cluster-scope/base/subscriptions/web-terminal/subscription.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: web-terminal
+spec:
+  channel: DEFINED_IN_OVERLAY
+  installPlanApproval: Manual
+  name: web-terminal
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/overlays/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/moc/zero/kustomization.yaml
@@ -85,6 +85,7 @@ resources:
   - ../../../base/subscriptions/ocs-operator
   - ../../../base/subscriptions/opendatahub-operator
   - ../../../base/subscriptions/openshift-pipelines-operator-rh
+  - ../../../base/subscriptions/web-terminal
 
 generators:
   - secret-generator.yaml
@@ -99,3 +100,4 @@ patchesStrategicMerge:
   - subscriptions/metering-ocp_patch.yaml
   - subscriptions/ocs-operator_patch.yaml
   - subscriptions/openshift-pipelines-operator-rh_patch.yaml
+  - subscriptions/web-terminal.yaml

--- a/cluster-scope/overlays/moc/zero/subscriptions/web-terminal.yaml
+++ b/cluster-scope/overlays/moc/zero/subscriptions/web-terminal.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: web-terminal
+  namespace: openshift-operators
+spec:
+  channel: alpha


### PR DESCRIPTION
The web terminal operator adds a web cli to the openshift console. See
[1] for more details.

[1]: https://www.openshift.com/blog/a-deeper-look-at-the-web-terminal-operator-1