### PR TITLE
Add operate-first group as jupyterhub admins

### DIFF
--- a/odh/base/jupyterhub/overrides/jupyterhub/base/jupyterhub-configmap.yaml
+++ b/odh/base/jupyterhub/overrides/jupyterhub/base/jupyterhub-configmap.yaml
@@ -8,6 +8,6 @@ metadata:
 data:
   jupyterhub_config.py: |
     c.JupyterHub.authenticate_prometheus = False;
-  jupyterhub_admins: "asanmukh@redhat.com"
+  jupyterhub_admins: "admin"
   gpu_mode: ""
   singleuser_pvc_size: 2Gi

--- a/odh/base/jupyterhub/overrides/jupyterhub/base/jupyterhub-groups-configmap.yaml
+++ b/odh/base/jupyterhub/overrides/jupyterhub/base/jupyterhub-groups-configmap.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: jupyterhub
+  name: jupyterhub-default-groups-config
+data:
+  admin_groups: "operate-first"
+  allowed_groups: ""


### PR DESCRIPTION
* Revert changes made in https://github.com/operate-first/apps/pull/431
* This PR overrides the `jupyterhub-default-groups-configmap` from [upstream](https://github.com/opendatahub-io/odh-manifests/blob/master/jupyterhub/jupyterhub/base/jupyterhub-groups-configmap.yaml).

Resolves https://github.com/operate-first/support/issues/69