### PR TITLE
Update odh to 1.0.5

### DIFF
--- a/kfdefs/overlays/moc/zero/ds-ml-workflows-ws/kfdef.yaml
+++ b/kfdefs/overlays/moc/zero/ds-ml-workflows-ws/kfdef.yaml
@@ -1,36 +1,38 @@
+---
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
 metadata:
   name: opendatahub
 spec:
   applications:
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: odh-common
-    name: odh-common
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: odhseldon/cluster
-    name: odhseldon
-  - kustomizeConfig:
-      parameters:
-      - name: s3_endpoint_url
-        value: s3.odh.com
-      repoRef:
-        name: manifests
-        path: jupyterhub/jupyterhub
-    name: jupyterhub
-  - kustomizeConfig:
-      overlays:
-      - additional
-      repoRef:
-        name: manifests
-        path: jupyterhub/notebook-images
-    name: notebook-images
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-common
+      name: odh-common
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odhseldon/cluster
+      name: odhseldon
+    - kustomizeConfig:
+        parameters:
+          - name: s3_endpoint_url
+            value: s3.odh.com
+        repoRef:
+          name: manifests
+          path: jupyterhub/jupyterhub
+      name: jupyterhub
+    - kustomizeConfig:
+        overlays:
+          - additional
+        repoRef:
+          name: manifests
+          path: jupyterhub/notebook-images
+      name: notebook-images
   repos:
-  - name: kf-manifests
-    uri: https://github.com/kubeflow/manifests/tarball/v1.2-branch
-  - name: manifests
-    uri: https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.0
+    - name: kf-manifests
+      uri: https://github.com/kubeflow/manifests/tarball/v1.2-branch
+    - name: manifests
+      uri: https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.5
+  version: v1.0.5

--- a/kfdefs/overlays/moc/zero/thoth-infra-prod/kfdef.yaml
+++ b/kfdefs/overlays/moc/zero/thoth-infra-prod/kfdef.yaml
@@ -1,25 +1,26 @@
+---
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
 metadata:
   name: opendatahub
 spec:
   applications:
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: odh-common
-    name: odh-common
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: prometheus/cluster
-    name: prometheus-cluster
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: prometheus/operator
-    name: prometheus-operator
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-common
+      name: odh-common
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: prometheus/cluster
+      name: prometheus-cluster
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: prometheus/operator
+      name: prometheus-operator
   repos:
-  - name: manifests
-    uri: https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.2
-  version: v1.0.2
+    - name: manifests
+      uri: https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.5
+  version: v1.0.5

--- a/observatorium/base/instance/kfdef.yaml
+++ b/observatorium/base/instance/kfdef.yaml
@@ -19,5 +19,5 @@ spec:
       name: grafana-cluster
   repos:
     - name: manifests
-      uri: 'https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.4'
-  version: v1.0.4
+      uri: 'https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.5'
+  version: v1.0.5

--- a/odh-operator/base/kustomization.yaml
+++ b/odh-operator/base/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 images:
 - name: aipipeline/kubeflow-operator
   newName: quay.io/opendatahub/opendatahub-operator
-  newTag: v1.0.4
+  newTag: v1.0.5

--- a/odh/base/argo/kfdef.yaml
+++ b/odh/base/argo/kfdef.yaml
@@ -24,5 +24,5 @@ spec:
       name: odhargo
   repos:
     - name: manifests
-      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.4"
-  version: v1.0.4
+      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.5"
+  version: v1.0.5

--- a/odh/base/dashboard/kfdef.yaml
+++ b/odh/base/dashboard/kfdef.yaml
@@ -22,7 +22,7 @@ spec:
       name: odh-dashboard
   repos:
     - name: manifests
-      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.4"
+      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.5"
     - name: opf
       uri: "https://github.com/operate-first/apps/tarball/master"
-  version: v1.0.4
+  version: v1.0.5

--- a/odh/base/datacatalog/kfdef.yaml
+++ b/odh/base/datacatalog/kfdef.yaml
@@ -33,5 +33,5 @@ spec:
       name: thriftserver
   repos:
     - name: manifests
-      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.4"
-  version: v1.0.4
+      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.5"
+  version: v1.0.5

--- a/odh/base/jupyterhub/kfdef.yaml
+++ b/odh/base/jupyterhub/kfdef.yaml
@@ -35,7 +35,7 @@ spec:
       name: notebook-images
   repos:
     - name: manifests
-      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.4"
+      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.5"
     - name: opf-manifests
       uri: "https://github.com/operate-first/apps/tarball/master"
-  version: v1.0.4
+  version: v1.0.5

--- a/odh/base/kafka/kfdef.yaml
+++ b/odh/base/kafka/kfdef.yaml
@@ -25,5 +25,5 @@ spec:
       name: kafka-cluster
   repos:
     - name: manifests
-      uri: https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.4
-  version: v1.0.4
+      uri: https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.5
+  version: v1.0.5

--- a/odh/base/monitoring/kfdef.yaml
+++ b/odh/base/monitoring/kfdef.yaml
@@ -49,7 +49,7 @@ spec:
       name: grafana-operator
   repos:
     - name: manifests
-      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.4"
+      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.5"
     - name: opf
       uri: "https://github.com/operate-first/apps/tarball/master"
-  version: v1.0.4
+  version: v1.0.5

--- a/odh/base/superset/kfdef.yaml
+++ b/odh/base/superset/kfdef.yaml
@@ -23,5 +23,5 @@ spec:
       name: superset
   repos:
     - name: manifests
-      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.4"
-  version: v1.0.4
+      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.0.5"
+  version: v1.0.5


### PR DESCRIPTION
See release change log here: https://github.com/opendatahub-io/odh-manifests/releases

I've also updated the operator image along with this patch. 

All kfdefs were updated in this repo, included user provisioned.