### PR TITLE
Add machineconfig to manage selinux context for /var/hpvolumes

### DIFF
--- a/cluster-scope/base/machineconfigs/hostpath-provisioner-selinux/kustomization.yaml
+++ b/cluster-scope/base/machineconfigs/hostpath-provisioner-selinux/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- machineconfig.yaml

--- a/cluster-scope/base/machineconfigs/hostpath-provisioner-selinux/machineconfig.yaml
+++ b/cluster-scope/base/machineconfigs/hostpath-provisioner-selinux/machineconfig.yaml
@@ -1,0 +1,27 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 50-set-selinux-for-hostpath-provisioner-controller
+  labels:
+    machineconfiguration.openshift.io/role: master
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    systemd:
+      units:
+        - contents: |
+            [Unit]
+            Description=Set SELinux contextx for hostpath provisioner
+            Before=kubelet.service
+
+            [Service]
+            Type=oneshot
+            RemainAfterExit=yes
+            ExecStartPre=-mkdir -p /var/hpvolumes
+            ExecStart=/usr/bin/chcon -Rt container_file_t /var/hpvolumes
+
+            [Install]
+            WantedBy=multi-user.target
+          enabled: true
+          name: hostpath-provisioner-selinux.service

--- a/cluster-scope/overlays/moc/curator/kustomization.yaml
+++ b/cluster-scope/overlays/moc/curator/kustomization.yaml
@@ -26,3 +26,4 @@ patchesStrategicMerge:
   - subscriptions/kubevirt-hyperconverged_patch.yaml
   - subscriptions/ocs-operator_patch.yaml
   - subscriptions/web-terminal.yaml
+  - storageclasses/hostpath-provisioner.yaml

--- a/cluster-scope/overlays/moc/curator/kustomization.yaml
+++ b/cluster-scope/overlays/moc/curator/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../../../base/groups/cluster-admins
   - ../../../base/hostpathprovisioners/hostpath-provisioner
   - ../../../base/ingresscontrollers/default
+  - ../../../base/machineconfigs/hostpath-provisioner-selinux
   - ../../../base/namespaces/hostpath-provisioner
   - ../../../base/namespaces/openshift-cnv
   - ../../../base/namespaces/openshift-storage

--- a/cluster-scope/overlays/moc/curator/storageclasses/hostpath-provisioner.yaml
+++ b/cluster-scope/overlays/moc/curator/storageclasses/hostpath-provisioner.yaml
@@ -1,0 +1,6 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: hostpath-provisioner
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"


### PR DESCRIPTION
Ensure that the directory used by the hostpath-provisioner (a)
exists and (b) has an appropriate selinux context.

Deploying a machineconfig will trigger a rolling reboot of cluster
nodes.
