### PR TITLE
feat: Add memory intensive user profile

### DIFF
--- a/odh/base/jupyterhub/overrides/jupyterhub/base/jupyterhub-singleuser-profiles-configmap.yaml
+++ b/odh/base/jupyterhub/overrides/jupyterhub/base/jupyterhub-singleuser-profiles-configmap.yaml
@@ -1,0 +1,90 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jupyter-singleuser-profiles
+data:
+  jupyterhub-singleuser-profiles.yaml: |
+      profiles:
+      - name: globals
+        env:
+          - name: S3_ENDPOINT_URL
+            value: $(s3_endpoint_url)
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 500m
+          limits:
+            memory: 2Gi
+            cpu: 1
+
+      - name: Spark Notebook
+        images:
+        - 's2i-spark-minimal-notebook:3.6'
+        - 's2i-spark-scipy-notebook:3.6'
+        - 's2i-spark-minimal-notebook:py36-spark2.4.5-hadoop2.7.3'
+        env:
+          - name: PYSPARK_SUBMIT_ARGS
+            value: '--conf spark.cores.max=2 --conf spark.executor.instances=2 --conf spark.executor.memory=1G --conf spark.executor.cores=1 --conf spark.driver.memory=2G --packages com.amazonaws:aws-java-sdk:1.7.4,org.apache.hadoop:hadoop-aws:2.7.3 pyspark-shell'
+          - name: PYSPARK_DRIVER_PYTHON
+            value: 'jupyter'
+          - name: PYSPARK_DRIVER_PYTHON_OPTS
+            value: 'notebook'
+          - name: SPARK_HOME
+            value: '/opt/app-root/lib/python3.6/site-packages/pyspark/'
+          - name: PYTHONPATH
+            value: '$PYTHONPATH:/opt/app-root/lib/python3.6/site-packages/:/opt/app-root/lib/python3.6/site-packages/pyspark/python/:/opt/app-root/lib/python3.6/site-packages/pyspark/python/lib/py4j-0.8.2.1-src.zip'
+        services:
+          spark:
+            resources:
+            - name: spark-cluster-template
+              path: notebookPodServiceTemplate
+            - name: spark-cluster-template
+              path: sparkClusterTemplate
+            configuration:
+              worker_nodes: '2'
+              master_nodes: '1'
+              master_memory_limit: '2Gi'
+              master_cpu_limit: '1'
+              master_memory_request: '2Gi'
+              master_cpu_request: '1'
+              worker_memory_limit: '2Gi'
+              worker_cpu_limit: '1'
+              worker_memory_request: '2Gi'
+              worker_cpu_request: '1'
+              spark_image: 'quay.io/radanalyticsio/openshift-spark-py36:2.4.5-2'
+            return:
+              SPARK_CLUSTER: 'metadata.name'
+
+      sizes:
+      - name: Small
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 1
+          limits:
+            memory: 2Gi
+            cpu: 2
+      - name: Medium
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 2
+          limits:
+            memory: 4Gi
+            cpu: 4
+      - name: Large
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 4
+          limits:
+            memory: 8Gi
+            cpu: 8
+      - name: Large - Memory intensive
+        resources:
+          requests:
+            memory: 16Gi
+            cpu: 4
+          limits:
+            memory: 32Gi
+            cpu: 8


### PR DESCRIPTION
Fixes: https://github.com/operate-first/support/issues/116

Override of https://github.com/opendatahub-io/odh-manifests/blob/master/jupyterhub/jupyterhub/base/jupyterhub-singleuser-profiles-configmap.yaml

Adding a new size: **Large - memory intensive**:
- https://github.com/operate-first/apps/pull/381/files#diff-60cff131ed8817563fe2d0ab7ccc61958aef4f5e7e3439766914ae1648b14ce3R83-R90
- CPU request and limit stays the same as in **Large**
- Memory has 16GiB request, 32GiB limit