### PR TITLE
Add jupyterhub-idle-culler 

### DIFF
--- a/jupyterhub-idle-culler/base/buildconfig.yaml
+++ b/jupyterhub-idle-culler/base/buildconfig.yaml
@@ -3,15 +3,15 @@ apiVersion: build.openshift.io/v1
 metadata:
   name: jupyterhub-idle-culler
 spec:
-    source:
-      dockerfile: |
-        FROM quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.27.0
-        RUN pip install jupyterhub-idle-culler==1.1 pycurl==7.43.0.6
-    strategy:
-      dockerStrategy: {}
-    output:
-      to:
-        kind: ImageStreamTag
-        name: jupyterhub-idle-culler:latest
-    triggers:
-    - type: ConfigChange
+  source:
+    dockerfile: |
+      FROM quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.27.0
+      RUN pip install jupyterhub-idle-culler==1.1 pycurl==7.43.0.6
+  strategy:
+    dockerStrategy: {}
+  output:
+    to:
+      kind: ImageStreamTag
+      name: jupyterhub-idle-culler:latest
+  triggers:
+  - type: ConfigChange

--- a/jupyterhub-idle-culler/base/buildconfig.yaml
+++ b/jupyterhub-idle-culler/base/buildconfig.yaml
@@ -1,0 +1,17 @@
+kind: BuildConfig
+apiVersion: build.openshift.io/v1
+metadata:
+  name: jupyterhub-idle-culler
+spec:
+    source:
+      dockerfile: |
+        FROM quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.27.0
+        RUN pip install jupyterhub-idle-culler==1.1 pycurl==7.43.0.6
+    strategy:
+      dockerStrategy: {}
+    output:
+      to:
+        kind: ImageStreamTag
+        name: jupyterhub-idle-culler:latest
+    triggers:
+    - type: ConfigChange

--- a/jupyterhub-idle-culler/base/deploymentconfig.yaml
+++ b/jupyterhub-idle-culler/base/deploymentconfig.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: jupyterhub-idle-culler
+spec:
+  selector:
+    app: jupyterhub-idle-culler
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: jupyterhub-idle-culler
+    spec:
+      containers:
+        - name: jupyterhub-idle-culler
+          image: jupyterhub-idle-culler:latest
+          env:
+            - name: JUPYTERHUB_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: jupyterhub-api-token
+                  key: token
+          ports:
+            - containerPort: 8080
+          command:
+            - jupyterhub-idle-culler
+            - --timeout=120
+            - --url=<some-url>
+  triggers:
+    - type: ConfigChange
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+        containerNames:
+          - jupyterhub-idle-culler
+        from:
+          kind: ImageStreamTag
+          name: jupyterhub-idle-culler:latest

--- a/jupyterhub-idle-culler/base/imagestream.yaml
+++ b/jupyterhub-idle-culler/base/imagestream.yaml
@@ -1,0 +1,7 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: jupyterhub-idle-culler
+spec:
+  lookupPolicy:
+    local: true

--- a/jupyterhub-idle-culler/base/kustomization.yaml
+++ b/jupyterhub-idle-culler/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- buildconfig.yaml
+- deploymentconfig.yaml
+- imagestream.yaml

--- a/jupyterhub-idle-culler/overlays/moc/zero/.sops.yaml
+++ b/jupyterhub-idle-culler/overlays/moc/zero/.sops.yaml
@@ -1,0 +1,3 @@
+creation_rules:
+  - encrypted_regex: "^data|stringData$"
+    pgp: "0508677DD04952D06A943D5B4DC4116D360E3276"

--- a/jupyterhub-idle-culler/overlays/moc/zero/deploymentconfig_patch.yaml
+++ b/jupyterhub-idle-culler/overlays/moc/zero/deploymentconfig_patch.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: jupyterhub-idle-culler
+spec:
+  selector:
+    app: jupyterhub-idle-culler
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: jupyterhub-idle-culler
+    spec:
+      containers:
+        - name: jupyterhub-idle-culler
+          command:
+            - jupyterhub-idle-culler
+            - --timeout=259200  # 3 days
+            - --url=https://jupyterhub-opf-jupyterhub.apps.zero.massopen.cloud/hub/api

--- a/jupyterhub-idle-culler/overlays/moc/zero/kustomization.yaml
+++ b/jupyterhub-idle-culler/overlays/moc/zero/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../../base/
-namespace: opf-jupyterhub-idle-culler
+namespace: opf-jupyterhub
 commonLabels:
   app: jupyterhub-idle-culler
 generators:

--- a/jupyterhub-idle-culler/overlays/moc/zero/kustomization.yaml
+++ b/jupyterhub-idle-culler/overlays/moc/zero/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../base/
+namespace: opf-jupyterhub-idle-culler
+commonLabels:
+  app: jupyterhub-idle-culler
+generators:
+  - secrets/secret-generator.yaml
+patchesStrategicMerge:
+  - deploymentconfig_patch.yaml

--- a/jupyterhub-idle-culler/overlays/moc/zero/secrets/secret-generator.yaml
+++ b/jupyterhub-idle-culler/overlays/moc/zero/secrets/secret-generator.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: secret-generator
+files:
+  - secrets/secret.enc.yaml

--- a/jupyterhub-idle-culler/overlays/moc/zero/secrets/secret.enc.yaml
+++ b/jupyterhub-idle-culler/overlays/moc/zero/secrets/secret.enc.yaml
@@ -1,0 +1,37 @@
+kind: Secret
+apiVersion: v1
+metadata:
+    name: jupyterhub-api-token
+stringData:
+    token: ENC[AES256_GCM,data:VVcy1oZ11rNL7ObRdE9m8Q1SVLfbOShS9rm9YdSTrKo=,iv:4aLnvKBGoUuZySuC8RGCf80bHCc8z5yRT2CCTwbOLfg=,tag:lYeA85XwzCXKX+8pLaxN4Q==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-05-08T00:21:20Z'
+    mac: ENC[AES256_GCM,data:QMndyToB73TV1qrMr+2Tj6yz+uirC3iJEGVInzWwHT3imUq7Sx1rhVr5AjK2e4c5sLb92qWBWMcBSuoretlg2o7PCBEQhSg3aBsCVc4bL7TxJd1YgiDdwyMVcbyy/NcUEd2Er1JtZHMvlCG1hFQNDEWVKPj4a4grqqnlq/oTBkE=,iv:Fq2/D82TE06P+a887Tk0aHvkSDPPJEP+jadNUwbdZJU=,tag:e+q8oed+Qx4flct5o+XO3Q==,type:str]
+    pgp:
+    -   created_at: '2021-05-08T00:21:20Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA9aKBcudqifiARAAU2kARhzHFjAomp8isMgA2Edwh9qoQW8knnNcC3S5Gcru
+            xnRfXDLNpJYmCOecIziunTBwrfmLOQLI5J+RbL01q6zyUMqTwo2oBEBJnVhvvc+W
+            JKS9NJW5uJpzqKDT3I6nYUX+oPveDpBBNuzC1bz2Lc2tITLJURI/1N8f+qCmGZMd
+            rvQYIsNWFmM2bp0nb+hQhG0+qIGuQOZUSJmTwUfvQW6Ct8mQp8tOyoLMWJTCU4yI
+            5ysPypWtxEMWO89YEnskTrCjfPVMBJO46Igt6rimf3TTKvPiHUg5r7k9DAteh3VS
+            oIY0x44nVN2FkoYVC4RZioYGjlzG/HPC88POzMTChrwIWBkZqq2Ap7OpF575jXvj
+            IKTkRKj6XLuXQ821GfTouVx1WMG82f9O01VlmDs46vXs9rHDeIv27EjTUYka/nO/
+            bLMc/IO5YK1dUxqUrNqO2h9t148HqvqUSy0KMiWJ0r9qo3WRDocCSJx1IemPNlmV
+            xbOsp+qRZjJIWDfYxAjPiliAFrRMEC0QO9lNg0G3tqvRuqEgLWaUxE2bEFk/M0oQ
+            XDry14G4Bb/7XQMPyZ79STAUwE6EK73iHVLEG7guPmnDtyR2kLslYEWl/MVlF2kT
+            gWctfvIUZnlwj9OauTGYgtiQtIqHe1JihK7NNQpvnNpCgQNhpyZZgBsclmvIgnrS
+            4AHkohwayfpbEzN4SwM4KtLi/+FhQOCh4ILhk4rgiuLI5mu14FblK9FYKqbA+Do8
+            ZzH0mrZkd1gChTC9Xq7ezmtbSjEvK3fgl+SiB2cAh843i1Fc/1QI3czT4qlnbWPh
+            MpQA
+            =dBq/
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^data|stringData$
+    version: 3.6.1


### PR DESCRIPTION
Resolves: https://github.com/operate-first/SRE/issues/229

Using buildconfig/deployment configs here, which may be controversial. Not opposed to adding a Dockerfile and pushing to quay, though we'd need to decide where that would go. This just seemed like a quick and easy way to get it this out the door. 

I've set idle timeout to 3 days, open to suggestions here. 

The jupyterhub token is created via Jupyterhub UI using my (admin) account. The docs for jupyterhub-idle-culler also seemed to suggest this. 

I think we should try to encourage upstream to introduce this as a [jupyterhub managed service](https://jupyterhub.readthedocs.io/en/stable/reference/services.html#launching-a-hub-managed-service) so we don't have to rely on our api tokens.