### PR TITLE
Move ODH deployment to its own ns.

### DIFF
--- a/cluster-scope/base/namespaces/opendatahub-operator/kustomization.yaml
+++ b/cluster-scope/base/namespaces/opendatahub-operator/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: opendatahub-operator
+
+resources:
+  - namespace.yaml
+
+components:
+  - ../../../components/monitoring-rbac

--- a/cluster-scope/base/namespaces/opendatahub-operator/namespace.yaml
+++ b/cluster-scope/base/namespaces/opendatahub-operator/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Operate First: Opendatahub operator"
+    openshift.io/requester: operate-first
+  name: opendatahub-operator
+spec: {}

--- a/cluster-scope/overlays/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/moc/zero/kustomization.yaml
@@ -43,6 +43,7 @@ resources:
   - ../../../base/namespaces/mesh-for-data
   - ../../../base/namespaces/observatorium-operator
   - ../../../base/namespaces/open-aiops
+  - ../../../base/namespaces/opendatahub-operator
   - ../../../base/namespaces/openshift-cnv
   - ../../../base/namespaces/openshift-logging
   - ../../../base/namespaces/openshift-metering

--- a/odh-operator/base/kustomization.yaml
+++ b/odh-operator/base/kustomization.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: openshift-operators
+namespace: opendatahub-operator
 
 # Source: https://github.com/opendatahub-io/opendatahub-operator/tree/master/kustomize/overlays/opendatahub
 resources:


### PR DESCRIPTION
Given that odh is manually deployed w/o OLM, it makes more sense to be consistent with our own philosophy and deploy it to its own namespace.