### PR TITLE
Add explicit allow list for cluster management argocd proj.

### DIFF
--- a/argocd/overlays/moc-infra/projects/cluster-management.yaml
+++ b/argocd/overlays/moc-infra/projects/cluster-management.yaml
@@ -8,3 +8,6 @@ spec:
     server: '*'
   sourceRepos:
   - '*'
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'


### PR DESCRIPTION
As per argocd 1.8.7 notes: 

```
This release fixed a regression regarding which cluster resources are permitted on the AppProject level. Previous to this fix, after #3960 has been merged, all cluster resources were allowed on project level when neither of the allow or deny lists was defined. However, the correct behavior is to block all resources in this case.

If you have Projects with empty allow and deny lists, but want the associated applications be able to sync cluster resources, you will have to adapt your cluster resources allow lists to explicitly allow the resources.
```