### PR TITLE
Install Service Mesh operator

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/jaeger-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/jaeger-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-operators
+resources:
+- subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/jaeger-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/jaeger-operator/subscription.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: jaeger-operator
+spec:
+  channel: DEFINED_IN_OVERLAY
+  installPlanApproval: Automatic
+  name: jaeger-product
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/kiali-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/kiali-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-operators
+resources:
+- subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/kiali-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/kiali-operator/subscription.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kiali-operator
+spec:
+  channel: DEFINED_IN_OVERLAY
+  installPlanApproval: Automatic
+  name: kiali-ossm
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/servicemesh-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/servicemesh-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-operators
+resources:
+  - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/servicemesh-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/servicemesh-operator/subscription.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: servicemesh-operator
+spec:
+  channel: DEFINED_IN_OVERLAY
+  installPlanApproval: Automatic
+  name: servicemeshoperator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Part of: https://github.com/operate-first/support/issues/111

Installs Service Mesh and it's prerequisites according to:
https://docs.openshift.com/container-platform/4.7/service_mesh/v2x/installing-ossm.html

- [x] Install ElasticSearch operator (already available)
- [x] Install Jaeger operator
- [x] Install Kiali operator
- [x] Install Service mesh operator  