### PR TITLE
feat: Onboard moc-reporting

### DIFF
--- a/cluster-scope/base/clusterrolebindings/cluster-logs-readers/clusterrolebinding.yaml
+++ b/cluster-scope/base/clusterrolebindings/cluster-logs-readers/clusterrolebinding.yaml
@@ -14,3 +14,5 @@ subjects:
     name: open-aiops
   - kind: Group
     name: data-science
+  - kind: Group
+    name: moc-reporting

--- a/cluster-scope/base/groups/moc-reporting/group.yaml
+++ b/cluster-scope/base/groups/moc-reporting/group.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: moc-reporting
+users: []

--- a/cluster-scope/base/groups/moc-reporting/kustomization.yaml
+++ b/cluster-scope/base/groups/moc-reporting/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ./group.yaml

--- a/cluster-scope/base/namespaces/moc-reporting/kustomization.yaml
+++ b/cluster-scope/base/namespaces/moc-reporting/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: moc-reporting
+
+resources:
+- namespace.yaml
+
+components:
+- ../../../components/project-admin-rolebindings/moc-reporting

--- a/cluster-scope/base/namespaces/moc-reporting/namespace.yaml
+++ b/cluster-scope/base/namespaces/moc-reporting/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "MOC: Reporting"
+    openshift.io/requester: moc-reporting
+  name: moc-reporting
+spec: {}

--- a/cluster-scope/components/project-admin-rolebindings/moc-reporting/kustomization.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/moc-reporting/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+- ./rbac.yaml

--- a/cluster-scope/components/project-admin-rolebindings/moc-reporting/rbac.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/moc-reporting/rbac.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-admin-moc-reporting
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: moc-reporting

--- a/cluster-scope/overlays/moc/common/groups/moc-reporting.enc.yaml
+++ b/cluster-scope/overlays/moc/common/groups/moc-reporting.enc.yaml
@@ -1,0 +1,94 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+    name: moc-reporting
+    annotations:
+        kustomize.config.k8s.io/behavior: replace
+users:
+    - ENC[AES256_GCM,data:zBU1Rs9x2v1linbqOjbt,iv:LK7PEELzBnwHZIbv6ljhsZKT0QnvVxjW2FezwmQo14Y=,tag:sKGFo1vpdcCkLYoI/MwqRQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2021-03-29T12:56:47Z"
+    mac: ENC[AES256_GCM,data:NRoeIiS4ZBUaVnYQdKg8wRtnAfVmHaJWfsvgB8el9T91MnpIsE9Sq6t3NhXHtVv51ZGqDlLuk/1/zY0bG/Bx+TpUz2I3bsnfbI4qCo/U4VD9+SHyjubJRe05D+L3QIZlj2sIFdC/PWRyEj5QZAgZfrNsm8ocKOFcgzGOHHMUfcA=,iv:Z3tDTpzd5X/EO752a9iB25ibv/16jh0rqSva+krGFZ8=,tag:7Dn4hsu4LGJ60blBHFFsLA==,type:str]
+    pgp:
+        - created_at: "2021-03-02T07:30:35Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA9aKBcudqifiARAAxhfSTV+e3AUDXxvlgYdX+juu0PtQcxJrvn0BdYQyxtjI
+            XNmdWC+/LilQPcciZEmZwht6GOJ3aLw/dO78XJz8GnhUp4ZJP7z8V8B53RSzxKiA
+            3/6Vi6xZqdaND5gIXdiqvf5jw+66w/g6nrAnDo3HORT6L1FZVcuw3S38xjx2aAXS
+            W/tJh41g+FNH6opYEQiOdSmxPLuwPEtK9KrqGLAyqU7k7s9u9jQhj5uueOsB0/wl
+            kDiZtBVI4ZmsmnwIA5ShF8LYTvouSDtMn4pDeW6xk5N1hW2ZGCoj2ehS0dDOemMh
+            gSdGbO1dfxszuKTSVy2KeEUzm8eBiRCpUFV49HBz5qx2PhDGMQ8tT9MJ7dQ8ApST
+            77HCm+fdAf+UZvboVAytZPcMW85lVPAg0uIKAnUYW0ReWZJ6UhnAnevx/8RwPf/r
+            bmL/6jogLW8Qry/NDSIsnOb1m2VurMaBDFfPwg4ljB/Qmi4xfSz7Nen7y1swuEXy
+            TFBqpYgvGUQzUU+AWmckinCo2N8o5A8erygEudqE0G0FZrP0+O4GwbnHnAvduWY2
+            sR06/igs8EoF957nBe/Z15OjzNBAyOMsMwiYFf5mA9EsGcAUFg0eM7sydmKOHvqf
+            uHk1D144speuK9sBZ+3qxlhH7vogEBK7Hg2vWTufMuTrU+83QGr0rB375A3GS3TS
+            4AHk98zBLN3kQTQihDtgQbYq/uEeiuC44Cnh7Krgd+L6ZfPv4BzlWDl9SVFjmLxW
+            p36DAeQJO3gwep9DM8qAqVDQA3e4Xyjgt+TlWWSBTBeuXcaSUwzjWo8E4sd/J3bh
+            VtEA
+            =c9lu
+            -----END PGP MESSAGE-----
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-03-11T14:06:29Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcDMA7rAHYSMKfAZAQwABuAdf5pnaYPUKl6fKEHX8wwzP4R4YfJD+9zvmsfX1z62
+            8JPbEVXAR+Zhv64Tt5ZnZTx9d6krmwJE2pVPtquYBbnINlHVwmVMUEh5hcCSmKHV
+            FE1+cCbUnxceeDwgT5khErEsCIFrTPOd3NP1VZkisiSY6C7O6z1HTUNixTlOjMsw
+            f2ERtHylbbx6mF6KyjM2ItvwxSdfBGk1IkHCB/UIVhwAuJmAMX1UgXBJqwVWnjH/
+            G0sjNrN161u/eFNuDHuXhlIQxhZjgwTrX1Lt/YAwZ5SjSLKs+/c73AbO882XqCQ6
+            Ds9fE+B7jv9+qkdSBgMCaLvQHa4hTcE4z72c9tJOsdRRcAYlTWtRXODC9N3Xzvoh
+            vY10Rs+eWMvNx/BXvb2fNGP/F0lwHkLkIjpq3WNnpRXZGB4OIgdR5Li+mxv5oQQB
+            xBwjUmLYCWQIiZbpz4FIlnsrQnWoQ1ijG98n8w/x54xHhFnnpZO3/y205FW5xZ74
+            nx2ec2c1PTtUXseHxKwM0uAB5PV8xg5mdy0v9csujzbFX0fhD7XgHOA74Wb44Ovi
+            TK/03eCl5YieT3fDLr2kbxOlYyxdwaxg+DJxqS8biQqZS2jVubyC4LzklPX6fP4t
+            3846jpBA6wvvauJDtVzW4aafAA==
+            =+KL4
+            -----END PGP MESSAGE-----
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-03-11T14:06:29Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMAyzcsT8FUYakARAAUBqlNTkgdYY5GBdfOv0pYNT/8PSN2Erk1/JdWO6Vo2g0
+            lAcIs1rngzqWbMLyLdA61X3phIaWZpZY6E4eFb4C3Kkf0hW7ClQF2egzXryw8FyX
+            aZAxe4jF+nmylVMmo8fUlYh1ey4KvUITDcZ6ezxS6oLxw7GgKDCTTxAp26uE1ktF
+            sNDGDBiMtTcBX/hxLnfp6iFy9iDutj4aM+lbY8o2apJngqvtV/j/ACmecSwj4H7O
+            3dKOnLGtDSHNjigNjwhd4NlmHxDLxSsBFaEgSm+RTV9wVKQ7cp28drrWDt1tvqVP
+            Rv8oiujvqOu8iRMyW+8UZ7KKhR6SuGGXTQpijbxPnIlH0zgOQBkRsoNluvsE3XFx
+            ipiIVGsIUjM/NGar+4Hz52GK96tasgWPffJD36HYtXflmQeqm9ZiiQ9H64ZTqYud
+            /FQ4Y+jzcsMCsn+dbBX35LiC0x23bNBmuhRyxuVtXVGzVYfHX19Zqh0h+HJb3W4K
+            JS8XkPICgfJ9r5RViD576slg8358tuieE1jkl1MyXrEzVzsiqBD8RpXfnUZ4BHSi
+            8FFwx5B1aul+wVOcaqTUbpnKXbsdsakmsCu35vpeBW/XoXcdUvRV0t6XYvNivdDz
+            TR7Fe3KMSc35J47/k7Nr79p3fWGDEqJHHkT8c2XvCNlvVsClAOYI95lBl1/Cb9vS
+            4AHkJqGdR+B4ZC9mm1n2yXpwF+EZsuAY4DHhGjrg7+Kwi2uS4LzlYKo8REssjB79
+            pQiiufP5QdAPHfWpV1Fv4cr7gusZuNDgIOR3DC5KCYxr1OxMNhWB6c7F4iQWgGPh
+            FasA
+            =SWF/
+            -----END PGP MESSAGE-----
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-03-11T14:06:29Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcBMA77Gn+FOVmJYAQgAuwMh1svJvsnuXzswE6qJyhaQeVM+RhrdwRQtXyQLCVfu
+            8lXk8AbWMhRxpa3zT2qIrzKb8834SMgr0npV6oCuAJ9opfQuMztgt+tGYl8AGMnQ
+            45cYALvbwVtDS2SaSVOTxLsONGLTO72OCY+U6GU6MnkkVkm8wFBsu4u+NQMWRmDF
+            wh+gRPMJTmgntE7gtpZX5uBAThRyqJsv4pxIu8qZGLZCtG+2Q7BjihFMszggrfsO
+            PfskY4vVBaBAaIZhtxuji1/TJpsm4kqGQjsFfsDtowSYO634XUkA0ff1FAcuXzOi
+            5dSFFZA1obnGAGce2DVjayb9sf4e8lxyQtxbVMaLW9LgAeTFLz8mZqkUSRvK+y7E
+            Qn764dPI4HvgueHxk+DS4qzENTjgZeWWLbJcMr8yRS2Evl/rihpLo2wh8otgJRQ+
+            vMEOt2BSg+C55NSHX35kUBLDJJG1d77BZvTiDs8vDuHq3QA=
+            =W3jx
+            -----END PGP MESSAGE-----
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+    encrypted_regex: ^(users|data|stringData)$
+    version: 3.7.0

--- a/cluster-scope/overlays/moc/common/kustomization.yaml
+++ b/cluster-scope/overlays/moc/common/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ../../../base/groups/fde
   - ../../../base/groups/lab-cicd
   - ../../../base/groups/mesh-for-data
+  - ../../../base/groups/moc-reporting
   - ../../../base/groups/open-aiops
   - ../../../base/groups/operate-first
   - ../../../base/groups/ray

--- a/cluster-scope/overlays/moc/common/secret-generator.yaml
+++ b/cluster-scope/overlays/moc/common/secret-generator.yaml
@@ -11,6 +11,7 @@ files:
   - groups/data-science.enc.yaml
   - groups/fde.enc.yaml
   - groups/mesh-for-data.enc.yaml
+  - groups/moc-reporting.enc.yaml
   - groups/open-aiops.enc.yaml
   - groups/operate-first.enc.yaml
   - groups/ray.enc.yaml

--- a/cluster-scope/overlays/moc/infra/groups/cluster-admins.enc.yaml
+++ b/cluster-scope/overlays/moc/infra/groups/cluster-admins.enc.yaml
@@ -5,25 +5,25 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:TOE6B8u0JtlaA+Q=,iv:CP1f5xp28+k2AbwdYPtLLCTYQPHoS+GU5SxxdhenSYk=,tag:DPNyEKBEYGnskXywBSgK/w==,type:str]
-- ENC[AES256_GCM,data:dNMEhoVzwpYfifruAk1c,iv:SDzAVj4Z/1xurYk2L6T46X+unYDjsVPR4RKy7GXqWt0=,tag:Hm/eQrGaj58EzmlBUcZ0vA==,type:str]
-- ENC[AES256_GCM,data:C1FzjjUBcQ4hltBwawAs,iv:Rrk3zMQRRSYr5tcTmzEzI/Sj3rOMMLncIPYF8EvQkEM=,tag:J89DGocC3IU6gexr2/E2bg==,type:str]
-- ENC[AES256_GCM,data:KGGg9ispMfT1v7xJaFuGM391,iv:A1GHS8oPVFxhYN2E1C5Mt6ibah5mpTFVL1eL3rLHrXc=,tag:lmCWY8pVNQoMDfdqk+8GBA==,type:str]
-- ENC[AES256_GCM,data:VKXH/iR/AMxz4lj/57Lc9N4=,iv:5W3Ch63dAzpSlNBzpIvMmlpKMKP15jbH6P+Bp3AiFzg=,tag:Xo3FZT4sL8pn9JHdt5ej8Q==,type:str]
-- ENC[AES256_GCM,data:56NDBgBgUoWITpJNdmIaUmhT/g==,iv:UDTNdUiZGvSSGSGEuSD7YdkKgMobkPPvFOzhs07TzkY=,tag:bnjB2qG5FDVRT/6bg+pCkA==,type:str]
-- ENC[AES256_GCM,data:G9eWuVxNv6qBW6O64B8H1A==,iv:BwImOt73k2SwRTN57fZPahgS8koRqyILtw0LrX43paY=,tag:lmdF/bgagMplV+k7YAxGOg==,type:str]
-- ENC[AES256_GCM,data:20ZSzh0u3K/mFZGlJsePHw==,iv:lGmTAfC4H7tghQPx6VrzouzzIDeaEQgDPJ2Rim77vDE=,tag:aIxi2kdp5Xu2Li+DcHxcXA==,type:str]
-- ENC[AES256_GCM,data:jFP/7OqNV9kxdfbJZh5hAsf0Vw==,iv:iur4nw0AKS+mDho/sS1O7uf8RN0jVdjXaEebG3dxbFs=,tag:xImpPVYFMQAX3SX0iTVggg==,type:str]
+    - ENC[AES256_GCM,data:TOE6B8u0JtlaA+Q=,iv:CP1f5xp28+k2AbwdYPtLLCTYQPHoS+GU5SxxdhenSYk=,tag:DPNyEKBEYGnskXywBSgK/w==,type:str]
+    - ENC[AES256_GCM,data:C1FzjjUBcQ4hltBwawAs,iv:Rrk3zMQRRSYr5tcTmzEzI/Sj3rOMMLncIPYF8EvQkEM=,tag:J89DGocC3IU6gexr2/E2bg==,type:str]
+    - ENC[AES256_GCM,data:KGGg9ispMfT1v7xJaFuGM391,iv:A1GHS8oPVFxhYN2E1C5Mt6ibah5mpTFVL1eL3rLHrXc=,tag:lmCWY8pVNQoMDfdqk+8GBA==,type:str]
+    - ENC[AES256_GCM,data:VKXH/iR/AMxz4lj/57Lc9N4=,iv:5W3Ch63dAzpSlNBzpIvMmlpKMKP15jbH6P+Bp3AiFzg=,tag:Xo3FZT4sL8pn9JHdt5ej8Q==,type:str]
+    - ENC[AES256_GCM,data:56NDBgBgUoWITpJNdmIaUmhT/g==,iv:UDTNdUiZGvSSGSGEuSD7YdkKgMobkPPvFOzhs07TzkY=,tag:bnjB2qG5FDVRT/6bg+pCkA==,type:str]
+    - ENC[AES256_GCM,data:G9eWuVxNv6qBW6O64B8H1A==,iv:BwImOt73k2SwRTN57fZPahgS8koRqyILtw0LrX43paY=,tag:lmdF/bgagMplV+k7YAxGOg==,type:str]
+    - ENC[AES256_GCM,data:20ZSzh0u3K/mFZGlJsePHw==,iv:lGmTAfC4H7tghQPx6VrzouzzIDeaEQgDPJ2Rim77vDE=,tag:aIxi2kdp5Xu2Li+DcHxcXA==,type:str]
+    - ENC[AES256_GCM,data:jFP/7OqNV9kxdfbJZh5hAsf0Vw==,iv:iur4nw0AKS+mDho/sS1O7uf8RN0jVdjXaEebG3dxbFs=,tag:xImpPVYFMQAX3SX0iTVggg==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-03-12T17:02:52Z'
-    mac: ENC[AES256_GCM,data:hQ2l3XGwN5CleKifMel26eG+IQ6Q4CdAtduPDlhMplZjo7BIeF6P/LGBBkP1rfQTgp7yM73QsJq4UXmuIBRTXf+H/gC88hLQIDMwumDvU5MV8pMtdxefSDYMIElZ22hPdFZN5X5Yg1W8tNlgy1wWZR2I0nEyDtViWVwXJ1SO0MA=,iv:XlJCLbl/deV3D5xgc2BLCE7l/8zQPkzBV2/69VoroLY=,tag:ChRYuDYLjlmpuUlIyWZDVQ==,type:str]
+    age: []
+    lastmodified: "2021-03-29T12:57:41Z"
+    mac: ENC[AES256_GCM,data:/+s80mRXsOK4q7jwT9GihW3uuIgSTVGFW8zcbhu+SK3BEl2o1E6nfx89VlGXnPJF1/e0EJPyVzhMck8BARF4HhSqvcU5/gBcfsxoLjKBk4EFATs6A7EqU4AAxeDVY97KQbNWFYenVjSLtoXAnLotHLcfC1J+VrfLSorwHeO41es=,iv:LUVPkhKu8pCzoQtRYMn/NNeuc6JgWFOWMMPR4V1hWHk=,tag:JNTm/B/zzb/PQ86AX/SkPg==,type:str]
     pgp:
-    -   created_at: '2021-01-12T17:24:03Z'
-        enc: |-
+        - created_at: "2021-01-12T17:24:03Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAATDzySUo52IwfBnmfGVvfKy/EuenK0YLgkf6JNZ/t7pr3
@@ -42,9 +42,9 @@ sops:
             MMUA
             =QSN3
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-03-11T14:06:50Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-03-11T14:06:50Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAvK4kmChXK2YT7z9gCNUnG+dsx7AC+UXUFAGhRpqRg0oH
@@ -60,9 +60,9 @@ sops:
             mgRPeCoSOMsuJeL19uWc4ZJqAA==
             =vQo7
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-03-11T14:06:50Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-03-11T14:06:50Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAPrUmL2fHCeFpk5XSz1gt/wcMbrP8xEYBrddzhU/8tu2o
@@ -81,9 +81,9 @@ sops:
             MYkA
             =cJ8G
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-03-11T14:06:50Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-03-11T14:06:50Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAcnmXEzV0Tm3aZRkKE+7tyROPLn2q/zll3J7QW1FCxat+
@@ -96,6 +96,6 @@ sops:
             6I4pq8raJOCl5H6gM9CttYd840j6ZYALLefikzvG2+GHMgA=
             =aWv+
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.0

--- a/cluster-scope/overlays/moc/zero/groups/cluster-admins.enc.yaml
+++ b/cluster-scope/overlays/moc/zero/groups/cluster-admins.enc.yaml
@@ -5,22 +5,22 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:qSSc2HKcZ49zG3s=,iv:CP1f5xp28+k2AbwdYPtLLCTYQPHoS+GU5SxxdhenSYk=,tag:Tw8qn556zfhCQlQsgS1X9g==,type:str]
-- ENC[AES256_GCM,data:hGDY7FaJLhUMm5ZuWY9z,iv:SDzAVj4Z/1xurYk2L6T46X+unYDjsVPR4RKy7GXqWt0=,tag:uzBKr72sQ29JS6VkMqdACQ==,type:str]
-- ENC[AES256_GCM,data:agXEe6Oy/JGdYhvZGwSK,iv:Rrk3zMQRRSYr5tcTmzEzI/Sj3rOMMLncIPYF8EvQkEM=,tag:QGKMHrvUzRNAUx40siZDsA==,type:str]
-- ENC[AES256_GCM,data:NedbJLOSkDmI6cAsNKwyfdLU,iv:A1GHS8oPVFxhYN2E1C5Mt6ibah5mpTFVL1eL3rLHrXc=,tag:iHTTnm0O1VyIzQQwaPkZLw==,type:str]
-- ENC[AES256_GCM,data:Fdo9s47JoU3a6KiWWJ7YjUA=,iv:5W3Ch63dAzpSlNBzpIvMmlpKMKP15jbH6P+Bp3AiFzg=,tag:xnXBf9+hB90uULYRBNcLqA==,type:str]
-- ENC[AES256_GCM,data:ZACTQyjFMwD1gXKu571N11RVhg==,iv:qaAQMIDiA/SJ3YTABJZQ6W5tjlhw0K63oh3FsfuNNY8=,tag:B7MihbC5rVQ/YIsrV8NT3Q==,type:str]
+    - ENC[AES256_GCM,data:qSSc2HKcZ49zG3s=,iv:CP1f5xp28+k2AbwdYPtLLCTYQPHoS+GU5SxxdhenSYk=,tag:Tw8qn556zfhCQlQsgS1X9g==,type:str]
+    - ENC[AES256_GCM,data:agXEe6Oy/JGdYhvZGwSK,iv:Rrk3zMQRRSYr5tcTmzEzI/Sj3rOMMLncIPYF8EvQkEM=,tag:QGKMHrvUzRNAUx40siZDsA==,type:str]
+    - ENC[AES256_GCM,data:NedbJLOSkDmI6cAsNKwyfdLU,iv:A1GHS8oPVFxhYN2E1C5Mt6ibah5mpTFVL1eL3rLHrXc=,tag:iHTTnm0O1VyIzQQwaPkZLw==,type:str]
+    - ENC[AES256_GCM,data:Fdo9s47JoU3a6KiWWJ7YjUA=,iv:5W3Ch63dAzpSlNBzpIvMmlpKMKP15jbH6P+Bp3AiFzg=,tag:xnXBf9+hB90uULYRBNcLqA==,type:str]
+    - ENC[AES256_GCM,data:ZACTQyjFMwD1gXKu571N11RVhg==,iv:qaAQMIDiA/SJ3YTABJZQ6W5tjlhw0K63oh3FsfuNNY8=,tag:B7MihbC5rVQ/YIsrV8NT3Q==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-03-12T17:02:31Z'
-    mac: ENC[AES256_GCM,data:XJfWfPfIa8hunJ7M8ZZe8JnyFRUcXY2Rgmj1sLT5EA+8al+u20P1KsSDDxK1kUcA62WTEQpRKzmAXhccQIA5nNMwZBbIINCWFfbAHV2cg26PhdoFfSB0w+m2aO1O21JvhxDjF+AnLxJwAmSVdc81q6SMpjnFLO3yoC45XZIAbKE=,iv:lHKX5etajHnCCh7eV+ugJbxmk0Jbhh6Km4oyfcQOZ4s=,tag:w0zElinPX/f6nzd7Iju6lA==,type:str]
+    age: []
+    lastmodified: "2021-03-29T12:57:34Z"
+    mac: ENC[AES256_GCM,data:g6o/61aBDH3kTRVbS04PpmGhWmsbq48RlstkMBN8qxrhJEDStmkHsxrTkBVnj7dfKCbxSaNLlNPWCtwphYNZnUBUgo/hsIOQDac8t2Zid7+zL9ixyTb7Qwj44DDaIhZEbXoFElkC17NiTZaCoZD2olxW0jkLL9WrxIFGzBxco9U=,iv:FLCydt3GWEr9Br/iAMgyNLqUnSX8dy7PEaGkAbj1WfI=,tag:A7NFppFRWd9pNPotTrwhvQ==,type:str]
     pgp:
-    -   created_at: '2021-01-12T17:24:03Z'
-        enc: |-
+        - created_at: "2021-01-12T17:24:03Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAPa+BVbfI284XVFHGnNXMX9+O1JhiSnNP6dHYox1PZUSm
@@ -39,9 +39,9 @@ sops:
             zpYA
             =LEjZ
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-03-11T14:06:41Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-03-11T14:06:41Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAuAld50yRBH+Bm4cq0tfJkTiRMbTFNDLVYq18xsL1tZ+j
@@ -57,9 +57,9 @@ sops:
             60UrSB7sPznRHeJe6yLe4fTXAA==
             =SlR1
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-03-11T14:06:41Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-03-11T14:06:41Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAvR92uY+uC3Emm9s33FhYTGDmpCDOIan6JE4mM1CmS6Sy
@@ -78,9 +78,9 @@ sops:
             VCYA
             =vTg+
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-03-11T14:06:41Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-03-11T14:06:41Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAFqplQqeJKsVPODWgb+XEcqEyxeBWZEevVQotKQ3HWeBU
@@ -93,6 +93,6 @@ sops:
             9xFuOwtLnuCM5MSqKVD0X+i8AQBLCj8qLKHiMsw8POFmwQA=
             =xyhO
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.0

--- a/cluster-scope/overlays/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/moc/zero/kustomization.yaml
@@ -53,6 +53,7 @@ resources:
   - ../../../base/namespaces/m4d-system
   - ../../../base/namespaces/metallb-system
   - ../../../base/namespaces/mesh-for-data
+  - ../../../base/namespaces/moc-reporting
   - ../../../base/namespaces/observatorium-operator
   - ../../../base/namespaces/open-aiops
   - ../../../base/namespaces/opendatahub-operator


### PR DESCRIPTION
Resolves: https://github.com/operate-first/support/issues/169

@rob-baron this PR creates the `moc-reporting` namespace for you, a user group `moc-reporting` with you included. It also removes you from the `cluster-admins` group while adding you to `cluster-logs-readers`. Are there any additional permissions you'd need for your project?