### PR TITLE
Update Vector Config

### DIFF
--- a/vector/overlays/moc/zero/opf-observatorium/configmap.yaml
+++ b/vector/overlays/moc/zero/opf-observatorium/configmap.yaml
@@ -11,22 +11,33 @@ data:
         type: kafka
         bootstrap_servers: odh-message-bus-kafka-bootstrap.opf-kafka.svc:9092
         group_id: cluster-logs-consumer
-        key_field: message
+        key_field: message_key
         topics:
         - zero-prod.cluster-logs.application
+
+    transforms:
+      loki_parser:
+        type: remap
+        inputs:
+        - opf_kafka_source
+        source: "
+          message = parse_json!(.message) \n
+          .message = message.message \n
+          .docker = message.docker \n
+          .kubernetes = message.kubernetes \n "
+
     sinks:
       opf_loki_sink:
         type: loki
         inputs:
-        - opf_kafka_source
+        - loki_parser
         endpoint: http://opf-observatorium-loki-distributor-http.opf-observatorium.svc:3100
         tenant_id: cluster-app-logs
         encoding:
-          codec: text
-          only_fields:
-            - message
+          codec: json
         healthcheck:
           enabled: true
         labels:
           openshift_cluster: moc/zero
           cluster_log_level: app-logs
+          k8s_namespace_name: "{{ kubernetes.namespace_name }}"


### PR DESCRIPTION
This will format the incoming logs better for Loki consumption and querying.

Incoming kafka message format:
```yaml
{
  "docker": {
    "container_id": "15ca5404857de22c33270c00e7e5e33aee7221aae62b1cfd45521f9d9be8e221"
  },
  "kubernetes": {
    "container_name": "audio-decoder",
    "namespace_name": "fde-audio-decoder-demo",
    "pod_name": "audio-decoder-6cf644b8b6-gzlx5",
    "container_image": "quay.io/xxxx/docker-py-kaldi-asr@sha256:d6a8b45a5c763589a5fb2a8916399036e1e2b0cb90391a6591761e87c13f14bc",
    "container_image_id": "quay.io/xxxxxx/docker-py-kaldi-asr@sha256:d6a8b45a5c763589a5fb2a8916399036e1e2b0cb90391a6591761e87c13f14bc",
    "pod_id": "737eb6dd-4b5e-4ee7-98da-c570051a566a",
    "host": "os-sto-0",
    "master_url": "https://kubernetes.default.svc",
    "namespace_id": "d1df7a09-7d50-47e8-ac5a-326089e55a62",
    "namespace_labels": {
      "app_kubernetes_io/instance": "cluster-resources-zero"
    },
    "flat_labels": [
      "deployment=audio-decoder",
      "pod-template-hash=6cf644b8b6"
    ]
  },
  "message": "  File \"/usr/lib/python3.4/ssl.py\", line 812, in do_handshake",
  "level": "unknown",
  "hostname": "os-sto-0",
  "pipeline_metadata": {
    "collector": {
      "ipaddr4": "192.12.185.130",
      "inputname": "fluent-plugin-systemd",
      "name": "fluentd",
      "received_at": "2021-04-14T12:01:36.538402+00:00",
      "version": "1.7.4 1.6.0"
    }
  },
  "@timestamp": "2021-04-14T11:53:14.506123+00:00",
  "viaq_index_name": "app-write",
  "viaq_msg_id": "YjU4NWVlNmMtZGE3Ni00MDRmLTllZDctOGJmZjJmYWExMzEy"
}
```

Vector Output will look like:
```yaml
{
  "docker.container_id": "0a0464501a0769116d6a49b670c8029a21a4045a8c03f64321996a22dd6c3c9b",
  "kubernetes.container_image": "quay.io/odh-jupyterhub/jupyterhub-img@sha256:8a05e1f7dba3d1a0fac10a931140e81114b352372845ea82ed29fc9aa488574b",
  "kubernetes.container_image_id": "quay.io/odh-jupyterhub/jupyterhub-img@sha256:8a05e1f7dba3d1a0fac10a931140e81114b352372845ea82ed29fc9aa488574b",
  "kubernetes.container_name": "jupyterhub",
  "kubernetes.flat_labels[0]": "app=jupyterhub",
  "kubernetes.flat_labels[1]": "component=web",
  "kubernetes.flat_labels[2]": "deployment=jupyterhub-123",
  "kubernetes.flat_labels[3]": "deploymentconfig=jupyterhub",
  "kubernetes.flat_labels[4]": "component_opendatahub_io/name=jupyterhub",
  "kubernetes.flat_labels[5]": "opendatahub_io/component=true",
  "kubernetes.host": "os-wrk-1",
  "kubernetes.master_url": "https://kubernetes.default.svc",
  "kubernetes.namespace_id": "45bfdb6d-3250-4300-8517-3f87dd2d0f67",
  "kubernetes.namespace_labels.app_kubernetes_io/instance": "cluster-resources-zero",
  "kubernetes.namespace_labels.control-plane": "kubeflow",
  "kubernetes.namespace_labels.katib-metricscollector-injection": "enabled",
  "kubernetes.namespace_name": "opf-jupyterhub",
  "kubernetes.pod_id": "301ee33b-7ed1-408c-9162-628c5d496764",
  "kubernetes.pod_name": "jupyterhub-123-6k6x6",
  "message": "[E 2021-04-16 18:06:15.094 JupyterHub log:181] 503 GET /hub/user/xxxx@xxxx.com/api/metrics/v1?1618596375034 (xxxx@xxxx.com@::ffff:10.130.6.1) 5.35ms",
  "source_type": "kafka"
}
# New Query-able labels added
cluster_log_level: "app-logs"
k8s_namespace_name: "opf-jupyterhub"
openshift_cluster: "moc/zero"
```