### PR TITLE
feat: add Apicurio to viewers on opf-monitoring

### DIFF
--- a/kfdefs/overlays/moc/zero/opf-monitoring/rolebindings/opf-monitoring-view.yaml
+++ b/kfdefs/overlays/moc/zero/opf-monitoring/rolebindings/opf-monitoring-view.yaml
@@ -14,3 +14,6 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: thoth-devops
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: apicurio


### PR DESCRIPTION
I've mimicked this PR: https://github.com/operate-first/apps/pull/593/files

What I'm after is: getting access to the Apicurio team members to Graphana and Prometheus