### PR TITLE
Add quotas to opf-* namespaces

### DIFF
--- a/cluster-scope/base/namespaces/opf-alertreceiver/kustomization.yaml
+++ b/cluster-scope/base/namespaces/opf-alertreceiver/kustomization.yaml
@@ -9,3 +9,5 @@ resources:
 
 components:
 - ../../../components/project-admin-rolebindings/operate-first
+- ../../../components/limitranges/default
+- ../../../components/resourcequotas/x-small

--- a/cluster-scope/base/namespaces/opf-argo/kustomization.yaml
+++ b/cluster-scope/base/namespaces/opf-argo/kustomization.yaml
@@ -11,3 +11,5 @@ components:
   - ../../../components/project-admin-rolebindings/operate-first
   - ../../../components/monitoring-rbac
   - ../../../components/odh-dashboard
+  - ../../../components/limitranges/default
+  - ../../../components/resourcequotas/x-small

--- a/cluster-scope/base/namespaces/opf-auth/kustomization.yaml
+++ b/cluster-scope/base/namespaces/opf-auth/kustomization.yaml
@@ -9,3 +9,5 @@ resources:
 
 components:
 - ../../../components/project-admin-rolebindings/operate-first
+- ../../../components/limitranges/default
+- ../../../components/resourcequotas/x-small

--- a/cluster-scope/base/namespaces/opf-ci-test-pods/kustomization.yaml
+++ b/cluster-scope/base/namespaces/opf-ci-test-pods/kustomization.yaml
@@ -10,3 +10,5 @@ resources:
 components:
   - ../../../components/project-admin-rolebindings/thoth-devops
   - ../../../components/project-admin-rolebindings/operate-first
+  - ../../../components/limitranges/default
+  - ../../../components/resourcequotas/small

--- a/cluster-scope/base/namespaces/opf-dashboard/kustomization.yaml
+++ b/cluster-scope/base/namespaces/opf-dashboard/kustomization.yaml
@@ -11,3 +11,5 @@ components:
   - ../../../components/project-admin-rolebindings/operate-first
   - ../../../components/monitoring-rbac
   - ../../../components/odh-dashboard
+  - ../../../components/limitranges/default
+  - ../../../components/resourcequotas/x-small

--- a/cluster-scope/base/namespaces/opf-datacatalog/kustomization.yaml
+++ b/cluster-scope/base/namespaces/opf-datacatalog/kustomization.yaml
@@ -11,3 +11,5 @@ components:
   - ../../../components/project-admin-rolebindings/operate-first
   - ../../../components/monitoring-rbac
   - ../../../components/odh-dashboard
+  - ../../../components/limitranges/default
+  - ../../../components/resourcequotas/small

--- a/cluster-scope/base/namespaces/opf-slack-first/kustomization.yaml
+++ b/cluster-scope/base/namespaces/opf-slack-first/kustomization.yaml
@@ -9,3 +9,5 @@ resources:
 
 components:
 - ../../../components/project-admin-rolebindings/operate-first
+- ../../../components/limitranges/default
+- ../../../components/resourcequotas/x-small

--- a/cluster-scope/base/namespaces/opf-superset/kustomization.yaml
+++ b/cluster-scope/base/namespaces/opf-superset/kustomization.yaml
@@ -11,3 +11,5 @@ components:
   - ../../../components/project-admin-rolebindings/operate-first
   - ../../../components/monitoring-rbac
   - ../../../components/odh-dashboard
+  - ../../../components/limitranges/default
+  - ../../../components/resourcequotas/x-small

--- a/cluster-scope/base/namespaces/opf-trino/kustomization.yaml
+++ b/cluster-scope/base/namespaces/opf-trino/kustomization.yaml
@@ -11,3 +11,5 @@ components:
 - ../../../components/project-admin-rolebindings/operate-first
 - ../../../components/monitoring-rbac
 - ../../../components/odh-dashboard
+- ../../../components/limitranges/default
+- ../../../components/resourcequotas/large

--- a/cluster-scope/components/resourcequotas/x-small/kustomization.yaml
+++ b/cluster-scope/components/resourcequotas/x-small/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+- ./resourcequotas.yaml

--- a/cluster-scope/components/resourcequotas/x-small/resourcequotas.yaml
+++ b/cluster-scope/components/resourcequotas/x-small/resourcequotas.yaml
@@ -1,0 +1,11 @@
+kind: ResourceQuota
+apiVersion: v1
+metadata:
+  name: x-small
+spec:
+  hard:
+    requests.cpu: '500m'
+    requests.memory: 2Gi
+    limits.cpu: '500m'
+    limits.memory: 2Gi
+    requests.storage: 10Gi


### PR DESCRIPTION
Adding quotas to most `opf-*` namespaces, the ones currently omitted are: 

- opf-ci-pipelines
- opf-ci-prow
- opf-jupyterhub
- opf-jupyterhub-stage
- opf-kafka
- opf-monitoring
- opf-observatorium

I am open to suggestions if we should add quotas to these namespace, and what they should be set to. 

I have also added a nother tier "x-small" because for some of these, "small" seemed overkill, and I suspect we will see more of such situations. We will need to update the support doc accordingly.