### PR TITLE
Update Strimzi Kafka CRs to kafka.strimzi.io/v1beta2

### DIFF
--- a/odh-manifests/kafka/base/kafka-cluster.yaml
+++ b/odh-manifests/kafka/base/kafka-cluster.yaml
@@ -1,156 +1,53 @@
 ---
-apiVersion: kafka.strimzi.io/v1alpha1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: odh-message-bus
 spec:
   kafka:
-    version: "2.4.0"
+    version: 2.7.0
     replicas: 3
     listeners:
-      plain: {}
-      tls: {}
-      external:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+      - name: external
+        port: 9094
         type: route
+        tls: true
     config:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 3
-      log.message.format.version: "2.4"
+      log.message.format.version: '2.7'
+      inter.broker.protocol.version: '2.7'
     storage:
       type: persistent-claim
       size: 200Gi
       deleteClaim: false
-    metrics:
-      # Inspired by config from Kafka 2.0.0 example rules:
-      # https://github.com/prometheus/jmx_exporter/blob/master/example_configs/kafka-2_0_0.yml
-      lowercaseOutputName: true
-      rules:
-      # Special cases and very specific rules
-      - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value
-        name: kafka_server_$1_$2
-        type: GAUGE
-        labels:
-          clientId: "$3"
-          topic: "$4"
-          partition: "$5"
-      - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>Value
-        name: kafka_server_$1_$2
-        type: GAUGE
-        labels:
-          clientId: "$3"
-          broker: "$4:$5"
-      # Some percent metrics use MeanRate attribute
-      # Ex) kafka.server<type=(KafkaRequestHandlerPool), name=(RequestHandlerAvgIdlePercent)><>MeanRate
-      - pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*><>MeanRate
-        name: kafka_$1_$2_$3_percent
-        type: GAUGE
-      # Generic gauges for percents
-      - pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*><>Value
-        name: kafka_$1_$2_$3_percent
-        type: GAUGE
-      - pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*, (.+)=(.+)><>Value
-        name: kafka_$1_$2_$3_percent
-        type: GAUGE
-        labels:
-          "$4": "$5"
-      # Generic per-second counters with 0-2 key/value pairs
-      - pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+), (.+)=(.+)><>Count
-        name: kafka_$1_$2_$3_total
-        type: COUNTER
-        labels:
-          "$4": "$5"
-          "$6": "$7"
-      - pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+)><>Count
-        name: kafka_$1_$2_$3_total
-        type: COUNTER
-        labels:
-          "$4": "$5"
-      - pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*><>Count
-        name: kafka_$1_$2_$3_total
-        type: COUNTER
-      # Generic gauges with 0-2 key/value pairs
-      - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Value
-        name: kafka_$1_$2_$3
-        type: GAUGE
-        labels:
-          "$4": "$5"
-          "$6": "$7"
-      - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Value
-        name: kafka_$1_$2_$3
-        type: GAUGE
-        labels:
-          "$4": "$5"
-      - pattern: kafka.(\w+)<type=(.+), name=(.+)><>Value
-        name: kafka_$1_$2_$3
-        type: GAUGE
-      # Emulate Prometheus 'Summary' metrics for the exported 'Histogram's.
-      # Note that these are missing the '_sum' metric!
-      - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Count
-        name: kafka_$1_$2_$3_count
-        type: COUNTER
-        labels:
-          "$4": "$5"
-          "$6": "$7"
-      - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*), (.+)=(.+)><>(\d+)thPercentile
-        name: kafka_$1_$2_$3
-        type: GAUGE
-        labels:
-          "$4": "$5"
-          "$6": "$7"
-          quantile: "0.$8"
-      - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Count
-        name: kafka_$1_$2_$3_count
-        type: COUNTER
-        labels:
-          "$4": "$5"
-      - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*)><>(\d+)thPercentile
-        name: kafka_$1_$2_$3
-        type: GAUGE
-        labels:
-          "$4": "$5"
-          quantile: "0.$6"
-      - pattern: kafka.(\w+)<type=(.+), name=(.+)><>Count
-        name: kafka_$1_$2_$3_count
-        type: COUNTER
-      - pattern: kafka.(\w+)<type=(.+), name=(.+)><>(\d+)thPercentile
-        name: kafka_$1_$2_$3
-        type: GAUGE
-        labels:
-          quantile: "0.$4"
+    metricsConfig:
+      type: jmxPrometheusExporter
+      valueFrom:
+        configMapKeyRef:
+          name: kafka-metrics-config
+          key: kafka-prometheus-metrics
   zookeeper:
     replicas: 3
     storage:
       type: persistent-claim
       size: 10Gi
       deleteClaim: false
-    metrics:
-      # Inspired by Zookeeper rules
-      # https://github.com/prometheus/jmx_exporter/blob/master/example_configs/zookeeper.yaml
-      lowercaseOutputName: true
-      rules:
-      # replicated Zookeeper
-      - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+)><>(\\w+)"
-        name: "zookeeper_$2"
-      - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+)><>(\\w+)"
-        name: "zookeeper_$3"
-        labels:
-          replicaId: "$2"
-      - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+)><>(\\w+)"
-        name: "zookeeper_$4"
-        labels:
-          replicaId: "$2"
-          memberType: "$3"
-      - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+), name3=(\\w+)><>(\\w+)"
-        name: "zookeeper_$4_$5"
-        labels:
-          replicaId: "$2"
-          memberType: "$3"
-      # standalone Zookeeper
-      - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port(\\d+)><>(\\w+)"
-        name: "zookeeper_$2"
-      - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port(\\d+), name1=(InMemoryDataTree)><>(\\w+)"
-        name: "zookeeper_$2_$3"
+    metricsConfig:
+      type: jmxPrometheusExporter
+      valueFrom:
+        configMapKeyRef:
+          name: kafka-metrics-config
+          key: zookeeper-prometheus-metrics
   entityOperator:
     topicOperator: {}
     userOperator: {}

--- a/odh-manifests/kafka/overlays/topics/audio-decoder-decoded-speech.yaml
+++ b/odh-manifests/kafka/overlays/topics/audio-decoder-decoded-speech.yaml
@@ -1,5 +1,5 @@
 # audio-decoder-decoded-speech.yaml
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: audio-decoder.decoded-speech

--- a/odh-manifests/kafka/overlays/topics/audio-decoder-sentiment-text.yaml
+++ b/odh-manifests/kafka/overlays/topics/audio-decoder-sentiment-text.yaml
@@ -1,5 +1,5 @@
 # audio-decoder-sentiment-text.yaml
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: audio-decoder.sentiment-text

--- a/odh-manifests/kafka/overlays/topics/thoth-advise-justification.yaml
+++ b/odh-manifests/kafka/overlays/topics/thoth-advise-justification.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: zero-prod.thoth.advise-reporter.advise-justification

--- a/odh-manifests/kafka/overlays/topics/thoth-adviser-re-run.yaml
+++ b/odh-manifests/kafka/overlays/topics/thoth-adviser-re-run.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: zero-prod.thoth.investigator.adviser-re-run

--- a/odh-manifests/kafka/overlays/topics/thoth-adviser-trigger.yaml
+++ b/odh-manifests/kafka/overlays/topics/thoth-adviser-trigger.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: zero-prod.thoth.adviser-trigger

--- a/odh-manifests/kafka/overlays/topics/thoth-hash-mismatch.yaml
+++ b/odh-manifests/kafka/overlays/topics/thoth-hash-mismatch.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: zero-prod.thoth.package-update.hash-mismatch

--- a/odh-manifests/kafka/overlays/topics/thoth-kebechet-trigger.yaml
+++ b/odh-manifests/kafka/overlays/topics/thoth-kebechet-trigger.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: zero-prod.thoth.kebechet-trigger

--- a/odh-manifests/kafka/overlays/topics/thoth-missing-package-version.yaml
+++ b/odh-manifests/kafka/overlays/topics/thoth-missing-package-version.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: zero-prod.thoth.package-update.missing-package-version

--- a/odh-manifests/kafka/overlays/topics/thoth-missing-package.yaml
+++ b/odh-manifests/kafka/overlays/topics/thoth-missing-package.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: zero-prod.thoth.package-update.missing-package

--- a/odh-manifests/kafka/overlays/topics/thoth-package-extract-trigger.yaml
+++ b/odh-manifests/kafka/overlays/topics/thoth-package-extract-trigger.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: zero-prod.thoth.package-extract-trigger

--- a/odh-manifests/kafka/overlays/topics/thoth-package-released.yaml
+++ b/odh-manifests/kafka/overlays/topics/thoth-package-released.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: zero-prod.thoth.package-release.package-released

--- a/odh-manifests/kafka/overlays/topics/thoth-provenance-checker-trigger.yaml
+++ b/odh-manifests/kafka/overlays/topics/thoth-provenance-checker-trigger.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: zero-prod.thoth.provenance-checker-trigger

--- a/odh-manifests/kafka/overlays/topics/thoth-qebhwt-trigger.yaml
+++ b/odh-manifests/kafka/overlays/topics/thoth-qebhwt-trigger.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: zero-prod.thoth.qebhwt-trigger

--- a/odh-manifests/kafka/overlays/topics/thoth-si-unanalyzed-package.yaml
+++ b/odh-manifests/kafka/overlays/topics/thoth-si-unanalyzed-package.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: zero-prod.thoth.investigator.si-unanalyzed-package

--- a/odh-manifests/kafka/overlays/topics/thoth-solved-package.yaml
+++ b/odh-manifests/kafka/overlays/topics/thoth-solved-package.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: zero-prod.thoth.solver.solved-package

--- a/odh-manifests/kafka/overlays/topics/thoth-unresolved-package.yaml
+++ b/odh-manifests/kafka/overlays/topics/thoth-unresolved-package.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: zero-prod.thoth.investigator.unresolved-package

--- a/odh-manifests/kafka/overlays/topics/thoth-unrevsolved-package.yaml
+++ b/odh-manifests/kafka/overlays/topics/thoth-unrevsolved-package.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: zero-prod.thoth.investigator.unrevsolved-package

--- a/odh-manifests/kafka/overlays/topics/thoth-update-provides-source-distro.yaml
+++ b/odh-manifests/kafka/overlays/topics/thoth-update-provides-source-distro.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: zero-prod.thoth.update-provides-source-distro

--- a/odh-manifests/kafka/overlays/topics/zero-cluster-app-logs.yaml
+++ b/odh-manifests/kafka/overlays/topics/zero-cluster-app-logs.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   name: zero-prod.cluster-logs.application


### PR DESCRIPTION
Since the Strimzi Kafka Operator will be updated in the upcoming z-stream release for ODH, we need to update the CRs to the new version as well .

Related https://github.com/opendatahub-io/odh-manifests/pull/405
Closes https://github.com/operate-first/apps/issues/552
