### PR TITLE
Upgrade zero cluster to 4.7.2

### DIFF
--- a/cluster-scope/overlays/moc/zero/clusterversion.yaml
+++ b/cluster-scope/overlays/moc/zero/clusterversion.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+metadata:
+  name: version
+spec:
+  channel: stable-4.7
+  desiredUpdate:
+    image: >-
+      quay.io/openshift-release-dev/ocp-release@sha256:83fca12e93240b503f88ec192be5ff0d6dfe750f81e8b5ef71af991337d7c584
+    version: 4.7.2

--- a/cluster-scope/overlays/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/moc/zero/kustomization.yaml
@@ -107,6 +107,7 @@ resources:
   - ../../../base/subscriptions/openshift-pipelines-operator-rh
   - ../../../base/subscriptions/serverless-operator
   - ../../../base/subscriptions/web-terminal
+  - clusterversion.yaml
 
 generators:
   - secret-generator.yaml


### PR DESCRIPTION
Update the zero cluster to 4.7.2.

The `ClusterVersion` resource includes a `clusterID` attribute that I have omitted from this update, since if we were to reinstall the cluster the ID would be different.