### PR TITLE
fix: Operator image override

### DIFF
--- a/odh-operator/base/kustomization.yaml
+++ b/odh-operator/base/kustomization.yaml
@@ -10,6 +10,5 @@ resources:
   - serviceaccount.yaml
 
 images:
-- name: aipipeline/kubeflow-operator
-  newName: quay.io/opendatahub/opendatahub-operator
+- name: quay.io/opendatahub/opendatahub-operator
   newTag: v1.0.5


### PR DESCRIPTION
Fixes: https://github.com/operate-first/apps/issues/413

We're patching wrong image: 

https://github.com/operate-first/apps/blob/1b042ed6650f069f2ed0aabe69d1250488897afb/odh-operator/base/deployment.yaml#L32


This should fix it

/cc @HumairAK 