### PR TITLE
Add missing patch fields for idle culler.

### DIFF
--- a/jupyterhub-idle-culler/overlays/moc/zero/deploymentconfig_patch.yaml
+++ b/jupyterhub-idle-culler/overlays/moc/zero/deploymentconfig_patch.yaml
@@ -13,6 +13,15 @@ spec:
     spec:
       containers:
         - name: jupyterhub-idle-culler
+          image: jupyterhub-idle-culler:latest
+          env:
+            - name: JUPYTERHUB_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: jupyterhub-api-token
+                  key: token
+          ports:
+            - containerPort: 8080
           command:
             - jupyterhub-idle-culler
             - --timeout=259200  # 3 days


### PR DESCRIPTION
For some reason the patch is removing the container list item, not sure why it's happening but this should fix the final build.