### PR TITLE
fix: ODH Dashboard image replace

### DIFF
--- a/odh/base/dashboard/overrides/overlays/custom-image/kustomization.yaml
+++ b/odh/base/dashboard/overrides/overlays/custom-image/kustomization.yaml
@@ -5,7 +5,7 @@ bases:
   - ../../base
 
 images:
-  - name: quay.io/opendatahub/odh-dashboard:v0.9
+  - name: quay.io/opendatahub/odh-dashboard
     newName: quay.io/operate-first/odh-dashboard
     newTag: latest
 


### PR DESCRIPTION
Fixes https://github.com/operate-first/odh-dashboard/issues/9

After upgrade it simply wasn't using our image. I have no idea why it didn't fail earlier.