### PR TITLE
fix: ACME quota for HA

### DIFF
--- a/cluster-scope/base/core/namespaces/acme-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/acme-operator/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 - namespace.yaml
 components:
 - ../../../../components/project-admin-rolebindings/operate-first
-- ../../../../components/resourcequotas/x-small
+- ../../../../components/resourcequotas/small
 - ../../../../components/limitranges/default


### PR DESCRIPTION
ACME operator requires 2 pods to be running for HA - where CPU limit is 500m on each. `x-small` doesn't allow for the second pod to start successfully.

Note this is just for HA, doesn't have any effect on basic functionality.

Part of: https://github.com/operate-first/support/issues/237