### PR TITLE
support jupyter book in the jupyter notebook image

### DIFF
--- a/odh/base/jupyterhub/notebook-images/jupyterbook-test.yaml
+++ b/odh/base/jupyterhub/notebook-images/jupyterbook-test.yaml
@@ -1,0 +1,22 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: jupyter-book
+  labels:
+    component.opendatahub.io/name: jupyterhub
+    opendatahub.io/component: 'true'
+    opendatahub.io/notebook-image: 'true'
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: latest
+      annotations: null
+      from:
+        kind: DockerImage
+        name: 'quay.io/thoth-station/s2i-jupyter-book-notebook:latest'
+      generation: 1
+      importPolicy: {}
+      referencePolicy:
+        type: Local

--- a/odh/base/jupyterhub/notebook-images/kustomization.yaml
+++ b/odh/base/jupyterhub/notebook-images/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ceph-drive-failure.yaml
   - cloud-price-analysis.yaml
   - configuration-files-analysis.yaml
+  - jupyterbook-test.yaml
   - mailing-list-analysis-toolkit.yaml
   - ml-prague-workshop.yaml
   - ocp-ci-analysis.yaml


### PR DESCRIPTION
support jupyter book in the jupyter notebook image
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


Related-to: https://github.com/operate-first/support/issues/189


This is just a test image for the users, once the users verify the content, then the package would be installed in the base image itself.