### PR TITLE
Rename endpoint.name to endpoint.port for apicurio-monitor.

### DIFF
--- a/kfdefs/overlays/moc/zero/opf-monitoring/servicemonitors/apicurio-registry-servicemonitor.yaml
+++ b/kfdefs/overlays/moc/zero/opf-monitoring/servicemonitors/apicurio-registry-servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   endpoints:
     - targetPort: web          # apicurio
-    - name: http               # limitador
+    - port: http               # limitador
     - targetPort: envoy-http   # envoy
     - targetPort: redis        # redis
   namespaceSelector:


### PR DESCRIPTION
`name` is not a valid field in `v1.ServiceMonitor.spec.endpoints`, I think `port` was intended here.