### PR TITLE
Incrase opf-datacatalog quota to custom quota.

### DIFF
--- a/cluster-scope/base/namespaces/opf-datacatalog/kustomization.yaml
+++ b/cluster-scope/base/namespaces/opf-datacatalog/kustomization.yaml
@@ -1,15 +1,14 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 namespace: opf-datacatalog
 
 resources:
-  - namespace.yaml
+- namespace.yaml
+- ./resourcequota.yaml
 
 components:
-  - ../../../components/project-admin-rolebindings/operate-first
-  - ../../../components/monitoring-rbac
-  - ../../../components/odh-dashboard
-  - ../../../components/limitranges/default
-  - ../../../components/resourcequotas/small
+- ../../../components/project-admin-rolebindings/operate-first
+- ../../../components/monitoring-rbac
+- ../../../components/odh-dashboard
+- ../../../components/limitranges/default

--- a/cluster-scope/base/namespaces/opf-datacatalog/resourcequota.yaml
+++ b/cluster-scope/base/namespaces/opf-datacatalog/resourcequota.yaml
@@ -1,0 +1,11 @@
+kind: ResourceQuota
+apiVersion: v1
+metadata:
+  name: custom
+spec:
+  hard:
+    requests.cpu: '4'
+    requests.memory: 8Gi
+    limits.cpu: '9'
+    limits.memory: 16Gi
+    requests.storage: 20Gi


### PR DESCRIPTION
Spark operator reporting errors with small quota: 

```
pods "spark-operator-7c9964f4fb-k9rmg" is forbidden: exceeded quota: small, requested: limits.cpu=500m,limits.memory=1000Mi,requests.cpu=300m,requests.memory=400Mi, used: limits.cpu=7900m,limits.memory=11864Mi,requests.cpu=1900m,requests.memory=3748Mi, limited: limits.cpu=1,limits.memory=4Gi,requests.cpu=1,requests.memory=4Gi
```