### PR TITLE
Add thanos to Observatorium CR for metrics long term storage

### DIFF
--- a/observatorium/base/instance/example-thanos-objectstorage-secret.yaml
+++ b/observatorium/base/instance/example-thanos-objectstorage-secret.yaml
@@ -1,0 +1,15 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: thanos-objectstorage-secret
+stringData:
+  thanos.yaml: |
+    type: s3
+    config:
+      bucket: MY_BUCKET_NAME
+      endpoint: my-s3-endpoint.example.com:80
+      insecure: true
+      access_key: MY_ACCESS_KEY
+      secret_key: MY_ACCESS_SECRET_KEY
+type: Opaque

--- a/observatorium/base/instance/observatorium.yaml
+++ b/observatorium/base/instance/observatorium.yaml
@@ -36,7 +36,7 @@ spec:
       secretName: loki-objectstorage-secret
     thanos:
       key: thanos.yaml
-      name: thanos-objectstorage
+      name: thanos-objectstorage-secret
   # All other Thanos and Observatorium components are scaled down
   api:
     rbac:
@@ -45,37 +45,72 @@ spec:
     tenants: []
     replicas: 0
   compact:
-    replicas: 0
-    retentionResolution1h: 1s
-    retentionResolution5m: 1s
-    retentionResolutionRaw: 14d
+    enableDownsampling: true
+    image: quay.io/thanos/thanos:v0.16.0
+    replicas: 1
+    retentionResolution1h: 0d    # forever
+    retentionResolution5m: 30d
+    retentionResolutionRaw: 7d
+    version: v0.16.0
     volumeClaimTemplate:
       spec:
         accessModes:
-        - ReadWriteOnce
+          - ReadWriteOnce
+        resources:
+          requests:
+            # https://github.com/thanos-io/thanos/blob/main/docs/components/compact.md#disk
+            storage: 100Gi  # recommended value
   hashrings:
   - hashring: default
   receivers:
-    replicas: 0
+    image: quay.io/thanos/thanos:v0.16.0
+    replicas: 1
+    version: v0.16.0
     volumeClaimTemplate:
       spec:
         accessModes:
         - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+  # thanosReceiveController auto populates the hashrings
+  thanosReceiveController:
+    image: quay.io/observatorium/thanos-receive-controller:master-2020-02-06-b66e0c8
+    version: master-2020-02-06-b66e0c8
   rule:
-    replicas: 0
+    image: quay.io/thanos/thanos:v0.16.0
+    replicas: 1
+    version: v0.16.0
     volumeClaimTemplate:
       spec:
         accessModes:
         - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
   store:
     cache:
-      replicas: 0
-    shards: 0
+      exporterImage: prom/memcached-exporter:v0.6.0
+      exporterVersion: v0.6.0
+      image: docker.io/memcached:1.6.3-alpine
+      memoryLimitMb: 1024
+      replicas: 1
+      version: 1.6.3-alpine
+    image: quay.io/thanos/thanos:v0.16.0
+    shards: 1
+    version: v0.16.0
     volumeClaimTemplate:
       spec:
         accessModes:
         - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
   query:
-    replicas: 0
+    image: quay.io/thanos/thanos:v0.16.0
+    replicas: 1
+    version: v0.16.0
   queryFrontend:
-    replicas: 0
+    image: quay.io/thanos/thanos:v0.16.0
+    replicas: 1
+    version: v0.16.0

--- a/observatorium/overlays/moc/zero/objectbucketclaims/kustomization.yaml
+++ b/observatorium/overlays/moc/zero/objectbucketclaims/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - loki-obc.yaml
+  - thanos-obc.yaml

--- a/observatorium/overlays/moc/zero/objectbucketclaims/thanos-obc.yaml
+++ b/observatorium/overlays/moc/zero/objectbucketclaims/thanos-obc.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: thanos-objectstorage
+spec:
+  generateBucketName: thanos-objectstorage
+  storageClassName: ocs-storagecluster-ceph-rgw

--- a/observatorium/overlays/moc/zero/secrets/secret-generator.yaml
+++ b/observatorium/overlays/moc/zero/secrets/secret-generator.yaml
@@ -4,3 +4,4 @@ metadata:
   name: loki-objectstorage-secret-generator
 files:
   - ./secrets/loki-objectstorage-secret.enc.yaml
+  - ./secrets/thanos-objectstorage-secret.enc.yaml

--- a/observatorium/overlays/moc/zero/secrets/thanos-objectstorage-secret.enc.yaml
+++ b/observatorium/overlays/moc/zero/secrets/thanos-objectstorage-secret.enc.yaml
@@ -1,0 +1,37 @@
+kind: Secret
+apiVersion: v1
+metadata:
+    name: thanos-objectstorage-secret
+stringData:
+    thanos.yaml: ENC[AES256_GCM,data:oyJtwCJMGy6y3tOOQLO98X1m/gYCafS8NaFm73Ui87b1vWwqyYAIgBWYlrTyhxTaP1klVOm2haGpEu68xgLUA1bhOYSqOdQg4LKXLxftGJ3BFiFVK3BaSymBwzbQv1+QrzmUtN7VoaHeF+t2ShLpfcpIKvenRGGpRt4BHhyR4atRkCacoNkPaBxyOHYPk7Q7k8kS3QDsNc8EriI8kT10pE5dI0FO++WNK3DHtPo6VhzAfHkGk8FzBoJemiWyMF//nDCoZD0A0JG0EmwbDov0pBphGoTc1gE+ovnQqm7RwrFkeDStDo/49l/JQMIFczpG6PtzndwIZAzaJrXSliLJ2V2sw2wzVxchsxmBicJjSKb8gedqa+z5Hp+d6E8u2Azc1rtg6Q==,iv:5xeQhX+YtQLiuW1Weoripl2Tf4Lh4VqXXZmkUrmRkkQ=,tag:AbdMP41TFJYZhLL3Q4NErw==,type:str]
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-03-11T17:47:13Z'
+    mac: ENC[AES256_GCM,data:KS562LM8so2KJyezzbfAJ6llLOoBJS5n1JFYLKpjYUlrGlohWkbx9pBRr6EAhI/dU+TyhAaxCsWaSbrNiWFX1DHmHHbFXs7LLN5ftoTKOXCOb1XC3dkXRwNyJ+Pwvi9iVoznkJO0SAOjCs6mkaN8T80WkN3ZVESDl4NIma8Wzao=,iv:DdQoYZ5cNO2JPSvFKi6Eilscfo/187b12WYoE6plAXM=,tag:Mcnq4WJdSEVq2AtYJbJODA==,type:str]
+    pgp:
+    -   created_at: '2021-03-11T17:47:12Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA9aKBcudqifiAQ//fWUSmdINpftWqVV2fTAb85/Mcx0W6xD6u0fOLkmSZDnU
+            OQGIAGx0hlYnCYtdbNJFp4J6QTERmm09BBlIuwPRNnVfkhToc5o3gIMaIVr3UqKo
+            Q+0Z2y/9cydqTMHAg6Tka2ejQR7qAxA12C0WGgZbMmKExqVqKVXfq7kK5wTJtoOe
+            e4q+5WCCNQMk9/xR01v+vjHJ64ED+I5Wr6TY0ud2QuH5D8XHLkFHmk2Nv8oXVUSj
+            dlGjzhWgPud/tcvyU1FBeqSX1UGPV1PilcgKUH3UOY1JiSduHY7b89SGGDaKlPp+
+            b3fMfoZFRAbcX3azPOyh0tYi7njPXiphhP7N5/75JDuEfhzO5SaGK8a6UecTkuWr
+            OQZDe0/kRFjTtPU2pr/M2Ov9GUedRRcGiEYG5DuZGtLns2z1j8z9NuJJuWo4q6dC
+            5RUq9Nu7Jx1xaWxQLJ0k4/hILQZdiwiI0xtwNi5wkPZm/DdlY02umkEd5gbZxbmf
+            TJ3Ft2b7YHAj70xP5MLa+6Mzop+siOA//UFG2zUJKxOZ9HKb1ejWYu5zHUhH6GfP
+            DUb/4GBC1riBfPvUgOh9QXPm7JN2h86xKXGqu5AeoGs5u8N0kdrmNzbMBQBcQFsz
+            5YjWW7LxbM/MgevmJP6toumdYp1N+sZc2I3quuR+sZN7aEx1Q6dJ4QOLLwWUkt7S
+            XgGNuVYCn98A5eYUzzcF9JTW6ybDGVytH4F/fbIuKJKFlxhkoaQU+VHtVL+yEwp6
+            3Igldzdfhi2aaabgV3xLesr4k9s1RYzcnkEkj4ri50Xg8UtQUJA2To2puHpXtAA=
+            =r0Jx
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^(data|stringData)$
+    version: 3.6.1


### PR DESCRIPTION
Closes #74 

Once this is deployed, I will need to update the opf-monitoring prometheus instance to remote-write metrics to this instance 
And also add a grafana datasource for this thanos instance.

Explaining Retention Policies:
`retentionResolution1h: 0d    # forever` Store downsampled values for 1h resolution forever
`retentionResolution5m: 30d` Store downsampled values for 5m resolution for 30 days
`retentionResolutionRaw: 7d` Store downsampled values for raw (original) resolution for 7 days