### PR TITLE
enable thoth-devops group to view the opf-monitoring grafana dashboard

### DIFF
--- a/kfdefs/overlays/moc/zero/opf-monitoring/rolebindings/opf-monitoring-view.yaml
+++ b/kfdefs/overlays/moc/zero/opf-monitoring/rolebindings/opf-monitoring-view.yaml
@@ -11,3 +11,6 @@ subjects:
   - kind: ServiceAccount
     name: grafana-datasource
     namespace: opf-monitoring
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: thoth-devops


### PR DESCRIPTION
enable thoth-devops group to view the opf-monitoring grafana dashboard
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>