### PR TITLE
fix(odh-jupyterhub): Viewing pods/log in a namespace

### DIFF
--- a/cluster-scope/components/project-logs-reader/role.yaml
+++ b/cluster-scope/components/project-logs-reader/role.yaml
@@ -4,12 +4,23 @@ kind: Role
 metadata:
   name: project-logs-reader
 rules:
-  - apiGroups:
+  - verbs:
+      - get
+    apiGroups:
       - ""
+      - project.openshift.io
     resources:
-      - pods/log
-      - pods
-    verbs:
+      - projects
+  - verbs:
       - get
       - list
       - watch
+    apiGroups:
+      - ""
+    resources:
+      - events
+      - namespaces
+      - namespaces/status
+      - pods
+      - pods/log
+      - pods/status


### PR DESCRIPTION
Fixes: https://github.com/operate-first/support/issues/156

Allows user to see the namespace/project listed as an available in web console along with some additional goods like events (that are also propagated to JH spawner so why to hide it in the console) 