### PR TITLE
add ray ml singleuser profile to overlays

### DIFF
--- a/odh/base/jupyterhub/ray-odh-integration/kustomization.yaml
+++ b/odh/base/jupyterhub/ray-odh-integration/kustomization.yaml
@@ -8,3 +8,7 @@ resources:
   - ray-operator-rolebinding.yaml
   - ray-operator-imagestream.yaml
   - ray-operator-deployment.yaml
+  - ray-cluster-template-cm.yaml
+  - ray-jh-rolebinding.yaml
+  - ray-ml-node-imagestream.yaml
+  - ray-ml-profile-cm.yaml

--- a/odh/base/jupyterhub/ray-odh-integration/ray-cluster-template-cm.yaml
+++ b/odh/base/jupyterhub/ray-odh-integration/ray-cluster-template-cm.yaml
@@ -1,0 +1,113 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ray-cluster-template
+data:
+  rayClusterResourceTemplate: |
+    kind: RayCluster
+    apiVersion: cluster.ray.io/v1
+    metadata:
+      name: 'ray-cluster-{{ user }}'
+      labels:
+        # allows me to return name of service that Ray operator creates
+        odh-ray-cluster-service: 'ray-cluster-{{ user }}-ray-head'
+    spec:
+      # we can parameterize this when we fix the JH launcher json/jinja bug
+      maxWorkers: 5
+      # The autoscaler will scale up the cluster faster with higher upscaling speed.
+      # E.g., if the task requires adding more nodes then autoscaler will gradually
+      # scale up the cluster in chunks of upscaling_speed*currently_running_nodes.
+      # This number should be > 0.
+      upscalingSpeed: 1.0
+      # If a node is idle for this many minutes, it will be removed.
+      idleTimeoutMinutes: 5
+      # Specify the pod type for the ray head node (as configured below).
+      headPodType: head-node
+      # Specify the allowed pod types for this ray cluster and the resources they provide.
+      podTypes:
+      - name: head-node
+        podConfig:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            generateName: 'ray-cluster-{{ user }}-head-'
+          spec:
+            restartPolicy: Never
+            volumes:
+            - name: dshm
+              emptyDir:
+                medium: Memory
+            containers:
+            - name: ray-node
+              imagePullPolicy: Always
+              image: '{{ ray_image }}'
+              # Do not change this command - it keeps the pod alive until it is explicitly killed.
+              command: ["/bin/bash", "-c", "--"]
+              args: ['trap : TERM INT; sleep infinity & wait;']
+              # This volume allocates shared memory for Ray to use for plasma
+              env:
+              # defining HOME is part of a workaround for:
+              # https://github.com/ray-project/ray/issues/14155
+              - name: HOME
+                value: '/opt'
+              volumeMounts:
+              - mountPath: /dev/shm
+                name: dshm
+              resources:
+                requests:
+                  cpu: '{{ cpu_request }}'
+                  memory: '{{ memory_request}}'
+                limits:
+                  cpu: '{{ cpu_limit }}'
+                  # The maximum memory that this pod is allowed to use. The
+                  # limit will be detected by ray and split to use 10% for
+                  # redis, 30% for the shared memory object store, and the
+                  # rest for application memory. If this limit is not set and
+                  # the object store size is not set manually, ray will
+                  # allocate a very large object store in each pod that may
+                  # cause problems for other pods.
+                  memory: '{{ memory_limit }}'
+      - name: worker-nodes
+        # we can parameterize this when we fix the JH launcher json/jinja bug
+        minWorkers: 0
+        maxWorkers: 5
+        podConfig:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            # Automatically generates a name for the pod with this prefix.
+            generateName: 'ray-cluster-{{ user }}-worker-'
+          spec:
+            restartPolicy: Never
+            volumes:
+            - name: dshm
+              emptyDir:
+                medium: Memory
+            containers:
+            - name: ray-node
+              imagePullPolicy: Always
+              image: '{{ ray_image }}'
+              command: ["/bin/bash", "-c", "--"]
+              args: ["trap : TERM INT; sleep infinity & wait;"]
+              env:
+              - name: HOME
+                value: '/opt'
+              volumeMounts:
+              - mountPath: /dev/shm
+                name: dshm
+              resources:
+                requests:
+                  cpu: '{{ cpu_request }}'
+                  memory: '{{ memory_request}}'
+                limits:
+                  cpu: '{{ cpu_limit }}'
+                  memory: '{{ memory_limit }}'
+      # Commands to start Ray on the head node. You don't need to change this.
+      # Note dashboard-host is set to 0.0.0.0 so that Kubernetes can port forward.
+      headStartRayCommands:
+          - cd /opt/ray; pipenv run ray stop
+          - ulimit -n 65536; cd /opt/ray; pipenv run ray start --head --no-monitor --port=6379 --object-manager-port=8076 --dashboard-host 0.0.0.0
+      # Commands to start Ray on worker nodes. You don't need to change this.
+      workerStartRayCommands:
+          - cd /opt/ray; pipenv run ray stop
+          - ulimit -n 65536; cd /opt/ray; pipenv run ray start --address=$RAY_HEAD_IP:6379 --object-manager-port=8076

--- a/odh/base/jupyterhub/ray-odh-integration/ray-jh-rolebinding.yaml
+++ b/odh/base/jupyterhub/ray-odh-integration/ray-jh-rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  # By default, the ODH JupyterHub Launcher does not have authorization
+  # to create objects of type Deployment in your project namespace.
+  # Adding this rolebinding in your project will allow the launcher to
+  # create the ray cluster Deployment objects defined in the singleuser profile.
+  name: ray-jupyterhub
+subjects:
+  - kind: ServiceAccount
+    name: jupyterhub-hub
+roleRef:
+  kind: Role
+  # we bind the launcher to same role used by the ray operator
+  name: ray-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/odh/base/jupyterhub/ray-odh-integration/ray-ml-node-imagestream.yaml
+++ b/odh/base/jupyterhub/ray-odh-integration/ray-ml-node-imagestream.yaml
@@ -1,0 +1,14 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  # image for ray head or worker nodes
+  name: ray-ml-node
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: experimental
+      from:
+        kind: DockerImage
+        # can rebuild with newer nightly SHAs periodically
+        name: 'quay.io/erikerlandson/ray-ml-ubi:py-3.6-ray-43570553'

--- a/odh/base/jupyterhub/ray-odh-integration/ray-ml-profile-cm.yaml
+++ b/odh/base/jupyterhub/ray-odh-integration/ray-ml-profile-cm.yaml
@@ -1,0 +1,32 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ray-ml-profile
+  labels:
+    jupyterhub: singleuser-profiles
+data:
+  jupyterhub-singleuser-profiles.yaml: |
+    profiles:
+      - name: Ray ML Notebook
+        images:
+          - 'ray-ml-notebook:experimental'
+        env:
+          # this is a workaround that may not be neccesary in the future
+          - name: RAY_CLIENT_MODE
+            value: '1'
+        services:
+          ray-cluster:
+            resources:
+              - name: ray-cluster-template
+                path: rayClusterResourceTemplate
+            configuration:
+              ray_image: 'ray-ml-node:experimental'
+              # number of workers currently disabled due to json/jinja bug in JH launcher
+              #max_workers: 5
+              memory_request: '1024Mi'
+              memory_limit: '1024Mi'
+              cpu_request: '1'
+              cpu_limit: '1'
+            return:
+              # This path applies to the last item in 'resources' list above
+              RAY_CLUSTER: 'metadata.labels[odh-ray-cluster-service]'


### PR DESCRIPTION
addresses https://github.com/operate-first/support/issues/102 - adding ray cluster template and a singleuser profile for ray ML notebook backed by a ray cluster