### PR TITLE
use curl instead of both wget and curl in the same script

### DIFF
--- a/scripts/argocd/update_cluster_resources.sh
+++ b/scripts/argocd/update_cluster_resources.sh
@@ -39,19 +39,25 @@ echo "Synchronizing resources to tag version ${1}"
 # CRDS
 CRD_PATH=cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions
 echo "Updating Cluster CRDs.."
-wget -q https://raw.githubusercontent.com/argoproj/argo-cd/${1}/manifests/crds/application-crd.yaml -O $CRD_PATH/applications.argoproj.io/customresourcedefinition.yaml
-wget -q https://raw.githubusercontent.com/argoproj/argo-cd/${1}/manifests/crds/appproject-crd.yaml -O $CRD_PATH/appprojects.argoproj.io/customresourcedefinition.yaml
+curl -sL -o $CRD_PATH/applications.argoproj.io/customresourcedefinition.yaml \
+	https://raw.githubusercontent.com/argoproj/argo-cd/${1}/manifests/crds/application-crd.yaml
+curl -sL -o  $CRD_PATH/appprojects.argoproj.io/customresourcedefinition.yaml \
+	https://raw.githubusercontent.com/argoproj/argo-cd/${1}/manifests/crds/appproject-crd.yaml
 
 # Clusterroles
 ROLE_PATH=cluster-scope/base/rbac.authorization.k8s.io/clusterroles
 echo "Updating Cluster ClusterRoles.."
-wget -q https://raw.githubusercontent.com/argoproj/argo-cd/${1}/manifests/cluster-rbac/argocd-server-clusterrole.yaml -O $ROLE_PATH/argocd-server/clusterrole.yaml
-wget -q https://raw.githubusercontent.com/argoproj/argo-cd/${1}/manifests/cluster-rbac/argocd-application-controller-clusterrole.yaml -O $ROLE_PATH/argocd-application-controller/clusterrole.yaml
+curl -sL -o $ROLE_PATH/argocd-server/clusterrole.yaml \
+	https://raw.githubusercontent.com/argoproj/argo-cd/${1}/manifests/cluster-rbac/argocd-server-clusterrole.yaml
+curl -sL -o $ROLE_PATH/argocd-application-controller/clusterrole.yaml \
+	https://raw.githubusercontent.com/argoproj/argo-cd/${1}/manifests/cluster-rbac/argocd-application-controller-clusterrole.yaml
 
 # ClusterroleBindings
 BINDING_PATH=cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings
 echo "Updating Cluster ClusterRoleRolebindings.."
-wget -q https://raw.githubusercontent.com/argoproj/argo-cd/${1}/manifests/cluster-rbac/argocd-application-controller-clusterrolebinding.yaml -O $BINDING_PATH/argocd-application-controller/clusterrolebinding.yaml
-wget -q https://raw.githubusercontent.com/argoproj/argo-cd/${1}/manifests/cluster-rbac/argocd-server-clusterrolebinding.yaml -O $BINDING_PATH/argocd-server/clusterrolebinding.yaml
+curl -sL -o $BINDING_PATH/argocd-application-controller/clusterrolebinding.yaml \
+	https://raw.githubusercontent.com/argoproj/argo-cd/${1}/manifests/cluster-rbac/argocd-application-controller-clusterrolebinding.yaml
+curl -sL -o $BINDING_PATH/argocd-server/clusterrolebinding.yaml \
+	https://raw.githubusercontent.com/argoproj/argo-cd/${1}/manifests/cluster-rbac/argocd-server-clusterrolebinding.yaml
 
 echo "Done!"


### PR DESCRIPTION
While editing the update-cluster-resources script, I noticed that
we're using both `curl` and `wget` in the same script. This commits
settles on using `curl` in all cases.
