### PR TITLE
Enable monitoring on a namespace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ---
-exclude: scripts/onboarding.sh|argocd/overlays/dev/configs|argocd/overlays/moc-infra/configs
+exclude: scripts|argocd/overlays/dev/configs|argocd/overlays/moc-infra/configs
 
 repos:
   - repo: git://github.com/Lucas-C/pre-commit-hooks

--- a/docs/odh/prometheus/add_service_monitoring.md
+++ b/docs/odh/prometheus/add_service_monitoring.md
@@ -18,14 +18,13 @@ Please fork/clone the [operate-first/apps](https://github.com/operate-first/apps
 
 ### Steps:
 
-1. Add the following lines to each namespace's `kustomization.yaml` to enable rbac for each namespace:
+1. Run the following script to enable rbac for a namespace:
 
   ```
-  components:
-    - ../../../components/monitoring-rbac
+  bash scripts/enable-monitoring.sh NAMESPACE
   ```
 
-  These will be located under `apps/cluster-scope/base/namespaces/${NAMESPACE}/kustomization.yaml`.
+  This script will add a line that contains the 'monitoring-rbac' component to the components field in the kustomization.yaml of the given namespace.
 
 2. Add the service monitor filling out the details below accordingly:
 

--- a/scripts/enable-monitoring.sh
+++ b/scripts/enable-monitoring.sh
@@ -1,0 +1,28 @@
+ #!/bin/sh
+
+set -o errexit
+trap 'echo "Aborting due to errexit on line $LINENO. Exit code: $?" >&2' ERR
+set -o errtrace
+set -o pipefail
+
+if [ $# -ne 1 ] || [ "$#" == "--help" ] || [ "$#" == "-h" ]; then
+    echo "Enable monitoring on a namespace"
+    echo -e "\nUsage: $0 NAMESPACE\n"
+    exit 0
+fi
+
+APP_NAME="cluster-scope"
+NAMESPACE=$1
+
+add_rbac_component() {
+	pushd $APP_NAME/base/namespaces/$NAMESPACE > /dev/null
+	kustomize edit add component ../../../components/monitoring-rbac
+	popd > /dev/null
+}
+
+if [ ! -d $APP_NAME/base/namespaces/$NAMESPACE ]; then
+	echo "Namespace '$NAMESPACE' does not exist in $APP_NAME/base/namespace/. Exiting."
+	exit 1
+fi
+
+add_rbac_component


### PR DESCRIPTION
Part of: [operate-first/SRE#216](https://github.com/operate-first/SRE/issues/216 )
fix: https://github.com/operate-first/SRE/issues/277 

The script accepts a namespace and applies '- ../../../components/monitoring-rbac' line to 'components' field with a kustomize cli.

On success print nothing, and on failure print relevant error from kustomize cli. 

Notice that kustomize editing the file and uses specific annotation while listing the components, the '-' is at the first char and not the second on each line.