### PR TITLE
Remove JH dashboard CRs

### DIFF
--- a/odh/base/monitoring/overrides/grafana-operator/overlays/dashboards/jupyterhub-sli-slo.yaml
+++ b/odh/base/monitoring/overrides/grafana-operator/overlays/dashboards/jupyterhub-sli-slo.yaml
@@ -1,8 +1,0 @@
-apiVersion: integreatly.org/v1alpha1
-kind: GrafanaDashboard
-metadata:
-  name: jupyterhub-sli-slo
-  labels:
-    app: grafana
-spec:
-  url: https://raw.githubusercontent.com/operate-first/SRE/master/dashboards/jupyterhub-sli-slo.json

--- a/odh/base/monitoring/overrides/grafana-operator/overlays/dashboards/kustomization.yaml
+++ b/odh/base/monitoring/overrides/grafana-operator/overlays/dashboards/kustomization.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - jupyterhub-sli-slo.yaml

--- a/odh/overlays/moc/zero/monitoring/dashboards/operate-first/jupyterhub-usage.yaml
+++ b/odh/overlays/moc/zero/monitoring/dashboards/operate-first/jupyterhub-usage.yaml
@@ -1,9 +1,0 @@
-apiVersion: integreatly.org/v1alpha1
-kind: GrafanaDashboard
-metadata:
-  labels:
-    app: grafana
-  name: jupyterhub-usage
-spec:
-  customFolderName: Operate-First
-  url: https://raw.githubusercontent.com/operate-first/SRE/master/dashboards/jupyterhub-usage.json

--- a/odh/overlays/moc/zero/monitoring/dashboards/operate-first/kustomization.yaml
+++ b/odh/overlays/moc/zero/monitoring/dashboards/operate-first/kustomization.yaml
@@ -3,5 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - argocd.yaml
-  - jupyterhub-usage.yaml
   - opf-availability.yaml


### PR DESCRIPTION
Since we now have the dashboards available in `ODH v1.0.9` we can remove the old CRs

(related: https://github.com/operate-first/SRE/pull/257)