### PR TITLE
Increase kafka pvc to 100Gi

### DIFF
--- a/odh/overlays/moc/zero/kafka/overrides/kafka/base/kafka-cluster.yaml
+++ b/odh/overlays/moc/zero/kafka/overrides/kafka/base/kafka-cluster.yaml
@@ -19,7 +19,7 @@ spec:
       log.message.format.version: "2.4"
     storage:
       type: persistent-claim
-      size: 30Gi
+      size: 100Gi
       deleteClaim: false
     metrics:
       # Inspired by config from Kafka 2.0.0 example rules:


### PR DESCRIPTION
Kafka PVCs are full, increasing them to 100Gi from 30Gi