### PR TITLE
Add ClusterRole/Binding to enable Opf prometheus oauth token review

### DIFF
--- a/cluster-scope/base/clusterrolebindings/oauth-token-access-review/clusterrolebinding.yaml
+++ b/cluster-scope/base/clusterrolebindings/oauth-token-access-review/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: oauth-token-access-review
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: oauth-token-access-review
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: opf-monitoring

--- a/cluster-scope/base/clusterrolebindings/oauth-token-access-review/kustomization.yaml
+++ b/cluster-scope/base/clusterrolebindings/oauth-token-access-review/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/clusterroles/oauth-token-access-review/clusterrole.yaml
+++ b/cluster-scope/base/clusterroles/oauth-token-access-review/clusterrole.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: oauth-token-access-review
+rules:
+- verbs:
+    - create
+  apiGroups:
+    - authentication.k8s.io
+  resources:
+    - tokenreviews
+- verbs:
+    - create
+  apiGroups:
+    - authorization.k8s.io
+  resources:
+    - subjectaccessreviews

--- a/cluster-scope/base/clusterroles/oauth-token-access-review/kustomization.yaml
+++ b/cluster-scope/base/clusterroles/oauth-token-access-review/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - clusterrole.yaml

--- a/cluster-scope/overlays/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/moc/zero/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../../../base/clusterroles/metallb-system-controller
   - ../../../base/clusterroles/metallb-system-speaker
   - ../../../base/clusterroles/metrics
+  - ../../../base/clusterroles/oauth-token-access-review
   - ../../../base/clusterroles/observatorium-operator
   - ../../../base/clusterroles/opendatahub-operator
   - ../../../base/clusterroles/prow-aggregate-to-admin
@@ -21,6 +22,7 @@ resources:
   - ../../../base/clusterrolebindings/metallb-system-controller
   - ../../../base/clusterrolebindings/metallb-system-speaker
   - ../../../base/clusterrolebindings/metrics
+  - ../../../base/clusterrolebindings/oauth-token-access-review
   - ../../../base/clusterrolebindings/observatorium-operator
   - ../../../base/clusterrolebindings/opendatahub-operator
   - ../../../base/clusterrolebindings/opf-cluster-metrics-federation

--- a/odh-manifests/prometheus/operator/base/prometheus.yaml
+++ b/odh-manifests/prometheus/operator/base/prometheus.yaml
@@ -56,6 +56,8 @@ spec:
       - -skip-auth-regex=^/metrics
       - '-openshift-sar={"resource": "namespaces", "verb": "get", "resourceName":
           "opf-monitoring", "namespace": "opf-monitoring"}'
+      - '-openshift-delegate-urls={"/":{"resource": "namespaces", "verb": "get", "resourceName":
+          "opf-monitoring", "namespace": "opf-monitoring"}'
       image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.7
       name: oauth-proxy
       ports:


### PR DESCRIPTION
The current Prometheus proxy does not allow access to the Prometheus API because the Proxy does not have permissions to check the validity of oauth tokens.
This will give the `prometheus-k8s` serviceaccount in `opf-monitoring` namespace permissions to review oauth tokens.