### PR TITLE
fix: Ommit version for HyperConverged

### DIFF
--- a/kubevirt-hyperconverged/base/hyperconverged.yaml
+++ b/kubevirt-hyperconverged/base/hyperconverged.yaml
@@ -7,4 +7,3 @@ metadata:
   namespace: openshift-cnv
 spec:
   bareMetalPlatform: true
-  version: v2.5.4


### PR DESCRIPTION
`version` is managed by the operator, causing ArgoCD and Openshift Virtualization operator to fight. This PR should leave the version string to be managed by the operator only.

![image](https://user-images.githubusercontent.com/7453394/116517656-8e0f5c00-a8cf-11eb-86b9-832c1738b493.png)