### PR TITLE
fix: Turn subscriptions in openshift-operators to automatic

### DIFF
--- a/cluster-scope/base/subscriptions/openshift-pipelines-operator-rh/subscription.yaml
+++ b/cluster-scope/base/subscriptions/openshift-pipelines-operator-rh/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: openshift-pipelines-operator-rh
 spec:
   channel: DEFINED_IN_OVERLAY
-  installPlanApproval: Manual
+  installPlanApproval: Automatic
   name: openshift-pipelines-operator-rh
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/subscriptions/web-terminal/subscription.yaml
+++ b/cluster-scope/base/subscriptions/web-terminal/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: web-terminal
 spec:
   channel: DEFINED_IN_OVERLAY
-  installPlanApproval: Manual
+  installPlanApproval: Automatic
   name: web-terminal
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
`Manual` install plan strategy is messing with other operators with automated install plans installed to the same namespace.

`Automatic` strategy is respected only if all operators use it. Otherwise it acts as manual.

This is causing troubles updating Strimzi provided via ODH as `Automatic`.  

![image (3)](https://user-images.githubusercontent.com/7453394/115885893-af47f680-a450-11eb-831e-fcce90afa438.png)