### PR TITLE
Revert "Add PVC to kafka resource"

### DIFF
--- a/odh/overlays/moc/zero/kafka/overrides/kafka/base/kafka-cluster.yaml
+++ b/odh/overlays/moc/zero/kafka/overrides/kafka/base/kafka-cluster.yaml
@@ -12,18 +12,13 @@ spec:
       tls: {}
       external:
         type: route
-    # authorization type: simple will enable authorization for KafkaUsers
-    authorization:
-      type: simple
     config:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 3
       log.message.format.version: "2.4"
     storage:
-      type: persistent-claim
-      size: 10Gi
-      deleteClaim: false
+      type: ephemeral
     metrics:
       # Inspired by config from Kafka 2.0.0 example rules:
       # https://github.com/prometheus/jmx_exporter/blob/master/example_configs/kafka-2_0_0.yml
@@ -124,9 +119,7 @@ spec:
   zookeeper:
     replicas: 3
     storage:
-      type: persistent-claim
-      size: 10Gi
-      deleteClaim: false
+      type: ephemeral
     metrics:
       # Inspired by Zookeeper rules
       # https://github.com/prometheus/jmx_exporter/blob/master/example_configs/zookeeper.yaml
@@ -156,7 +149,4 @@ spec:
         name: "zookeeper_$2_$3"
   entityOperator:
     topicOperator: {}
-    # Meta Operator to manage KafkaUsers
-    userOperator:
-      watchedNamespace: opf-kafka
-      reconciliationIntervalSeconds: 60
+    userOperator: {}


### PR DESCRIPTION
Reverts operate-first/apps#465

This is because, this will remove access from the `ANONYMOUS` user and every existing user will need a corresponding `KafkaUser`. I'll create a new PR later with all the KafkaUsers defined. 

Docs: https://strimzi.io/docs/operators/0.19.0/using.html#ref-kafka-authorization-deployment-configuration-kafka