### PR TITLE
Increase alert duration check

### DIFF
--- a/odh/base/monitoring/overrides/prometheus-operator/overlays/alerts/prometheus-rules.yaml
+++ b/odh/base/monitoring/overrides/prometheus-operator/overlays/alerts/prometheus-rules.yaml
@@ -12,79 +12,79 @@ spec:
       rules:
         - alert: Prometheus Service Down
           expr: absent(up{service="prometheus-operated", pod=~"prometheus-odh-monitoring.*"} > 0)
-          for: 5m
+          for: 10m
           annotations:
             summary: "Prometheus service is no longer available"
             severity: "HIGH"
         - alert: Prometheus Alertmanager Down
           expr: absent(up{service="alert-manager"} == 1)
-          for: 5m
+          for: 10m
           annotations:
             summary: "Prometheus Alertmanager is no longer available"
             severity: "HIGH"
         - alert: Grafana Service Down
           expr: absent(up{service="grafana-service"} == 1)
-          for: 5m
+          for: 10m
           annotations:
             summary: "Grafana service is no longer available"
             severity: "HIGH"
         - alert: Grafana Operator
           expr: absent(up{service="grafana-operator-metrics"} == 1)
-          for: 5m
+          for: 10m
           annotations:
             summary: "Grafana operator metrics not available"
             severity: "LOW"
         - alert: JupyterHub Service Down
           expr: absent(up{service="jupyterhub"} == 1)
-          for: 5m
+          for: 10m
           annotations:
             summary: "JupyterHub service is no longer available"
             severity: "HIGH"
         - alert: ArgoCD Repo Server Down
           expr: absent(up{service="argocd-repo-server"} == 1)
-          for: 5m
+          for: 10m
           annotations:
             summary: "ArgoCD repo server is no longer available"
             severity: "HIGH"
         - alert: ArgoCD Server Down
           expr: absent(up{service="argocd-server-metrics"} == 1)
-          for: 5m
+          for: 10m
           annotations:
             summary: "ArgoCD server is no longer available"
             severity: "HIGH"
         - alert: ArgoCD Application Controller Down
           expr: absent(up{service="argocd-metrics"} == 1)
-          for: 5m
+          for: 10m
           annotations:
             summary: "ArgoCD application controller is no longer available"
             severity: "HIGH"
         - alert: ArgoCD Dex Server Down
           expr: absent(up{service="argocd-dex-server"} == 1)
-          for: 5m
+          for: 10m
           annotations:
             summary: "ArgoCD Dex Server is no longer available"
             severity: "HIGH"
         - alert: Observatorium Loki Ingester Down
           expr: absent(up{service="opf-observatorium-loki-ingester-http"} == 1)
-          for: 5m
+          for: 10m
           annotations:
             summary: "Loki ingester is no longer available"
             severity: "HIGH"
         - alert: Observatorium Loki Distributor Down
           expr: absent(up{service="opf-observatorium-loki-distributor-http"} == 1)
-          for: 5m
+          for: 10m
           annotations:
             summary: "Loki distributor is no longer available"
             severity: "HIGH"
         - alert: Observatorium Loki Querier Down
           expr: absent(up{service="opf-observatorium-loki-querier-http"} == 1)
-          for: 5m
+          for: 10m
           annotations:
             summary: "Loki querier is no longer available"
             severity: "HIGH"
         - alert: Observatorium Loki Query Frontend Down
           expr: absent(up{service="opf-observatorium-loki-query-frontend-http"} == 1)
-          for: 5m
+          for: 10m
           annotations:
             summary: "Loki query frontend is no longer available"
             severity: "HIGH"


### PR DESCRIPTION
Increasing the alert duration check to 10m for the service availability alerts. 
this addresses https://github.com/operate-first/SRE/issues/81