### PR TITLE
chore: Move Kafka PVCs from OCS to NFS and downsize

### DIFF
--- a/odh-manifests/kafka/base/kafka-cluster.yaml
+++ b/odh-manifests/kafka/base/kafka-cluster.yaml
@@ -28,7 +28,8 @@ spec:
       inter.broker.protocol.version: '2.7'
     storage:
       type: persistent-claim
-      size: 200Gi
+      size: 20Gi
+      class: moc-nfs-csi
       deleteClaim: false
     metricsConfig:
       type: jmxPrometheusExporter
@@ -40,7 +41,8 @@ spec:
     replicas: 3
     storage:
       type: persistent-claim
-      size: 10Gi
+      size: 2Gi
+      class: moc-nfs-csi
       deleteClaim: false
     metricsConfig:
       type: jmxPrometheusExporter


### PR DESCRIPTION
Relocate and shrink PVCs for kafka

1. Kafka from 3x 200Gi to 3x20Gi
2. Zookeeper from 3x10Gi to 3x2Gi

![image](https://user-images.githubusercontent.com/7453394/117662050-6a85c480-b19f-11eb-99cf-166e5160a7f6.png)