### PR TITLE
Scale up Observatorium Thanos Receiver and Thanos Query

### DIFF
--- a/observatorium/base/instance/observatorium.yaml
+++ b/observatorium/base/instance/observatorium.yaml
@@ -64,7 +64,7 @@ spec:
   - hashring: default
   receivers:
     image: quay.io/thanos/thanos:v0.16.0
-    replicas: 1
+    replicas: 3
     version: v0.16.0
     volumeClaimTemplate:
       spec:
@@ -108,7 +108,7 @@ spec:
             storage: 10Gi
   query:
     image: quay.io/thanos/thanos:v0.16.0
-    replicas: 1
+    replicas: 2
     version: v0.16.0
   queryFrontend:
     image: quay.io/thanos/thanos:v0.15.0


### PR DESCRIPTION
Scale up Thanos Receiver to 3 from 1
  Because resource usage in the thanos receive component seems to be pretty high

Scale up Thanos Query to 2 from 1
  I was seeing some timeout errors when querying thanos from grafana, when queries were a little big.