### PR TITLE
Add grafana proxy route

### DIFF
--- a/odh-manifests/grafana/grafana/base/grafana.yaml
+++ b/odh-manifests/grafana/grafana/base/grafana.yaml
@@ -57,9 +57,7 @@ spec:
             name: secret-grafana-tls
             readOnly: false
     ingress:
-        enabled: true
-        targetPort: oauth-proxy
-        termination: reencrypt
+        enabled: false
     secrets:
     - grafana-tls
     service:
@@ -72,4 +70,4 @@ spec:
             targetPort: oauth-proxy
     serviceAccount:
         annotations:
-            serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana-route"}}'
+            serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana"}}'

--- a/odh-manifests/grafana/grafana/base/route.yaml
+++ b/odh-manifests/grafana/grafana/base/route.yaml
@@ -1,0 +1,15 @@
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: grafana
+spec:
+  host: grafana-route-opf-monitoring.apps.zero.massopen.cloud
+  to:
+    kind: Service
+    name: grafana-service
+  port:
+    targetPort: oauth-proxy
+  tls:
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION
Resolves https://github.com/operate-first/support/issues/218

I tried creating a route named `grafana-route` but grafana-operator kept deleting it.
And I did not want to change the grafana url in the docs everywhere so I manually set the host in the route spec to the old host.