### PR TITLE
Add resourcequotas and limitrange components.

### DIFF
--- a/cluster-scope/components/limitranges/default/kustomization.yaml
+++ b/cluster-scope/components/limitranges/default/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+- ./limitrange.yaml

--- a/cluster-scope/components/limitranges/default/limitrange.yaml
+++ b/cluster-scope/components/limitranges/default/limitrange.yaml
@@ -1,0 +1,13 @@
+kind: LimitRange
+apiVersion: v1
+metadata:
+  name: default
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: 500m
+        memory: 1000Mi
+      defaultRequest:
+        cpu: 300m
+        memory: 400Mi

--- a/cluster-scope/components/resourcequotas/large/kustomization.yaml
+++ b/cluster-scope/components/resourcequotas/large/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+- ./resourcequotas.yaml

--- a/cluster-scope/components/resourcequotas/large/resourcequotas.yaml
+++ b/cluster-scope/components/resourcequotas/large/resourcequotas.yaml
@@ -1,0 +1,11 @@
+kind: ResourceQuota
+apiVersion: v1
+metadata:
+  name: large
+spec:
+  hard:
+    requests.cpu: '4'
+    requests.memory: 16Gi
+    limits.cpu: '4'
+    limits.memory: 16Gi
+    requests.storage: 80Gi

--- a/cluster-scope/components/resourcequotas/medium/kustomization.yaml
+++ b/cluster-scope/components/resourcequotas/medium/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+- ./resourcequotas.yaml

--- a/cluster-scope/components/resourcequotas/medium/resourcequotas.yaml
+++ b/cluster-scope/components/resourcequotas/medium/resourcequotas.yaml
@@ -1,0 +1,11 @@
+kind: ResourceQuota
+apiVersion: v1
+metadata:
+  name: medium
+spec:
+  hard:
+    requests.cpu: '2'
+    requests.memory: 8Gi
+    limits.cpu: '2'
+    limits.memory: 8Gi
+    requests.storage: 40Gi

--- a/cluster-scope/components/resourcequotas/small/kustomization.yaml
+++ b/cluster-scope/components/resourcequotas/small/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+- ./resourcequotas.yaml

--- a/cluster-scope/components/resourcequotas/small/resourcequotas.yaml
+++ b/cluster-scope/components/resourcequotas/small/resourcequotas.yaml
@@ -1,0 +1,11 @@
+kind: ResourceQuota
+apiVersion: v1
+metadata:
+  name: small
+spec:
+  hard:
+    requests.cpu: '1'
+    requests.memory: 4Gi
+    limits.cpu: '1'
+    limits.memory: 4Gi
+    requests.storage: 20Gi


### PR DESCRIPTION
Related: #438 

The `resourcequotas` aren't included in any of the namespaces yet, this is one way we can go about this. The idea is to include these like we do every other component within the cluster-scope/base/namespaces.

We don't have to use tiers if there are good arguments against it, this is a suggestion. 

I just willy nilly picked amounts for each tier and `limitrange`. We can discuss what amounts are reasonable. 

WDYT? 