### PR TITLE
fix openshift-cnv namespace

### DIFF
--- a/cluster-scope/base/namespaces/openshift-cnv/namespace.yaml
+++ b/cluster-scope/base/namespaces/openshift-cnv/namespace.yaml
@@ -7,5 +7,5 @@ metadata:
     openshift.io/requester: operate-first
   labels:
     openshift.io/cluster-monitoring: "true"
-  name: openshift-storage
+  name: openshift-cnv
 spec: {}


### PR DESCRIPTION
the openshift-cnv namespace.yaml had an incorrect namespace name
