### PR TITLE
Update monitoring

### DIFF
--- a/cluster-scope/base/namespaces/openshift-operators-redhat/kustomization.yaml
+++ b/cluster-scope/base/namespaces/openshift-operators-redhat/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 
 components:
   - ../../../components/project-admin-rolebindings/operate-first
+  - ../../../components/monitoring-rbac

--- a/cluster-scope/base/namespaces/openshift-operators/kustomization.yaml
+++ b/cluster-scope/base/namespaces/openshift-operators/kustomization.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: openshift-operators-redhat
+namespace: openshift-operators
 
 components:
   - ../../../components/monitoring-rbac

--- a/odh/base/monitoring/overrides/prometheus-operator/base/kafka-podmonitors.yaml
+++ b/odh/base/monitoring/overrides/prometheus-operator/base/kafka-podmonitors.yaml
@@ -1,0 +1,102 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: cluster-operator-metrics
+  labels:
+    app: strimzi
+    team: opendatahub
+spec:
+  selector:
+    matchLabels:
+      strimzi.io/kind: cluster-operator
+  podMetricsEndpoints:
+  - path: /metrics
+    port: http
+  namespaceSelector:
+    matchNames:
+      - opf-kafka
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: entity-operator-metrics
+  labels:
+    app: strimzi
+    team: opendatahub
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: entity-operator
+  podMetricsEndpoints:
+  - path: /metrics
+    port: healthcheck
+  namespaceSelector:
+    matchNames:
+      - opf-kafka
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: bridge-metrics
+  labels:
+    app: strimzi
+    team: opendatahub
+spec:
+  selector:
+    matchLabels:
+      strimzi.io/kind: KafkaBridge
+  podMetricsEndpoints:
+  - path: /metrics
+    port: rest-api
+  namespaceSelector:
+    matchNames:
+      - opf-kafka
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: kafka-metrics
+  labels:
+    app: strimzi
+    team: opendatahub
+spec:
+  selector:
+    matchExpressions:
+      - key: "strimzi.io/kind"
+        operator: In
+        values: ["Kafka", "KafkaConnect"]
+  podMetricsEndpoints:
+  - path: /metrics
+    port: tcp-prometheus
+    relabelings:
+    - separator: ;
+      regex: __meta_kubernetes_pod_label_(.+)
+      replacement: $1
+      action: labelmap
+    - sourceLabels: [__meta_kubernetes_namespace]
+      separator: ;
+      regex: (.*)
+      targetLabel: namespace
+      replacement: $1
+      action: replace
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      separator: ;
+      regex: (.*)
+      targetLabel: kubernetes_pod_name
+      replacement: $1
+      action: replace
+    - sourceLabels: [__meta_kubernetes_pod_node_name]
+      separator: ;
+      regex: (.*)
+      targetLabel: node_name
+      replacement: $1
+      action: replace
+    - sourceLabels: [__meta_kubernetes_pod_host_ip]
+      separator: ;
+      regex: (.*)
+      targetLabel: node_ip
+      replacement: $1
+      action: replace
+  namespaceSelector:
+    matchNames:
+      - opf-kafka

--- a/odh/base/monitoring/overrides/prometheus-operator/base/servicemonitor.yaml
+++ b/odh/base/monitoring/overrides/prometheus-operator/base/servicemonitor.yaml
@@ -16,3 +16,4 @@ spec:
       - opf-jupyterhub
       - opf-argo
       - opf-monitoring
+      - openshift-operators


### PR DESCRIPTION
Fixes #215 

Two Questions:
1) I haven't actually created overrides before, please let me know if I should have done things differently here
2) The prometheus-k8s service account used by the operator for monitoring doesn't have access to the `openshift-operators` namespace, as far as I can tell (I checked by logging in as the SA and trying to get services). I'm a _little_ confused as to how I'd give the SA access. (I was looking at https://github.com/operate-first/apps/tree/master/cluster-scope but I'm not clear).
