### PR TITLE
attempt to upgrade cnv to 2.6.0

### DIFF
--- a/cluster-scope/overlays/moc/zero/subscriptions/kubevirt-hyperconverged_patch.yaml
+++ b/cluster-scope/overlays/moc/zero/subscriptions/kubevirt-hyperconverged_patch.yaml
@@ -8,3 +8,4 @@ spec:
   # https://www.openshift.com/blog/whats-new-in-openshift-virtualization-in-ocp-4.7
   # As of 2021-03-01 there's no docs available for OpenShift Virtualization on Openshift 4.7. Guessing the proper channel from blogpost above.
   channel: "stable"
+  startingCSV: kubevirt-hyperconverged-operator.v2.6.0


### PR DESCRIPTION
There's an update available for 2.6.0 waiting for manual approval. We
talked about seeing what the behavior is if we update the subscription
with a startingCSV attribute matching the new version. This commit is
that test.
