### PR TITLE
Change quarkus-extension-registry quota to large

### DIFF
--- a/cluster-scope/base/namespaces/quarkus-extension-registry/kustomization.yaml
+++ b/cluster-scope/base/namespaces/quarkus-extension-registry/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 components:
 - ../../../components/project-admin-rolebindings/quarkus
 - ../../../components/limitranges/default
-- ../../../components/resourcequotas/medium
+- ../../../components/resourcequotas/large


### PR DESCRIPTION
I need more resources to deploy more pods and support the PostgreSQL DB