### PR TITLE
Add network interfaces for access to nfs server

### DIFF
--- a/cluster-scope/overlays/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/moc/zero/kustomization.yaml
@@ -131,6 +131,7 @@ resources:
   - ../../../base/subscriptions/serverless-operator
   - ../../../base/subscriptions/web-terminal
   - clusterversion.yaml
+  - nodenetworkconfigurationpolicies/moc-nfs-network.yaml
 
 generators:
   - secret-generator.yaml

--- a/cluster-scope/overlays/moc/zero/nodenetworkconfigurationpolicies/moc-nfs-network.yaml
+++ b/cluster-scope/overlays/moc/zero/nodenetworkconfigurationpolicies/moc-nfs-network.yaml
@@ -1,0 +1,59 @@
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: moc-nfs-network-enp4s0f1np1
+spec:
+  nodeSelector:
+    moc/primary-interface: enp4s0f1np1
+  desiredState:
+    interfaces:
+      - name: enp4s0f1np1.210
+        description: zero cluster provisioning network
+        type: vlan
+        state: up
+        vlan:
+          base-iface: enp4s0f1np1
+          id: 210
+        ipv4:
+          enabled: true
+          dhcp: true
+---
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: moc-nfs-network-enp4s0f1
+spec:
+  nodeSelector:
+    moc/primary-interface: enp4s0f1
+  desiredState:
+    interfaces:
+      - name: enp4s0f1.210
+        description: zero cluster provisioning network
+        type: vlan
+        state: up
+        vlan:
+          base-iface: enp4s0f1
+          id: 210
+        ipv4:
+          enabled: true
+          dhcp: true
+---
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: moc-nfs-network-eno2
+spec:
+  nodeSelector:
+    moc/primary-interface: eno2
+  desiredState:
+    interfaces:
+      - name: eno2.210
+        description: zero cluster provisioning network
+        type: vlan
+        state: up
+        vlan:
+          base-iface: eno2
+          id: 210
+        ipv4:
+          enabled: true
+          dhcp: true


### PR DESCRIPTION
Add network interfaces for access to nfs server

This adds vlan interfaces to provide access to an nfs server for
additional storage. We use node labels to select the appropriate
interface for a given node.
