### PR TITLE
Update Jupyterhub StorageClass to moc-nfs-csi

### DIFF
--- a/kfdefs/overlays/moc/zero/opf-jupyterhub/kustomization.yaml
+++ b/kfdefs/overlays/moc/zero/opf-jupyterhub/kustomization.yaml
@@ -18,7 +18,7 @@ patchesJson6902:
         path: /spec/applications/2/kustomizeConfig/parameters/-
         value:
           name: storage_class
-          value: ocs-storagecluster-cephfs
+          value: moc-nfs-csi
     target:
       group: kfdef.apps.kubeflow.org
       kind: KfDef


### PR DESCRIPTION
Tested this in the staging env and it doesn't affect existing PVCs.
New PVCs created were with the new `moc-nfs-csi` storageclass