### PR TITLE
Add clusterlogforwarder to forward app-logs to kafka

### DIFF
--- a/cluster-logging/overlays/moc/zero/clusterlogforwarders/clusterlogforwarder.yaml
+++ b/cluster-logging/overlays/moc/zero/clusterlogforwarders/clusterlogforwarder.yaml
@@ -10,8 +10,20 @@ spec:
       type: kafka
       url: tcp://odh-message-bus-kafka-bootstrap.opf-kafka.svc:9092/zero-prod.cluster.app-logs
   pipelines:
-    - name: forward-app-logs-to-kafka
+    - name: forward-app-logs
       inputRefs:
         - application
       outputRefs:
         - app-logs
+        # default outputref sends logs to the default CLO ES
+        - default
+    - name: forward-infra-logs
+      inputRefs:
+        - infrastructure
+      outputRefs:
+        - default
+    - name: forward-audit-logs
+      inputRefs:
+        - audit
+      outputRefs:
+        - default

--- a/cluster-logging/overlays/moc/zero/clusterlogforwarders/clusterlogforwarder.yaml
+++ b/cluster-logging/overlays/moc/zero/clusterlogforwarders/clusterlogforwarder.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: instance
+  namespace: openshift-logging
+spec:
+  outputs:
+    - name: app-logs
+      type: kafka
+      url: tcp://odh-message-bus-kafka-bootstrap.opf-kafka.svc:9092/zero-prod.cluster.app-logs
+  pipelines:
+    - name: forward-app-logs-to-kafka
+      inputRefs:
+        - application
+      outputRefs:
+        - app-logs

--- a/cluster-logging/overlays/moc/zero/clusterlogforwarders/kustomization.yaml
+++ b/cluster-logging/overlays/moc/zero/clusterlogforwarders/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - clusterlogforwarder.yaml

--- a/cluster-logging/overlays/moc/zero/kustomization.yaml
+++ b/cluster-logging/overlays/moc/zero/kustomization.yaml
@@ -7,6 +7,7 @@ namespace: openshift-logging
 resources:
   - ../../../base
   - configmaps
+  - clusterlogforwarders
 
 generators:
   - routes/secret-generator.yaml

--- a/odh/overlays/moc/zero/kafka/overrides/kafka/overlays/topics/zero-cluster-app-logs.yaml
+++ b/odh/overlays/moc/zero/kafka/overrides/kafka/overlays/topics/zero-cluster-app-logs.yaml
@@ -7,3 +7,6 @@ metadata:
 spec:
   partitions: 3
   replicas: 2
+  config:
+    # max message size is 10MB because fluentd default chunk size is 8MB
+    message.max.bytes: 10000000


### PR DESCRIPTION
Related https://github.com/operate-first/apps/issues/232

This will forward app-logs to kafka topic `zero-prod.cluster.app-logs`
Update max message size bytes for that topic to 10MB ([slack discussion on size](https://coreos.slack.com/archives/CB3HXM2QK/p1617720645002700))
More docs on log forwarding to kafka: https://docs.openshift.com/container-platform/4.7/logging/cluster-logging-external.html#cluster-logging-collector-log-forward-kafka_cluster-logging-external