### PR TITLE
fix: ArgoCD Cluster resource for Kubeflow

### DIFF
--- a/argocd/overlays/moc-infra/projects/operate-first.yaml
+++ b/argocd/overlays/moc-infra/projects/operate-first.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     project-template: global
 spec:
+  clusterResourceWhitelist:
+    - group: kubeflow.org
+      kind: Profile
   destinations:
     - namespace: 'opf-*'
       server: 'https://api.moc-infra.massopen.cloud:6443'


### PR DESCRIPTION
SSIA, similar to: https://github.com/operate-first/apps/pull/563
Part of https://github.com/operate-first/SRE/issues/267