### PR TITLE
fix: Thoth devops group not propagated properly

### DIFF
--- a/cluster-scope/overlays/moc/common/secret-generator.yaml
+++ b/cluster-scope/overlays/moc/common/secret-generator.yaml
@@ -18,6 +18,7 @@ files:
   - groups/rekor.enc.yaml
   - groups/sa-dach.enc.yaml
   - groups/sdap-mslsp.enc.yaml
+  - groups/thoth-devops.enc.yaml
   - groups/thoth.enc.yaml
   - groups/tufts-dcc-6.enc.yaml
   - groups/uky-redhat.enc.yaml


### PR DESCRIPTION
Follow up on #485

I've missed it in the review

/cc @harshad16 @HumairAK @4n4nd 