### PR TITLE
fix typo in metallb configuration

### DIFF
--- a/metallb/overlays/moc/zero/config.yaml
+++ b/metallb/overlays/moc/zero/config.yaml
@@ -2,4 +2,4 @@ address-pools:
   - name: default
     protocol: layer2
     addresses:
-      - 192.12.185.32-192.12.175.63
+      - 192.12.185.32-192.12.185.63


### PR DESCRIPTION
There was a typo in the metallb configuration that rendered the
default address range invalid.
