### PR TITLE
fix: Argo CD image replacement and kustomize flag

### DIFF
--- a/argocd/base/kustomization.yaml
+++ b/argocd/base/kustomization.yaml
@@ -11,7 +11,7 @@ patchesStrategicMerge:
 - deployments/argocd-server_patch.yaml
 - deployments/argocd-dex-server_patch.yaml
 images:
-- name: argoproj/argocd
+- name: quay.io/argoproj/argocd
   newName: quay.io/operate-first/argocd
   newTag: v2.0.1-1
 - name: redis

--- a/argocd/overlays/dev/configs/argo_cm/envs
+++ b/argocd/overlays/dev/configs/argo_cm/envs
@@ -1,4 +1,4 @@
 admin.enabled=true
-kustomize.buildOptions=--enable_alpha_plugins
+kustomize.buildOptions=--enable-alpha-plugins
 url=ARGOCD_ROUTE
 users.anonymous.enabled=true

--- a/argocd/overlays/moc-infra/configs/argo_cm/envs
+++ b/argocd/overlays/moc-infra/configs/argo_cm/envs
@@ -1,4 +1,4 @@
 admin.enabled=true
-kustomize.buildOptions=--enable_alpha_plugins
+kustomize.buildOptions=--enable-alpha-plugins
 url=https://argocd.operate-first.cloud
 users.anonymous.enabled=true


### PR DESCRIPTION
ArgoCD switched default images to quay from dockerhub - our `kustomization.yaml` failed to replace it

Additionally new kustomize uses `--enable-alpha-plugins` flag now