### PR TITLE
Add asanmukh as Jupyterhub admin

### DIFF
--- a/odh/base/jupyterhub/overrides/jupyterhub/base/jupyterhub-configmap.yaml
+++ b/odh/base/jupyterhub/overrides/jupyterhub/base/jupyterhub-configmap.yaml
@@ -8,6 +8,6 @@ metadata:
 data:
   jupyterhub_config.py: |
     c.JupyterHub.authenticate_prometheus = False;
-  jupyterhub_admins: "admin"
+  jupyterhub_admins: "asanmukh@redhat.com"
   gpu_mode: ""
   singleuser_pvc_size: 2Gi


### PR DESCRIPTION
only one user can be added as admin for some reason, so I will manually add @HumairAK and @tumido as admins.