### PR TITLE
Revert "attempt to upgrade cnv to 2.6.0"

### DIFF
--- a/cluster-scope/overlays/moc/zero/subscriptions/kubevirt-hyperconverged_patch.yaml
+++ b/cluster-scope/overlays/moc/zero/subscriptions/kubevirt-hyperconverged_patch.yaml
@@ -8,4 +8,3 @@ spec:
   # https://www.openshift.com/blog/whats-new-in-openshift-virtualization-in-ocp-4.7
   # As of 2021-03-01 there's no docs available for OpenShift Virtualization on Openshift 4.7. Guessing the proper channel from blogpost above.
   channel: "stable"
-  startingCSV: kubevirt-hyperconverged-operator.v2.6.0


### PR DESCRIPTION
This reverts commit 9fcda0a5a62e276479f8120ae30d561359dda91e.

Setting startingCSV doesn't have any impact (at least when there is a
pending installplan waiting for approval).
