### PR TITLE
Acme operator

### DIFF
--- a/acme-operator/base/deployment.yaml
+++ b/acme-operator/base/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openshift-acme
+spec:
+  selector:
+    matchLabels:
+      app: openshift-acme
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: openshift-acme
+    spec:
+      serviceAccountName: openshift-acme
+      containers:
+        - name: openshift-acme
+          image: quay.io/tnozicka/openshift-acme:controller
+          imagePullPolicy: Always
+          args:
+            - --exposer-image=quay.io/tnozicka/openshift-acme:exposer
+            - --loglevel=4

--- a/acme-operator/base/kustomization.yaml
+++ b/acme-operator/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+- serviceaccount.yaml

--- a/acme-operator/base/serviceaccount.yaml
+++ b/acme-operator/base/serviceaccount.yaml
@@ -1,0 +1,6 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: openshift-acme
+  labels:
+    app: openshift-acme

--- a/acme-operator/overlays/dev/issuer-letsencrypt-staging.yaml
+++ b/acme-operator/overlays/dev/issuer-letsencrypt-staging.yaml
@@ -1,0 +1,11 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: letsencrypt-staging
+  annotations:
+    "acme.openshift.io/priority": "50"
+  labels:
+    managed-by: "openshift-acme"
+    type: "CertIssuer"
+data:
+  "cert-issuer.types.acme.openshift.io": '{"type":"ACME","acmeCertIssuer":{"directoryUrl":"https://acme-staging-v02.api.letsencrypt.org/directory"}}'

--- a/acme-operator/overlays/dev/kustomization.yaml
+++ b/acme-operator/overlays/dev/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+- issuer-letsencrypt-staging.yaml

--- a/acme-operator/overlays/moc/zero/issuer-letsencrypt-live.yaml
+++ b/acme-operator/overlays/moc/zero/issuer-letsencrypt-live.yaml
@@ -1,0 +1,11 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: letsencrypt-live
+  annotations:
+    "acme.openshift.io/priority": "100"
+  labels:
+    managed-by: "openshift-acme"
+    type: "CertIssuer"
+data:
+  "cert-issuer.types.acme.openshift.io": '{"type":"ACME","acmeCertIssuer":{"directoryUrl":"https://acme-v02.api.letsencrypt.org/directory"}}'

--- a/acme-operator/overlays/moc/zero/kustomization.yaml
+++ b/acme-operator/overlays/moc/zero/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../base
+- issuer-letsencrypt-live.yaml
+namespace: acme-operator

--- a/cluster-scope/base/core/namespaces/acme-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/acme-operator/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: acme-operator
+resources:
+- namespace.yaml
+components:
+- ../../../../components/project-admin-rolebindings/operate-first
+- ../../../../components/resourcequotas/x-small
+- ../../../../components/limitranges/default

--- a/cluster-scope/base/core/namespaces/acme-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/acme-operator/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Openshift-ACME Controller"
+    openshift.io/requester: operate-first
+  name: acme-operator
+spec: {}

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: acme-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: acme-operator
+subjects:
+- kind: ServiceAccount
+  name: openshift-acme
+  namespace: acme-operator

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/acme-operator/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/acme-operator/clusterrole.yaml
@@ -1,0 +1,66 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: acme-operator
+rules:
+- apiGroups:
+  - "route.openshift.io"
+  resources:
+  - routes
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+  - deletecollection
+- apiGroups:
+  - "route.openshift.io"
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - services
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - limitranges
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apps"
+  resources:
+  - replicasets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/acme-operator/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/acme-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrole.yaml

--- a/cluster-scope/overlays/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/moc/zero/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ../../../base/apiextensions.k8s.io/customresourcedefinitions/prowjobs.prow.k8s.io
   - ../../../base/apiextensions.k8s.io/customresourcedefinitions/rayclusters.cluster.ray.io
   - ../../../base/config.openshift.io/oauths/cluster
+  - ../../../base/core/namespaces/acme-operator
   - ../../../base/core/namespaces/apicurio-apicurio-registry
   - ../../../base/core/namespaces/as-pushgateway
   - ../../../base/core/namespaces/b4mad-minecraft
@@ -104,6 +105,7 @@ resources:
   - ../../../base/operators.coreos.com/subscriptions/web-terminal
   - ../../../base/policy/podsecuritypolicies/controller
   - ../../../base/policy/podsecuritypolicies/speaker
+  - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator
   - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/argocd-manager
   - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-rb
   - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-logs-readers
@@ -121,6 +123,7 @@ resources:
   - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/scc-anyuid-tufts-dcc-6
   - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/scc-privileged-opf-ci-pipelines-aicoe-ci
   - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/scc-privileged-tufts-dcc-6
+  - ../../../base/rbac.authorization.k8s.io/clusterroles/acme-operator
   - ../../../base/rbac.authorization.k8s.io/clusterroles/cluster-logs-reader
   - ../../../base/rbac.authorization.k8s.io/clusterroles/metallb-system:controller
   - ../../../base/rbac.authorization.k8s.io/clusterroles/metallb-system:speaker

--- a/docs/issuing_certificates.md
+++ b/docs/issuing_certificates.md
@@ -1,0 +1,19 @@
+# Issuing certificates
+
+## Securing OpenShift `Route`s with ACME (Let's Encrypt)
+
+We manage and deploy cluster wide deployment of [OpenShift ACME](https://github.com/tnozicka/openshift-acme) controller. This operator facilitates [Let's Encrypt](https://letsencrypt.org/) certificate provisioning in any namespace on the cluster. Any `Route` resource is eligible, please use the following annotation to mark the route as managed by this operator:
+
+```yaml
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    kubernetes.io/tls-acme: "true"
+```
+
+Annotating a route will result with an additional temporary route and 2 pods being created in your namespace. Once the certificate is issued these pods will be removed. This process is repeated to renew certificates later on.
+
+## Issuing certificates via Cert Manager
+
+For other workloads that rely on SSL/TLS certificates, we will be able to provision certificates via Cert Manager shortly. This is currently work in progress.


### PR DESCRIPTION
Resolves: https://github.com/operate-first/support/issues/237
Part of: https://github.com/operate-first/support/issues/199

I've renamed most of the resources from `openshift-acme` to `acme-operator` since most things with `openshift-*` prefix usually refer to OpenShift-owned resources.Hopefully this lowers the confusion here.

It turned out that we can't use CertManager to secure OpenShift routes, since they don't want to support vendor specific resource (`Route`) and OpenShift can't make the routes to load certs from secrets for many years, so we need 2 different solutions in place - one for routes and another one for the rest.

References in the issue above.