### PR TITLE
feat: Onboard RH Labs - CI/CD

### DIFF
--- a/cluster-scope/base/groups/lab-cicd/group.yaml
+++ b/cluster-scope/base/groups/lab-cicd/group.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: lab-cicd
+users: []

--- a/cluster-scope/base/groups/lab-cicd/kustomization.yaml
+++ b/cluster-scope/base/groups/lab-cicd/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ./group.yaml

--- a/cluster-scope/base/namespaces/lab-cicd-1-jump-app-cicd/kustomization.yaml
+++ b/cluster-scope/base/namespaces/lab-cicd-1-jump-app-cicd/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: lab-cicd-1-jump-app-cicd
+
+resources:
+  - namespace.yaml
+
+components:
+  - ../../../components/project-admin-rolebindings/lab-cicd
+  - ../../../components/project-view-public

--- a/cluster-scope/base/namespaces/lab-cicd-1-jump-app-cicd/namespace.yaml
+++ b/cluster-scope/base/namespaces/lab-cicd-1-jump-app-cicd/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Red Hat CI/CD Lab: User 1 CI/CD"
+    openshift.io/requester: lab-cicd
+    operate-first.cloud/issue: https://github.com/operate-first/support/issues/113
+  name: lab-cicd-1-jump-app-cicd
+spec: {}

--- a/cluster-scope/base/namespaces/lab-cicd-1-jump-app-dev/kustomization.yaml
+++ b/cluster-scope/base/namespaces/lab-cicd-1-jump-app-dev/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: lab-cicd-1-jump-app-dev
+
+resources:
+  - namespace.yaml
+
+components:
+  - ../../../components/project-admin-rolebindings/lab-cicd
+  - ../../../components/project-view-public

--- a/cluster-scope/base/namespaces/lab-cicd-1-jump-app-dev/namespace.yaml
+++ b/cluster-scope/base/namespaces/lab-cicd-1-jump-app-dev/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Red Hat CI/CD Lab: User 1"
+    openshift.io/requester: lab-cicd
+    operate-first.cloud/issue: https://github.com/operate-first/support/issues/113
+  name: lab-cicd-1-jump-app-dev
+spec: {}

--- a/cluster-scope/base/namespaces/lab-cicd-2-jump-app-cicd/kustomization.yaml
+++ b/cluster-scope/base/namespaces/lab-cicd-2-jump-app-cicd/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: lab-cicd-2-jump-app-cicd
+
+resources:
+  - namespace.yaml
+
+components:
+  - ../../../components/project-admin-rolebindings/lab-cicd
+  - ../../../components/project-view-public

--- a/cluster-scope/base/namespaces/lab-cicd-2-jump-app-cicd/namespace.yaml
+++ b/cluster-scope/base/namespaces/lab-cicd-2-jump-app-cicd/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Red Hat CI/CD Lab: User 2 CI/CD"
+    openshift.io/requester: lab-cicd
+    operate-first.cloud/issue: https://github.com/operate-first/support/issues/113
+  name: lab-cicd-2-jump-app-cicd
+spec: {}

--- a/cluster-scope/base/namespaces/lab-cicd-2-jump-app-dev/kustomization.yaml
+++ b/cluster-scope/base/namespaces/lab-cicd-2-jump-app-dev/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: lab-cicd-2-jump-app-dev
+
+resources:
+  - namespace.yaml
+
+components:
+  - ../../../components/project-admin-rolebindings/lab-cicd
+  - ../../../components/project-view-public

--- a/cluster-scope/base/namespaces/lab-cicd-2-jump-app-dev/namespace.yaml
+++ b/cluster-scope/base/namespaces/lab-cicd-2-jump-app-dev/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Red Hat CI/CD Lab: User 2"
+    openshift.io/requester: lab-cicd
+    operate-first.cloud/issue: https://github.com/operate-first/support/issues/113
+  name: lab-cicd-2-jump-app-dev
+spec: {}

--- a/cluster-scope/base/namespaces/lab-cicd-3-jump-app-cicd/kustomization.yaml
+++ b/cluster-scope/base/namespaces/lab-cicd-3-jump-app-cicd/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: lab-cicd-3-jump-app-cicd
+
+resources:
+  - namespace.yaml
+
+components:
+  - ../../../components/project-admin-rolebindings/lab-cicd
+  - ../../../components/project-view-public

--- a/cluster-scope/base/namespaces/lab-cicd-3-jump-app-cicd/namespace.yaml
+++ b/cluster-scope/base/namespaces/lab-cicd-3-jump-app-cicd/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Red Hat CI/CD Lab: User 3 CI/CD"
+    openshift.io/requester: lab-cicd
+    operate-first.cloud/issue: https://github.com/operate-first/support/issues/113
+  name: lab-cicd-3-jump-app-cicd
+spec: {}

--- a/cluster-scope/base/namespaces/lab-cicd-3-jump-app-dev/kustomization.yaml
+++ b/cluster-scope/base/namespaces/lab-cicd-3-jump-app-dev/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: lab-cicd-3-jump-app-dev
+
+resources:
+  - namespace.yaml
+
+components:
+  - ../../../components/project-admin-rolebindings/lab-cicd
+  - ../../../components/project-view-public

--- a/cluster-scope/base/namespaces/lab-cicd-3-jump-app-dev/namespace.yaml
+++ b/cluster-scope/base/namespaces/lab-cicd-3-jump-app-dev/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Red Hat CI/CD Lab: User 3"
+    openshift.io/requester: lab-cicd
+    operate-first.cloud/issue: https://github.com/operate-first/support/issues/113
+  name: lab-cicd-3-jump-app-dev
+spec: {}

--- a/cluster-scope/base/namespaces/lab-cicd-4-jump-app-cicd/kustomization.yaml
+++ b/cluster-scope/base/namespaces/lab-cicd-4-jump-app-cicd/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: lab-cicd-4-jump-app-cicd
+
+resources:
+  - namespace.yaml
+
+components:
+  - ../../../components/project-admin-rolebindings/lab-cicd
+  - ../../../components/project-view-public

--- a/cluster-scope/base/namespaces/lab-cicd-4-jump-app-cicd/namespace.yaml
+++ b/cluster-scope/base/namespaces/lab-cicd-4-jump-app-cicd/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Red Hat CI/CD Lab: User 4 CI/CD"
+    openshift.io/requester: lab-cicd
+    operate-first.cloud/issue: https://github.com/operate-first/support/issues/113
+  name: lab-cicd-4-jump-app-cicd
+spec: {}

--- a/cluster-scope/base/namespaces/lab-cicd-4-jump-app-dev/kustomization.yaml
+++ b/cluster-scope/base/namespaces/lab-cicd-4-jump-app-dev/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: lab-cicd-4-jump-app-dev
+
+resources:
+  - namespace.yaml
+
+components:
+  - ../../../components/project-admin-rolebindings/lab-cicd
+  - ../../../components/project-view-public

--- a/cluster-scope/base/namespaces/lab-cicd-4-jump-app-dev/namespace.yaml
+++ b/cluster-scope/base/namespaces/lab-cicd-4-jump-app-dev/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Red Hat CI/CD Lab: User 4"
+    openshift.io/requester: lab-cicd
+    operate-first.cloud/issue: https://github.com/operate-first/support/issues/113
+  name: lab-cicd-4-jump-app-dev
+spec: {}

--- a/cluster-scope/components/project-admin-rolebindings/lab-cicd/kustomization.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/lab-cicd/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+- ./rbac.yaml

--- a/cluster-scope/components/project-admin-rolebindings/lab-cicd/rbac.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/lab-cicd/rbac.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-admin-lab-cicd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: lab-cicd

--- a/cluster-scope/overlays/moc/common/groups/lab-cicd.enc.yaml
+++ b/cluster-scope/overlays/moc/common/groups/lab-cicd.enc.yaml
@@ -1,0 +1,92 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+    name: lab-cicd
+    annotations:
+        kustomize.config.k8s.io/behavior: replace
+users:
+- ENC[AES256_GCM,data:YOvay0NDL75QcB8zBc8OZ7R2Cw==,iv:nUZj/l8Em7D8I/DAquXQJ11BFk4/c+E1m3TatNKf+dY=,tag:yPoRQtmQczZztriEExgDuQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-03-22T15:30:09Z'
+    mac: ENC[AES256_GCM,data:65bKl+Cqa0wmW6pDr4pzKIbrm92alFJGU9VnE0kvwOpUKmUFydHm30rnnPtJ9FOcntmxA9BlOVgpsTptyIJR5Vh/U0xfKTeNynG/+tlOd4YHwB7ns8+VUhKjYElnbaWY/VZPDKPyhKXfchgW25b93MHOkVlmHG7m9WQ4c+pf9JA=,iv:hPCpdjky/43PrnD5M3/u1EYvAMCU/x3/iv7bPgAtq/s=,tag:5linZUkp+palAlsox782Xg==,type:str]
+    pgp:
+    -   created_at: '2021-03-17T13:13:29Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA9aKBcudqifiAQ//bNAPPsCdKW42Cz9ewynP/oNt72pcG6zpTnceD3eaMMja
+            jafHmxugGCsiRDYkMiP0rn89QfGK456yw07M338SGRf25hsDhuWKvDK7eavBaePm
+            p6mnawAKUbF5h9YjeAzZ0/taBprtQi/M+ZlpOCd3xysQadRnZaMwktJS2ev/BXT6
+            8+5GxgtUnSAxcbNly1GDv/e2lVpZkQYdWhCCTOy82t8esG80kipOpm/hEo4ePLKW
+            wU7a/bG6mytaE739my1L3y6wKecUgGOMebz5VvboFsbBK+dJuF22gjgfwJ+Vf4Dy
+            IiOHJ24W2L8P6pejmLsl7Yw6T1I73GzCbPDXLabns82KFiel69ng6XhtUAQ+07g5
+            tRalogi/WqGlS4thsGwd420EYEGyJEFFJAW5AxISWWwT2iBqm7EsKzdrVbEFQvk6
+            ed39M3xDpqDMuYYvPKZ2b336vCzDWwoXzMqUzKWq4//qUsVrGql+SdlvHX77I0/h
+            N+73jxFPP2fbxqyBf9NCHA1n/0KW2i3ylSr1h0WcDl3MHXN25CBCOpzuRlXl62FV
+            VdjJooijIX3OivR5o1ZhjQmbj3vxyCyfai/qPGYOJhKr4aFihSPFkzg5SekadWf+
+            HyGxxuCHdmiKxxUcXyM1QuZm7DSjvyHZaeDaEqwF4Pm2YVNjx+v+oTp8nUiCPOnS
+            XAFWiZ1jW++YJr9WE0bg6ScJGJTsIacVvY+c/GMuh2qE/YVBnkgLleih2IAuYWmm
+            3o3M1VCzFxee36Q1EkllRoTiUZ/f0Redcv1SSwas7mBj3YN14P6/aLSRBeyx
+            =/kGa
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    -   created_at: '2021-03-17T13:13:29Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMAyzcsT8FUYakARAAm85yHfecZ0TLD1O37RakGWUZc1qCMbDoSsWzuiaQcXKT
+            3g+p5mW7TWaKkDDS6+JpDd9dwjUB1yYRhhzmzMmFQk8ybEfX2t/ThOL5/0fq6KwP
+            DROaTnlLQa7XSv2N4CJGx6Edk+1RaxjBWo9acIwlK5lokrFTrTwaXrxFl0QtCHEU
+            JWSo7bVPl1VEHmtziz/1w2hSLpNIMX8MEFZQfhH2pHX1CHT+okLDTec+CH8mpkQX
+            RRHxyjug9qJz/uPTKYXX7R4tzyfc3ncV/FvszSYd6BdvpFVJIypv75EJ3xqdxasT
+            GyFItEZsYO5zxxeLX3NoykYYcdQhu4yrUjg76zn6H+R16MfFV8W/aPMmCWNeXHsj
+            5FNzG7QqVk8J93b3ZCPTiUm1LAKZoodHnhajtVok4fM9lRMgmufeDzgoLy80ZUgz
+            d4M5oqvNJlJEkIlBmiRih6opLMWf1zOtkpEI+dXJsIxY5KBIOqgkTKyiv5IiGQ+o
+            b7sjOqWfNIMOkJXnWLnf09v1vu5ltWgLp4QKzOZ19Kysq3uvZahaCeDsC9yLuBbK
+            /a/8PDN8gOxoWpjhaYqfxaNc02xMs+uq3JUKabte4NFYFOgz5LTIFl00AjybrhAP
+            BTEnaagqJWO7g22ePutobg60cRCL00A4jysb7bedLkAgGGv4S+jM9sSF39hu3L3S
+            4AHkBWTaYeJWeI2Y8p8v+rYEseHH1ODZ4LTh6Dzg1uL6b0dR4HHlJyHOwp6XtUO3
+            08i+pzeH0LaFSDd8svak9h86l+ZokODgteRLhFpSkUUcEpZ3FjYov9hm4vGIEazh
+            sSIA
+            =ZENa
+            -----END PGP MESSAGE-----
+        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+    -   created_at: '2021-03-17T13:13:29Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcBMA77Gn+FOVmJYAQgActgaputTve3Fbt4vwR5tRswYeSENSKh/dn20npCuJrea
+            PlufpO2ktGcPIAUbRlINFMKpPafsq5YryC3R0RZPGwFM9jsWZVZQF1qqJK73m2iK
+            G57+RbQNq8gMmJ7+nH3dTYbs5MMUyf3z3s0pkc19o3EEOAtO97+vwa/OssLVpbDo
+            oyJ89noAvn9uAMDgQhIMeOAx1/btG5Mdnr7HGpCF0KqzRnuikupHNt+9Tmu0i3hV
+            UZWMsCzEohJmIfBQftyPn5k5HPTpxGdA3c5spEljN09F6cwOPL6EeUivnDRFhAYH
+            Xx+mOtYvENK/rAWclazvvVkX2VrzJgxxaOtwW/2MANLgAeRbWekuXetww5lecUDe
+            blOx4U0y4HvglOGXouC+4no5aLTgpOWtH9rtuHEwL85j0hBnUpIUk1A3tSc+3gmc
+            Hnum6wJ0Y+DS5CAujiihRRmIq+bg0I4UroHijsoXM+FTLwA=
+            =Igbc
+            -----END PGP MESSAGE-----
+        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+    -   created_at: '2021-03-17T13:13:29Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcDMA7rAHYSMKfAZAQwAKrDzJ3Uix8bYk2iXeOzTjJ0N9Fg7ouVugpHZe8AvKVv9
+            E16Mv9fcFT5eungmd11VIDxIvNrfwYAynweob3nZu5RXJ4+2Yu5SOV4Ysx04+5tQ
+            BZDHq18ymKPYcx4WG/4sv1Vq11aOEV/O+8U2NX8xVvUh2sOyJ0eCWoXkjW/JxDMk
+            o4MRiMKKABPCDNYG7Qaz2S/xtZZKrcQK9i5MU1od2Lthgv0jcw6Z6nXGHgiVjcV4
+            x93gFu8ry6D8qDwRB7HuEv4TVHkkOyvU1Qq9SA3ZdV9BArshdmgS1+lgbFY+R6t/
+            9DWcZAiGse8gK1ZuoNJi1Cpb5UDus0L6cEYsbuwMoAoDj2GT4IBtK0ZoZg/xjowt
+            iGE8zmfnoUN2G+hawJug76vOnBDvE61X2fvdyVl0WVDdBwy101isPPWFGJKbD5yp
+            l3TEaytRfWrRNEqCgeUjemmoNt5ERrpU8qz9AZNEp8KvJgaMeWaXprhnM6MZgP62
+            cwRMk74Q+1iv/QGvm59O0uAB5OgJEeZ9FH+SZi38lYeGPS/hHGPgKOBa4WQi4Ebi
+            T6CnrOCr5YzBPWFZ9d9rWPYAjv55X+jHzfSaMjQCW4BBRvymuScJ4KHk+0NDa6Yd
+            +be105co4Dkbe+Lf1YeQ4RZaAA==
+            =0HPd
+            -----END PGP MESSAGE-----
+        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+    encrypted_regex: ^(users|data|stringData)
+    version: 3.6.1

--- a/cluster-scope/overlays/moc/common/kustomization.yaml
+++ b/cluster-scope/overlays/moc/common/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ../../../base/groups/cnv-testing
   - ../../../base/groups/data-science
   - ../../../base/groups/fde
+  - ../../../base/groups/lab-cicd
   - ../../../base/groups/mesh-for-data
   - ../../../base/groups/open-aiops
   - ../../../base/groups/operate-first

--- a/cluster-scope/overlays/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/moc/zero/kustomization.yaml
@@ -40,6 +40,14 @@ resources:
   - ../../../base/namespaces/ds-ml-workflows-ws
   - ../../../base/namespaces/fde-audio-decoder-demo
   - ../../../base/namespaces/kubeflow
+  - ../../../base/namespaces/lab-cicd-1-jump-app-cicd
+  - ../../../base/namespaces/lab-cicd-1-jump-app-dev
+  - ../../../base/namespaces/lab-cicd-2-jump-app-cicd
+  - ../../../base/namespaces/lab-cicd-2-jump-app-dev
+  - ../../../base/namespaces/lab-cicd-3-jump-app-cicd
+  - ../../../base/namespaces/lab-cicd-3-jump-app-dev
+  - ../../../base/namespaces/lab-cicd-4-jump-app-cicd
+  - ../../../base/namespaces/lab-cicd-4-jump-app-dev
   - ../../../base/namespaces/local-storage
   - ../../../base/namespaces/m4d-blueprints
   - ../../../base/namespaces/m4d-system


### PR DESCRIPTION
Part of: https://github.com/operate-first/support/issues/113

@acidonper, sorry for the delay, let me know if this PR is what you need. It creates an user group `lab-cicd` which you are set to be the sole user for now. This group is the project admin on all the namespaces.

Additionally it creates namespaces:
- `lab-cicd-1-jump-app-cicd`
- `lab-cicd-1-jump-app-dev`
- `lab-cicd-2-jump-app-cicd`
- `lab-cicd-2-jump-app-dev`
- `lab-cicd-3-jump-app-cicd`
- `lab-cicd-3-jump-app-dev`
- `lab-cicd-4-jump-app-cicd`
- `lab-cicd-4-jump-app-dev`

Each of this namespaces is available to be viewed (`view` cluster role) by any authenticated or unauthenticated user

Will this work for you or are any changes needed?