### PR TITLE
Remove unnecessary imgstream fields for jupyter-book.

### DIFF
--- a/odh/base/jupyterhub/notebook-images/jupyterbook-test.yaml
+++ b/odh/base/jupyterhub/notebook-images/jupyterbook-test.yaml
@@ -12,11 +12,9 @@ spec:
     local: true
   tags:
     - name: latest
-      annotations: null
       from:
         kind: DockerImage
         name: 'quay.io/thoth-station/s2i-jupyter-book-notebook:latest'
-      generation: 1
       importPolicy: {}
       referencePolicy:
         type: Local


### PR DESCRIPTION
ArgoCd is not happy with these fields.