### PR TITLE
fix(hue): Set proper endpoint for S3 file explorer

### DIFF
--- a/odh/overlays/moc/zero/datacatalog/kfdef_patch.yaml
+++ b/odh/overlays/moc/zero/datacatalog/kfdef_patch.yaml
@@ -2,7 +2,9 @@
   path: /spec/applications/2/kustomizeConfig/parameters
   value:
     - name: s3_endpoint_url
-      value: s3.openshift-storage.svc:443
+      value: s3.openshift-storage.svc
+    - name: s3_is_secure
+      value: "false"
     - name: s3_credentials_secret
       value: opf-datacatalog-bucket
     - name: storage_class
@@ -12,7 +14,7 @@
   path: /spec/applications/3/kustomizeConfig/parameters
   value:
     - name: s3_endpoint_url
-      value: s3.openshift-storage.svc:443
+      value: s3.openshift-storage.svc
     - name: s3_credentials_secret
       value: opf-datacatalog-bucket
     - name: storage_class


### PR DESCRIPTION
Resolves: https://github.com/operate-first/support/issues/117
The https://github.com/operate-first/support/issues/131 issue still persists

Additionally it was required to grant S3 permissions to the `default` user group:

![image](https://user-images.githubusercontent.com/7453394/112832297-668d5f80-9095-11eb-8b15-5b19f63eb8c0.png)

