### PR TITLE
fix: Allow ACME operator namespace in argocd

### DIFF
--- a/argocd/overlays/moc-infra/projects/operate-first.yaml
+++ b/argocd/overlays/moc-infra/projects/operate-first.yaml
@@ -25,6 +25,8 @@ spec:
       server: 'https://api.zero.massopen.cloud:6443'
     - namespace: 'opendatahub-operator'
       server: 'https://api.zero.massopen.cloud:6443'
+    - namespace: 'acme-operator'
+      server: 'https://api.zero.massopen.cloud:6443'
   sourceRepos:
     - '*'
   roles:


### PR DESCRIPTION
SSIA
Part of: https://github.com/operate-first/support/issues/237