### PR TITLE
feat: Enable GH alert receiver for Cluster Monitoring on MOC Infra

### DIFF
--- a/cluster-scope/overlays/moc/infra/alertmanager-main-secret.yaml
+++ b/cluster-scope/overlays/moc/infra/alertmanager-main-secret.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-main
+  namespace: openshift-monitoring
+type: Opaque
+stringData:
+  alertmanager.yaml: |
+    global:
+      resolve_timeout: 5m
+    inhibit_rules:
+      - equal:
+          - namespace
+          - alertname
+        source_match:
+          severity: critical
+        target_match_re:
+          severity: warning|info
+      - equal:
+          - namespace
+          - alertname
+        source_match:
+          severity: warning
+        target_match_re:
+          severity: info
+    receivers:
+      - name: Default
+        webhook_configs:
+          - url: 'http://github-receiver-service.opf-alertreceiver.svc.cluster.local:9393/v1/receiver'
+      - name: Watchdog
+    route:
+      group_by:
+        - namespace
+        - alertname
+      group_interval: 5m
+      group_wait: 30s
+      receiver: Default
+      repeat_interval: 12h
+      routes:
+        - match:
+            alertname: Watchdog
+          receiver: Watchdog

--- a/cluster-scope/overlays/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/moc/infra/kustomization.yaml
@@ -22,6 +22,8 @@ resources:
   - crc-provisioning-vlan.yaml
   - zero-provisioning-vlan.yaml
 
+  - alertmanager-main-secret.yaml
+
 generators:
   - secret-generator.yaml
 


### PR DESCRIPTION
Part of: https://github.com/operate-first/SRE/issues/56
Depends on: https://github.com/operate-first/argocd-apps/pull/100

~Requires some more testing first.~

Tested against quicklab https://console-openshift-console.apps.testtcoufal.lab.upshift.rdu2.redhat.com/
and https://github.com/tumido/test/issues repo