### PR TITLE
Move image registry pv to nfs storage

### DIFF
--- a/cluster-scope/base/core/persistentvolumeclaims/image-registry-storage/persistentvolumeclaim.yaml
+++ b/cluster-scope/base/core/persistentvolumeclaims/image-registry-storage/persistentvolumeclaim.yaml
@@ -10,3 +10,4 @@ spec:
     requests:
       storage: 200Gi
   volumeMode: Filesystem
+  storageClassName: moc-nfs-csi


### PR DESCRIPTION
Explicitly select the moc-nfs-csi storageclass for the image registry
pv.

Part of #312
