### PR TITLE
enable hostpath-provisioner on curator cluster

### DIFF
--- a/cluster-scope/base/hostpathprovisioners/hostpath-provisioner/hostpathprovisioner.yaml
+++ b/cluster-scope/base/hostpathprovisioners/hostpath-provisioner/hostpathprovisioner.yaml
@@ -1,0 +1,9 @@
+apiVersion: hostpathprovisioner.kubevirt.io/v1beta1
+kind: HostPathProvisioner
+metadata:
+  name: hostpath-provisioner
+spec:
+  imagePullPolicy: IfNotPresent
+  pathConfig:
+    path: /var/hpvolumes
+    useNamingPrefix: true

--- a/cluster-scope/base/hostpathprovisioners/hostpath-provisioner/kustomization.yaml
+++ b/cluster-scope/base/hostpathprovisioners/hostpath-provisioner/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- hostpathprovisioner.yaml

--- a/cluster-scope/base/namespaces/hostpath-provisioner/kustomization.yaml
+++ b/cluster-scope/base/namespaces/hostpath-provisioner/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/cluster-scope/base/namespaces/hostpath-provisioner/namespace.yaml
+++ b/cluster-scope/base/namespaces/hostpath-provisioner/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hostpath-provisioner

--- a/cluster-scope/overlays/moc/curator/kustomization.yaml
+++ b/cluster-scope/overlays/moc/curator/kustomization.yaml
@@ -5,10 +5,14 @@ kind: Kustomization
 resources:
   - ../../../base/clusterrolebindings/cluster-admins-rb
   - ../../../base/groups/cluster-admins
+  - ../../../base/hostpathprovisioners/hostpath-provisioner
   - ../../../base/ingresscontrollers/default
+  - ../../../base/namespaces/hostpath-provisioner
+  - ../../../base/namespaces/openshift-cnv
   - ../../../base/namespaces/openshift-storage
   - ../../../base/oauths/cluster
   - ../../../base/operatorgroups/openshift-storage
+  - ../../../base/subscriptions/kubevirt-hyperconverged
   - ../../../base/subscriptions/ocs-operator
   - ../../../base/subscriptions/web-terminal
 
@@ -17,5 +21,6 @@ generators:
 
 patchesStrategicMerge:
   - oauths/cluster_patch.yaml
-  - subscriptions/web-terminal.yaml
+  - subscriptions/kubevirt-hyperconverged_patch.yaml
   - subscriptions/ocs-operator_patch.yaml
+  - subscriptions/web-terminal.yaml

--- a/cluster-scope/overlays/moc/curator/subscriptions/kubevirt-hyperconverged_patch.yaml
+++ b/cluster-scope/overlays/moc/curator/subscriptions/kubevirt-hyperconverged_patch.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+spec:
+  # https://www.openshift.com/blog/whats-new-in-openshift-virtualization-in-ocp-4.7
+  # As of 2021-03-01 there's no docs available for OpenShift Virtualization on Openshift 4.7. Guessing the proper channel from blogpost above.
+  channel: "stable"


### PR DESCRIPTION
install the cnv operator on the curator cluster in order to enable
the hostpathprovisioner for local storage.
