### PR TITLE
Expand thanos receive pvc

### DIFF
--- a/observatorium/base/instance/observatorium.yaml
+++ b/observatorium/base/instance/observatorium.yaml
@@ -16,11 +16,11 @@ spec:
       querier: 1
       query_frontend: 1
       table_manager: 1
-    version: 1.6.1
+    version: 2.2.0
     volumeClaimTemplate:
       spec:
         accessModes:
-        - ReadWriteOnce
+          - ReadWriteOnce
         resources:
           requests:
             storage: 250Mi
@@ -47,12 +47,12 @@ spec:
     replicas: 0
   compact:
     enableDownsampling: true
-    image: quay.io/thanos/thanos:v0.16.0
+    image: 'quay.io/thanos/thanos:v0.20.1'
     replicas: 1
     retentionResolution1h: 0d    # forever
     retentionResolution5m: 30d
     retentionResolutionRaw: 7d
-    version: v0.16.0
+    version: v0.20.1
     volumeClaimTemplate:
       spec:
         accessModes:
@@ -64,57 +64,57 @@ spec:
   hashrings:
   - hashring: default
   receivers:
-    image: quay.io/thanos/thanos:v0.16.0
+    image: 'quay.io/thanos/thanos:v0.20.1'
     replicas: 3
-    version: v0.16.0
+    version: v0.20.1
     volumeClaimTemplate:
       spec:
         accessModes:
-        - ReadWriteOnce
+          - ReadWriteOnce
         resources:
           requests:
             storage: 50Gi
   # thanosReceiveController auto populates the hashrings
   thanosReceiveController:
-    image: quay.io/observatorium/thanos-receive-controller:master-2020-02-06-b66e0c8
-    version: master-2020-02-06-b66e0c8
+    image: 'quay.io/observatorium/thanos-receive-controller:master-2021-04-28-ee165b6'
+    version: master-2021-04-28-ee165b6
   rule:
-    image: quay.io/thanos/thanos:v0.16.0
+    image: 'quay.io/thanos/thanos:v0.20.1'
     replicas: 1
-    version: v0.16.0
+    version: v0.20.1
     volumeClaimTemplate:
       spec:
         accessModes:
-        - ReadWriteOnce
+          - ReadWriteOnce
         resources:
           requests:
             storage: 10Gi
   store:
     cache:
-      exporterImage: prom/memcached-exporter:v0.6.0
-      exporterVersion: v0.6.0
-      image: docker.io/memcached:1.6.3-alpine
+      exporterImage: 'prom/memcached-exporter:v0.9.0'
+      exporterVersion: v0.9.0
+      image: 'docker.io/memcached:1.6.9-alpine'
       memoryLimitMb: 1024
       replica: 1
       resources:
         limits:
           memory: 1Gi
-      version: 1.6.3-alpine
-    image: quay.io/thanos/thanos:v0.16.0
+      version: 1.6.9-alpine
+    image: 'quay.io/thanos/thanos:v0.20.1'
     shards: 1
-    version: v0.16.0
+    version: v0.20.1
     volumeClaimTemplate:
       spec:
         accessModes:
-        - ReadWriteOnce
+          - ReadWriteOnce
         resources:
           requests:
             storage: 50Gi
   query:
-    image: quay.io/thanos/thanos:v0.16.0
+    image: 'quay.io/thanos/thanos:v0.20.1'
     replicas: 2
-    version: v0.16.0
+    version: v0.20.1
   queryFrontend:
-    image: quay.io/thanos/thanos:v0.15.0
+    image: 'quay.io/thanos/thanos:v0.20.1'
     replicas: 1
-    version: v0.15.0
+    version: v0.20.1

--- a/observatorium/base/instance/observatorium.yaml
+++ b/observatorium/base/instance/observatorium.yaml
@@ -73,7 +73,7 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 50Gi
+            storage: 100Gi
   # thanosReceiveController auto populates the hashrings
   thanosReceiveController:
     image: 'quay.io/observatorium/thanos-receive-controller:master-2021-04-28-ee165b6'


### PR DESCRIPTION
Related https://github.com/operate-first/SRE/issues/287

This PR will
* sync the Observatorium Thanos version to the current deployed version (v0.20.1)
* Increase the thanos receiver PVC size from 50Gi to 100Gi