### PR TITLE
Remove knative serving from kubeflow components kfdef

### DIFF
--- a/kubeflow-components/base/kfdef.yaml
+++ b/kubeflow-components/base/kfdef.yaml
@@ -60,11 +60,6 @@ spec:
           name: manifests
           path: stacks/openshift/application/kfp-tekton
       name: kfp-tekton
-    - kustomizeConfig:
-        repoRef:
-          name: manifests
-          path: knative/installs/generic
-      name: knative
   repos:
     - name: manifests
       uri: "https://github.com/tumido/manifests/archive/ocp-stack-dashboard-params.tar.gz"


### PR DESCRIPTION
Once this is merged, we can remove the breaking pods from `knative-serving` ns