### PR TITLE
add metallb

### DIFF
--- a/cluster-scope/base/clusterrolebindings/metallb-allow-privileged/clusterrolebinding.yaml
+++ b/cluster-scope/base/clusterrolebindings/metallb-allow-privileged/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metallb-allow-privileged
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+  - kind: ServiceAccount
+    name: speaker
+    namespace: metallb-system

--- a/cluster-scope/base/clusterrolebindings/metallb-allow-privileged/kustomization.yaml
+++ b/cluster-scope/base/clusterrolebindings/metallb-allow-privileged/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/clusterrolebindings/metallb-system-controller/clusterrolebinding.yaml
+++ b/cluster-scope/base/clusterrolebindings/metallb-system-controller/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metallb-system:controller
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: metallb-system

--- a/cluster-scope/base/clusterrolebindings/metallb-system-controller/kustomization.yaml
+++ b/cluster-scope/base/clusterrolebindings/metallb-system-controller/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/clusterrolebindings/metallb-system-speaker/clusterrolebinding.yaml
+++ b/cluster-scope/base/clusterrolebindings/metallb-system-speaker/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:speaker
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metallb-system:speaker
+subjects:
+- kind: ServiceAccount
+  name: speaker
+  namespace: metallb-system

--- a/cluster-scope/base/clusterrolebindings/metallb-system-speaker/kustomization.yaml
+++ b/cluster-scope/base/clusterrolebindings/metallb-system-speaker/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/clusterroles/metallb-system-controller/clusterrole.yaml
+++ b/cluster-scope/base/clusterroles/metallb-system-controller/clusterrole.yaml
@@ -1,0 +1,37 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:controller
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - services/status
+    verbs:
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - policy
+    resourceNames:
+      - controller
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use

--- a/cluster-scope/base/clusterroles/metallb-system-controller/kustomization.yaml
+++ b/cluster-scope/base/clusterroles/metallb-system-controller/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrole.yaml

--- a/cluster-scope/base/clusterroles/metallb-system-speaker/clusterrole.yaml
+++ b/cluster-scope/base/clusterroles/metallb-system-speaker/clusterrole.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: metallb
+  name: metallb-system:speaker
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - services
+      - endpoints
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - policy
+    resourceNames:
+      - speaker
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use

--- a/cluster-scope/base/clusterroles/metallb-system-speaker/kustomization.yaml
+++ b/cluster-scope/base/clusterroles/metallb-system-speaker/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrole.yaml

--- a/cluster-scope/base/namespaces/metallb-system/kustomization.yaml
+++ b/cluster-scope/base/namespaces/metallb-system/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml

--- a/cluster-scope/base/namespaces/metallb-system/namespace.yaml
+++ b/cluster-scope/base/namespaces/metallb-system/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metallb-system
+  labels:
+    app: metallb

--- a/cluster-scope/base/podsecuritypolicy/metallb-system-controller/kustomization.yaml
+++ b/cluster-scope/base/podsecuritypolicy/metallb-system-controller/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- podsecuritypolicy.yaml

--- a/cluster-scope/base/podsecuritypolicy/metallb-system-controller/podsecuritypolicy.yaml
+++ b/cluster-scope/base/podsecuritypolicy/metallb-system-controller/podsecuritypolicy.yaml
@@ -1,0 +1,40 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app: metallb
+  name: controller
+spec:
+  allowPrivilegeEscalation: false
+  allowedCapabilities: []
+  allowedHostPaths: []
+  defaultAddCapabilities: []
+  defaultAllowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - secret
+  - emptyDir

--- a/cluster-scope/base/podsecuritypolicy/metallb-system-speaker/kustomization.yaml
+++ b/cluster-scope/base/podsecuritypolicy/metallb-system-speaker/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- podsecuritypolicy.yaml

--- a/cluster-scope/base/podsecuritypolicy/metallb-system-speaker/podsecuritypolicy.yaml
+++ b/cluster-scope/base/podsecuritypolicy/metallb-system-speaker/podsecuritypolicy.yaml
@@ -1,0 +1,37 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  labels:
+    app: metallb
+  name: speaker
+spec:
+  allowPrivilegeEscalation: false
+  allowedCapabilities:
+  - NET_ADMIN
+  - NET_RAW
+  - SYS_ADMIN
+  allowedHostPaths: []
+  defaultAddCapabilities: []
+  defaultAllowPrivilegeEscalation: false
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: false
+  hostNetwork: true
+  hostPID: false
+  hostPorts:
+  - max: 7472
+    min: 7472
+  privileged: true
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - secret
+  - emptyDir

--- a/cluster-scope/overlays/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/moc/zero/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ../common
   - ../../../base/clusterroles/cluster-logs-reader
+  - ../../../base/clusterroles/metallb
   - ../../../base/clusterroles/metrics
   - ../../../base/clusterroles/observatorium-operator
   - ../../../base/clusterroles/opendatahub-operator
@@ -16,6 +17,7 @@ resources:
   - ../../../base/clusterrolebindings/cluster-admins-rb
   - ../../../base/clusterrolebindings/cluster-logs-readers
   - ../../../base/clusterrolebindings/cluster-metrics-federation
+  - ../../../base/clusterrolebindings/metallb
   - ../../../base/clusterrolebindings/metrics
   - ../../../base/clusterrolebindings/observatorium-operator
   - ../../../base/clusterrolebindings/opendatahub-operator

--- a/cluster-scope/overlays/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/moc/zero/kustomization.yaml
@@ -5,7 +5,8 @@ kind: Kustomization
 resources:
   - ../common
   - ../../../base/clusterroles/cluster-logs-reader
-  - ../../../base/clusterroles/metallb
+  - ../../../base/clusterroles/metallb-system-controller
+  - ../../../base/clusterroles/metallb-system-speaker
   - ../../../base/clusterroles/metrics
   - ../../../base/clusterroles/observatorium-operator
   - ../../../base/clusterroles/opendatahub-operator
@@ -17,7 +18,9 @@ resources:
   - ../../../base/clusterrolebindings/cluster-admins-rb
   - ../../../base/clusterrolebindings/cluster-logs-readers
   - ../../../base/clusterrolebindings/cluster-metrics-federation
-  - ../../../base/clusterrolebindings/metallb
+  - ../../../base/clusterrolebindings/metallb-allow-privileged
+  - ../../../base/clusterrolebindings/metallb-system-controller
+  - ../../../base/clusterrolebindings/metallb-system-speaker
   - ../../../base/clusterrolebindings/metrics
   - ../../../base/clusterrolebindings/observatorium-operator
   - ../../../base/clusterrolebindings/opendatahub-operator
@@ -42,6 +45,7 @@ resources:
   - ../../../base/namespaces/local-storage
   - ../../../base/namespaces/m4d-blueprints
   - ../../../base/namespaces/m4d-system
+  - ../../../base/namespaces/metallb-system
   - ../../../base/namespaces/mesh-for-data
   - ../../../base/namespaces/observatorium-operator
   - ../../../base/namespaces/open-aiops
@@ -87,6 +91,8 @@ resources:
   - ../../../base/operatorgroups/openshift-metering
   - ../../../base/operatorgroups/openshift-operators-redhat
   - ../../../base/operatorgroups/openshift-storage
+  - ../../../base/podsecuritypolicy/metallb-system-controller
+  - ../../../base/podsecuritypolicy/metallb-system-speaker
   - ../../../base/storageclasses/ocs-storagecluster-cephfs
   - ../../../base/subscriptions/cluster-logging-operator
   - ../../../base/subscriptions/elastic-operator

--- a/metallb/base/daemonset.yaml
+++ b/metallb/base/daemonset.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: metallb
+    component: speaker
+  name: speaker
+  namespace: metallb-system
+spec:
+  selector:
+    matchLabels:
+      app: metallb
+      component: speaker
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: '7472'
+        prometheus.io/scrape: 'true'
+      labels:
+        app: metallb
+        component: speaker
+    spec:
+      containers:
+      - args:
+        - --port=7472
+        - --config=config
+        env:
+        - name: METALLB_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: METALLB_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: METALLB_ML_BIND_ADDR
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: METALLB_ML_LABELS
+          value: app=metallb,component=speaker
+        - name: METALLB_ML_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: METALLB_ML_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: secretkey
+              name: memberlist
+        image: metallb/speaker:v0.9.5
+        imagePullPolicy: Always
+        name: speaker
+        ports:
+        - containerPort: 7472
+          name: monitoring
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+            - SYS_ADMIN
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: speaker
+      terminationGracePeriodSeconds: 2
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master

--- a/metallb/base/deployment.yaml
+++ b/metallb/base/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: metallb
+    component: controller
+  name: controller
+  namespace: metallb-system
+spec:
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: metallb
+      component: controller
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: '7472'
+        prometheus.io/scrape: 'true'
+      labels:
+        app: metallb
+        component: controller
+    spec:
+      containers:
+      - args:
+        - --port=7472
+        - --config=config
+        image: metallb/controller:v0.9.5
+        imagePullPolicy: Always
+        name: controller
+        ports:
+        - containerPort: 7472
+          name: monitoring
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: controller
+      terminationGracePeriodSeconds: 0

--- a/metallb/base/kustomization.yaml
+++ b/metallb/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: metallb-system
+
+resources:
+  - daemonset.yaml
+  - deployment.yaml
+  - rolebinding.yaml
+  - role.yaml
+  - serviceaccount.yaml

--- a/metallb/base/role.yaml
+++ b/metallb/base/role.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: metallb
+  name: config-watcher
+  namespace: metallb-system
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: metallb
+  name: pod-lister
+  namespace: metallb-system
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - list

--- a/metallb/base/rolebinding.yaml
+++ b/metallb/base/rolebinding.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: config-watcher
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: config-watcher
+subjects:
+- kind: ServiceAccount
+  name: controller
+- kind: ServiceAccount
+  name: speaker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: metallb
+  name: pod-lister
+  namespace: metallb-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-lister
+subjects:
+- kind: ServiceAccount
+  name: speaker

--- a/metallb/base/serviceaccount.yaml
+++ b/metallb/base/serviceaccount.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: metallb
+  name: controller
+  namespace: metallb-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: metallb
+  name: speaker
+  namespace: metallb-system

--- a/metallb/overlays/moc/zero/config.yaml
+++ b/metallb/overlays/moc/zero/config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - 192.12.185.32-192.12.175.63

--- a/metallb/overlays/moc/zero/config.yaml
+++ b/metallb/overlays/moc/zero/config.yaml
@@ -1,11 +1,5 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config
-data:
-  config: |
-    address-pools:
-    - name: default
-      protocol: layer2
-      addresses:
+address-pools:
+  - name: default
+    protocol: layer2
+    addresses:
       - 192.12.185.32-192.12.175.63

--- a/metallb/overlays/moc/zero/kustomization.yaml
+++ b/metallb/overlays/moc/zero/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: metallb-system
+
 resources:
   - ../../../base
 

--- a/metallb/overlays/moc/zero/kustomization.yaml
+++ b/metallb/overlays/moc/zero/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base
+
+configMapGenerator:
+  - name: config
+    files:
+      - config=config.yaml
+
+generators:
+  - secret-generator.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/metallb/overlays/moc/zero/memberlist.enc.yaml
+++ b/metallb/overlays/moc/zero/memberlist.enc.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: memberlist
+type: Opaque
+data:
+    secretkey: ENC[AES256_GCM,data:sWgDnuNLojvg29Ojmzfeps+/uOGG3935EZTuFmTJ82dAxLjJnt+eLVc9QBVhaRWdOhjO1fSiWcvTfr6XB/DxsiZp0mMUg66gDOEZy+I+iDCGEbQaCQ4lhc2CoxkTcVwOnNbn6zMvmlK2fMNJy4L0znRJXqmvmXWOE1XW/O/9wcBn/adh2u2QcNK0ngh/4yHceCKJbaBEB1rVWDQhszAiRSmL43EjSuah8hksNkBL2Q==,iv:fK626i9fSrygepOwxQ8GHBpBD2uZHumUQ1xE98Lm3cE=,tag:7Y6MSKiGYG5/iaeJ9dL9TA==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-03-18T20:16:56Z'
+    mac: ENC[AES256_GCM,data:P6brVPr2mVANHWyEdCo5CYDoaB+VD6qQtLPlS6yMLPAfyL8UyFb+ENAnYoo/i4ZY/JkpRo7BIBla4wO2fkxS7obu0UC2kPDeza6XJ2e0Lh/RHzL4GmoDaV/FJnEaD1b78hH5GFAbIoMdP+WUehRUa67REvPDt8QIKO0/plDCGMg=,iv:R22QvjEk0FeHJHYzZxkVGQOF2+f5pBrObTBjgPylPlY=,tag:7fg30y8VkryWSxCn0tnrlA==,type:str]
+    pgp:
+    -   created_at: '2021-03-18T20:13:45Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA9aKBcudqifiARAANIDqTmUUGl72Vjit+rqpXlXMpW2O+XF1Z09NjxFXQ5JO
+            d+a1p6odLWpeNoczHhctmEimGTGifCOXp3bpfsf2y+ynabU40GpgkKl5GrTU9KSV
+            iGXrbnOFeeARLfnjjQO28zJc6JhBJ043hWFx9hwDnwCcqyzazxM/QIlb5ifl0wYo
+            JZMsGDkcVbyn1wkH9PsyGd/+6p22atQCMrsZtODBxi0bNaCt5v4KC6XvvLWWqLWb
+            Oi8yjiK52axVX7pFQ+mkOnAtZKd7kD9+Bd2/pFhrwh0Zsm80V2HNqeb64Mpz9bAF
+            TIjyq8D3CCBZ4vlNQzs7O/f5mmU5Y+YRTPWck2UBAEQvraSd0NM+gpaCVWJ12yZl
+            CT/Qn/92ARq6ZBtRrq7BkURFC2xjInovnybSMw8XzsQPTMsYol8WNNg93PpmfVFo
+            IS+IC8aQzizdxexgeMLpFH4zNQaPOzZieIJNAXp/Jd74HmuAInx+5B6EuhRybEk4
+            FesHZIBSH4N5NST1JP9/gPgo6Nsg6Dnln2S9LnI4DOCLENQiw1yC7tXkU1a0R0aT
+            hCypluonVQJDKeg1zssHCnYOyk7Fhvrw8P+QX5t0yqmDDa8V499QzRnP9f5UP/k1
+            IzdaHyhGAnh3CiTVlvWIPNl0W8Kkhtcs+SRGiDis6dqwgxmwtzXaMFH5iD4DVmrS
+            4AHkkmdcjbVJpNcUDybWaEA2wOGm8+Ce4NvhKcHgceKUNJoH4KTliUju2W8uYa7e
+            A4QZNaCW2qSASUFgFHvUHkSkZXo5MuHguuTIfFa61iTSaMEZKT82S5pB4l8YND/h
+            Ko8A
+            =85Xx
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    -   created_at: '2021-03-18T20:16:55Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMAyzcsT8FUYakARAAhvWm+61G5ZI2XuzcbhbvAM/rpsOtx0m14hzxxGM9zjQO
+            pNjO0kpQau40WUxQVF0D7LfDjmOLdhH63Ab9cupUfPPq9OwO6FSGcpt9163po6H4
+            w/5RenGg0AYiM9BJmcwH18UPF6J0rgCeXEwc0bLWG+PG74gdP4cfTDhnvLThogws
+            pflJjUGqdJto7pDQjxq1uzducfjxpyCRGk1nBKjpisn1a7JqRcHTWaYF9icaqIHG
+            vCEr/idxnNCmR35z54WQFHTgr2mKKYBQrX8CTFrepjlMZfzVrZEKwhYB/7NO5IVt
+            Tfb2Y8CYi0NT8Ys450UY6N0Y16LEe5JWgdupldZQxHWCE1emwWKmD+m/0GtUG610
+            QUhdBs6WwKIA+U5RomnxrYlOZfB9ErhKx0BRLvCY3TQcZP0coEJMH1Bb3IBDuWrT
+            Zm6ny44Dv2Zwrwi0TMbc56bIaazdoDM9huCwwxlkggUg9dR8YiUS7ANvqtNVlAm0
+            ulZatzJm5EeanXekx8IByw7QNv5OseuuzdCrxr6++inCBeAYQW3Ded38aUl7KGL/
+            biz6iorAm8aW0bEHgdjyaag4LJGRpk80IyMeusBpTjRceKI8N/mjTudbAxh0afCL
+            QAec/+HMPR38H2OKEjP1IKFugbhJXDfvcWLd8++O5lHsUSvqSLtSex7Cq2+nCA7S
+            4AHkz+gWC9NR7hpr7/y4QF6Gy+HRy+Ct4Erhw07g8OLfWL3R4K/ltGtd9L1mcxAx
+            +V7RKRq749VhShvB+0arrKbMn7nQXk3gYeQCAB2Z5jbh2pG+8QMBzZdQ4mP69Jfh
+            yP8A
+            =mE/0
+            -----END PGP MESSAGE-----
+        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+    encrypted_regex: ^(users|data|stringData)$
+    version: 3.6.1

--- a/metallb/overlays/moc/zero/secret-generator.yaml
+++ b/metallb/overlays/moc/zero/secret-generator.yaml
@@ -1,0 +1,6 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: secret-generator
+files:
+  - memberlist.enc.yaml


### PR DESCRIPTION
the cnv cluster was running metallb to provide public ip for services
that don't work with the ingress router (e.g. for running ssh in a pod
or virtual machine).

This commit adds the basic manifests.
