### PR TITLE
fix: Datacatalog bucket

### DIFF
--- a/odh/overlays/moc/zero/datacatalog/bucket.yaml
+++ b/odh/overlays/moc/zero/datacatalog/bucket.yaml
@@ -4,8 +4,8 @@ kind: ObjectBucketClaim
 metadata:
   name: opf-datacatalog-bucket
 spec:
-  generateBucketName: opf-datacatalog-
-  storageClassName: ocs-storagecluster-ceph-rgw
+  bucketName: opf-datacatalog
+  storageClassName: openshift-storage.noobaa.io
   additionalConfig:
     maxObjects: "100000"
     maxSize: 10G

--- a/odh/overlays/moc/zero/datacatalog/kfdef_patch.yaml
+++ b/odh/overlays/moc/zero/datacatalog/kfdef_patch.yaml
@@ -2,7 +2,7 @@
   path: /spec/applications/2/kustomizeConfig/parameters
   value:
     - name: s3_endpoint_url
-      value: rook-ceph-rgw-ocs-storagecluster-cephobjectstore.openshift-storage.svc.cluster.local
+      value: s3.openshift-storage.svc:443
     - name: s3_credentials_secret
       value: opf-datacatalog-bucket
     - name: storage_class
@@ -12,7 +12,7 @@
   path: /spec/applications/3/kustomizeConfig/parameters
   value:
     - name: s3_endpoint_url
-      value: rook-ceph-rgw-ocs-storagecluster-cephobjectstore.openshift-storage.svc.cluster.local
+      value: s3.openshift-storage.svc:443
     - name: s3_credentials_secret
       value: opf-datacatalog-bucket
     - name: storage_class


### PR DESCRIPTION
Resolves: https://github.com/operate-first/support/issues/117

/hold requires manual sync after merge (because we're re-defining the storage class - original bucket has to be deleted first)