### PR TITLE
pet-image-detection imagestream

### DIFF
--- a/odh/base/jupyterhub/notebook-images/kustomization.yaml
+++ b/odh/base/jupyterhub/notebook-images/kustomization.yaml
@@ -11,5 +11,6 @@ resources:
   - ml-prague-workshop.yaml
   - ocp-ci-analysis.yaml
   - openshift-anomaly-detection.yaml
+  - pet-image-detection.yaml
   - ray-ml-notebook.yaml
   - time-series.yaml

--- a/odh/base/jupyterhub/notebook-images/pet-image-detection.yaml
+++ b/odh/base/jupyterhub/notebook-images/pet-image-detection.yaml
@@ -24,4 +24,3 @@ spec:
       importPolicy:
         scheduled: true
       name: "latest"
-      

--- a/odh/base/jupyterhub/notebook-images/pet-image-detection.yaml
+++ b/odh/base/jupyterhub/notebook-images/pet-image-detection.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url:
+      "https://github.com/aicoe-aiops/pet-image-detection"
+    opendatahub.io/notebook-image-name:
+      "Image Detection Notebook Image"
+    opendatahub.io/notebook-image-desc:
+      "Image with jupyter notebooks for image detection exploration"
+  name: pet-image-detection
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        openshift.io/imported-from: quay.io/aicoe/pet-image-detection
+      from:
+        kind: DockerImage
+        name: quay.io/aicoe/pet-image-detection:latest
+      importPolicy:
+        scheduled: true
+      name: "latest"

--- a/odh/base/jupyterhub/notebook-images/pet-image-detection.yaml
+++ b/odh/base/jupyterhub/notebook-images/pet-image-detection.yaml
@@ -24,3 +24,4 @@ spec:
       importPolicy:
         scheduled: true
       name: "latest"
+      


### PR DESCRIPTION
This PR will address [operatefirst/support#107](https://github.com/operate-first/support/issues/107), by adding the pet-image-detection image so that it is exposed on the JH launcher menu.