### PR TITLE
feat: Deploy Pulp operator via direct copies of the manifests

### DIFF
--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/pulpbackups.pulp.pulpproject.org/customresourcedefinition.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/pulpbackups.pulp.pulpproject.org/customresourcedefinition.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: pulpbackups.pulp.pulpproject.org
+spec:
+  group: pulp.pulpproject.org
+  names:
+    kind: PulpBackup
+    listKind: PulpBackupList
+    plural: pulpbackups
+    singular: pulpbackup
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+          description: Schema validation for the PulpBackup CRD
+          properties:
+            spec:
+              type: object
+              properties:
+                deployment_name:
+                  description: Name of the deployment to be backed up
+                  type: string
+                backup_pvc:
+                  description: Name of the PVC to be used for storing the backup
+                  type: string
+                backup_pvc_namespace:
+                  description: Namespace PVC is in
+                  type: string
+                backup_storage_requirements:
+                  description: Storage requirements for the backup
+                  type: string
+                backup_storage_class:
+                  description: Storage class to use when creating PVC for backup
+                  type: string
+                postgres_label_selector:
+                  description: Label selector used to identify postgres pod for executing migration
+                  type: string
+              required:
+                - deployment_name
+            status:
+              properties:
+                deploymentName:
+                  description: Name of the deployment backed up
+                  type: string
+                backupClaim:
+                  description: The PVC name used for the backup
+                  type: string
+                backupNamespace:
+                  description: The namespace used for the backup claim
+                  type: string
+                backupDirectory:
+                  description: The directory data is backed up to on the PVC
+                  type: string
+                deploymentStorageType:
+                  description: The deployment storage type
+                  type: string
+                adminPasswordSecret:
+                  description: Administrator password secret used by the deployed instance
+                  type: string
+                databaseConfigurationSecret:
+                  description: Database configuration secret used by the deployed instance
+                  type: string
+                objectStorageConfigurationSecret:
+                  description: Objectstorage configuration secret used by the deployed instance
+                  type: string
+                containerTokenSecret:
+                  description: Container token configuration secret used by the deployed instance
+                  type: string
+                conditions:
+                  description: The resulting conditions when a Service Telemetry is instantiated
+                  items:
+                    properties:
+                      status:
+                        type: string
+                      type:
+                        type: string
+                      reason:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                    type: object
+                  type: array
+              type: object

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/pulpbackups.pulp.pulpproject.org/kustomization.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/pulpbackups.pulp.pulpproject.org/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- customresourcedefinition.yaml

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/pulprestores.pulp.pulpproject.org/customresourcedefinition.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/pulprestores.pulp.pulpproject.org/customresourcedefinition.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: pulprestores.pulp.pulpproject.org
+spec:
+  group: pulp.pulpproject.org
+  names:
+    kind: PulpRestore
+    listKind: PulpRestoreList
+    plural: pulprestores
+    singular: pulprestore
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+          description: Schema validation for the PulpRestore CRD
+          properties:
+            spec:
+              type: object
+              properties:
+                backup_source:
+                  description: backup source
+                  type: string
+                  enum:
+                    - CR
+                    - PVC
+                deployment_name:
+                  description: Name of the deployment to be restored to
+                  type: string
+                backup_name:
+                  description: Name of the backup custom resource
+                  type: string
+                backup_pvc:
+                  description: Name of the PVC to be restored from, set as a status found on the backup object (backupClaim)
+                  type: string
+                backup_pvc_namespace:
+                  description: Namespace the PVC is in
+                  type: string
+                backup_dir:
+                  description: Backup directory name, set as a status found on the backup object (backupDirectory)
+                  type: string
+                storage_type:
+                  description: Configuration for the storage type utilized in the backup
+                  type: string
+                postgres_label_selector:
+                  description: Label selector used to identify postgres pod for executing migration
+                  type: string
+            status:
+              properties:
+                restoreComplete:
+                  description: The state of the restore
+                  type: boolean
+                conditions:
+                  description: The resulting conditions when a Service Telemetry is instantiated
+                  items:
+                    properties:
+                      status:
+                        type: string
+                      type:
+                        type: string
+                      reason:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                    type: object
+                  type: array
+              type: object

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/pulprestores.pulp.pulpproject.org/kustomization.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/pulprestores.pulp.pulpproject.org/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- customresourcedefinition.yaml

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/pulps.pulp.pulpproject.org/customresourcedefinition.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/pulps.pulp.pulpproject.org/customresourcedefinition.yaml
@@ -1,0 +1,458 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: pulps.pulp.pulpproject.org
+spec:
+  group: pulp.pulpproject.org
+  names:
+    kind: Pulp
+    listKind: PulpList
+    plural: pulps
+    singular: pulp
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+        description: Schema validation for the Pulp CRD
+        properties:
+          spec:
+            properties:
+              deployment_type:
+                description: Name of the deployment type
+                type: string
+              registry:
+                description: The container image registry to use for pulling images.
+                type: string
+                default: quay.io
+              project:
+                description: The container image registry project for pulling images.
+                type: string
+                default: pulp
+              image:
+                description: The image name (repo name) for the pulp image.
+                type: string
+                default: pulp
+              image_web:
+                description: The image name (repo name) for the pulp webserver image.
+                type: string
+                default: pulp-web
+              tag:
+                description: The image tag for the pulp image.
+                type: string
+                default: stable
+              pulp_settings:
+                x-kubernetes-preserve-unknown-fields: true
+                description: The pulp settings.
+                properties:
+                  debug:
+                    type: string
+                  GALAXY_FEATURE_FLAGS:
+                    properties:
+                      execution_environments:
+                        type: string
+                    type: object
+                type: object
+              admin_password_secret:
+                description: Secret where the administrator password can be found
+                type: string
+              postgres_configuration_secret:
+                description: Secret where the database configuration can be found
+                type: string
+              postgres_initdb_args:
+                description: The arguments to be passed to initialize the database
+                type: string
+              postgres_host_auth_method:
+                description: The method to be used for database host authentication
+                type: string
+              postgres_image:
+                description: Registry path to the PostgreSQL container to use
+                type: string
+              postgres_resource_requirements:
+                description: Resource requirements for the PostgreSQL container
+                properties:
+                  requests:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                      storage:
+                        type: string
+                    type: object
+                  limits:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                      storage:
+                        type: string
+                    type: object
+                type: object
+              postgres_storage_class:
+                description: Storage class to use for the PostgreSQL PVC
+                type: string
+              postgres_data_path:
+                description: Path where the PostgreSQL data are located
+                type: string
+              postgres_migrant_configuration_secret:
+                description: Secret where the old database configuration can be found for data migration
+                type: string
+              postgres_label_selector:
+                description: Label selector used to identify postgres pod for executing migration
+                type: string
+              storage_type:
+                description: Configuration for the storage type to be utilized
+                type: string
+                enum:
+                  - file
+                  - File
+                  - s3
+                  - S3
+                  - azure
+                  - Azure
+              file_storage:
+                description: Configuration for the persistentVolumeClaim for /var/lib/pulp.
+                properties:
+                  access_mode:
+                    description: The file storage access mode.
+                    type: string
+                    default: ReadWriteMany
+                    enum:
+                      - ReadWriteMany
+                      - ReadWriteOnce
+                  size:
+                    description: The size of the file storage; for example 100Gi.
+                    type: string
+                  storage_class:
+                    description: Storage class to use for the file persistentVolumeClaim
+                    type: string
+                type: object
+              object_storage_s3_secret:
+                description: The secret for S3 compliant object storage configuration.
+                type: string
+              object_storage_azure_secret:
+                description: The secret for Azure blob storage configuration.
+                type: string
+              hostname:
+                description: The hostname of the instance
+                type: string
+              ingress_type:
+                description: The ingress type to use to reach the deployed instance
+                type: string
+                enum:
+                  - none
+                  - Ingress
+                  - ingress
+                  - Route
+                  - route
+                  - LoadBalancer
+                  - loadbalancer
+                  - NodePort
+                  - nodeport
+              ingress_annotations:
+                description: Annotations to add to the ingress
+                type: string
+              ingress_tls_secret:
+                description: Secret where the ingress TLS secret can be found
+                type: string
+              loadbalancer_annotations:
+                description: Annotations to add to the loadbalancer
+                type: string
+              loadbalancer_protocol:
+                description: Protocol to use for the loadbalancer
+                type: string
+                default: http
+                enum:
+                  - http
+                  - https
+              loadbalancer_port:
+                description: Port to use for the loadbalancer
+                type: integer
+                default: 80
+              route_host:
+                description: The DNS to use to points to the instance
+                type: string
+              route_tls_termination_mechanism:
+                description: The secure TLS termination mechanism to use
+                type: string
+                default: Edge
+                enum:
+                  - Edge
+                  - edge
+                  - Passthrough
+                  - passthrough
+              route_tls_secret:
+                description: Secret where the TLS related credentials are stored
+                type: string
+              container_token_secret:
+                description: Secret where the container token certificates are stored
+                type: string
+              image_pull_policy:
+                description: Image pull policy for container image
+                type: string
+                default: IfNotPresent
+                enum:
+                  - IfNotPresent
+                  - Always
+                  - Never
+              affinity:
+                description: Defines various deployment affinities
+                properties:
+                  node_affinity:
+                    x-kubernetes-preserve-unknown-fields: true
+                    description: Defines the node affinity for the deployment
+                    type: object
+                type: object
+              redis_resource_requirements:
+                description: Resource requirements for the Redis container
+                properties:
+                  requests:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                      storage:
+                        type: string
+                    type: object
+                  limits:
+                    properties:
+                      cpu:
+                        type: string
+                      memory:
+                        type: string
+                      storage:
+                        type: string
+                    type: object
+                type: object
+              web:
+                description: The pulp web deployment.
+                properties:
+                  replicas:
+                    description: The number of replicas for the deployment.
+                    type: integer
+                    default: 1
+                    format: int32
+                  resource_requirements:
+                    description: Resource requirements for the pulp web container
+                    properties:
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              api:
+                description: The pulp api deployment.
+                properties:
+                  replicas:
+                    description: The number of replicas for the deployment.
+                    type: integer
+                    default: 1
+                    format: int32
+                  log_level:
+                    description: The log level for the deployment.
+                    type: string
+                    default: INFO
+                    enum:
+                      - DEBUG
+                      - INFO
+                      - WARNING
+                      - ERROR
+                      - CRITICAL
+                  resource_requirements:
+                    description: Resource requirements for the pulp api container
+                    properties:
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              content:
+                description: The pulp content deployment.
+                properties:
+                  replicas:
+                    description: The number of replicas for the deployment.
+                    type: integer
+                    default: 2
+                    format: int32
+                  log_level:
+                    description: The log level for the deployment.
+                    type: string
+                    default: INFO
+                    enum:
+                      - DEBUG
+                      - INFO
+                      - WARNING
+                      - ERROR
+                      - CRITICAL
+                  resource_requirements:
+                    description: Resource requirements for the pulp content container
+                    properties:
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              worker:
+                description: The pulp worker deployment.
+                properties:
+                  replicas:
+                    description: The number of replicas for the deployment.
+                    type: integer
+                    default: 2
+                    format: int32
+                  resource_requirements:
+                    description: Resource requirements for the pulp worker container
+                    properties:
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              resource_manager:
+                description: The pulp resource manager deployment.
+                properties:
+                  replicas:
+                    description: The number of replicas for the deployment.
+                    type: integer
+                    default: 1
+                    format: int32
+                  resource_requirements:
+                    description: Resource requirements for the pulp resource manager container
+                    properties:
+                      requests:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                      limits:
+                        properties:
+                          cpu:
+                            type: string
+                          memory:
+                            type: string
+                          storage:
+                            type: string
+                        type: object
+                    type: object
+                type: object
+            type: object
+          status:
+            properties:
+              webURL:
+                description: URL to access the deployed instance
+                type: string
+              adminPasswordSecret:
+                description: Admin password of the deployed instance
+                type: string
+              databaseConfigurationSecret:
+                description: Database configuration secret used by the deployed instance
+                type: string
+              storageType:
+                description: The type of storage being used by the deployed instance
+                type: string
+              storagePersistentVolumeClaim:
+                description: The name of the persistent volume claim used for storage
+                type: string
+              storageSecret:
+                description: The name of the secret used for object storage
+                type: string
+              deployedVersion:
+                description: Version of the deployed instance
+                type: string
+              deployedImage:
+                description: URL of the image used for the deployed instance
+                type: string
+              migrantDatabaseConfigurationSecret:
+                description: The configuration secret used for migrating an old deployment
+                type: string
+              containerTokenSecret:
+                description: The name of the secret used for container token authentication
+                type: string
+              conditions:
+                description: The resulting conditions when a Service Telemetry is instantiated
+                items:
+                  properties:
+                    status:
+                      type: string
+                    type:
+                      type: string
+                    reason:
+                      type: string
+                    lastTransitionTime:
+                      type: string
+                  type: object
+                type: array
+            type: object

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/pulps.pulp.pulpproject.org/kustomization.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/pulps.pulp.pulpproject.org/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- customresourcedefinition.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/pulp-operator/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/pulp-operator/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pulp-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pulp-operator
+subjects:
+- kind: ServiceAccount
+  name: pulp-operator
+  namespace: pulp-operator

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/pulp-operator/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/pulp-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/pulp-operator/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/pulp-operator/clusterrole.yaml
@@ -1,0 +1,105 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pulp-operator
+rules:
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  - routes/custom-host
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  - rbac.authorization.k8s.io
+  resources:
+  - pods
+  - pods/log
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  - roles
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - pulp-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments/scale
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - pulp.pulpproject.org
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/pulp-operator/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/pulp-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrole.yaml

--- a/cluster-scope/overlays/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/moc/zero/kustomization.yaml
@@ -8,6 +8,9 @@ resources:
   - ../../../base/apiextensions.k8s.io/customresourcedefinitions/kfdefs.kfdef.apps.kubeflow.org
   - ../../../base/apiextensions.k8s.io/customresourcedefinitions/observatoria.core.observatorium.io
   - ../../../base/apiextensions.k8s.io/customresourcedefinitions/prowjobs.prow.k8s.io
+  - ../../../base/apiextensions.k8s.io/customresourcedefinitions/pulpbackups.pulp.pulpproject.org
+  - ../../../base/apiextensions.k8s.io/customresourcedefinitions/pulprestores.pulp.pulpproject.org
+  - ../../../base/apiextensions.k8s.io/customresourcedefinitions/pulps.pulp.pulpproject.org
   - ../../../base/apiextensions.k8s.io/customresourcedefinitions/rayclusters.cluster.ray.io
   - ../../../base/config.openshift.io/oauths/cluster
   - ../../../base/core/namespaces/acme-operator
@@ -119,6 +122,7 @@ resources:
   - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/observatorium-operator
   - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/opendatahub-operator
   - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/opf-cluster-metrics-federation
+  - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/pulp-operator
   - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/scc-anyuid-observatorium
   - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/scc-anyuid-tufts-dcc-6
   - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/scc-privileged-opf-ci-pipelines-aicoe-ci
@@ -136,6 +140,7 @@ resources:
   - ../../../base/rbac.authorization.k8s.io/clusterroles/prow-aggregate-to-admin
   - ../../../base/rbac.authorization.k8s.io/clusterroles/prow-aggregate-to-edit
   - ../../../base/rbac.authorization.k8s.io/clusterroles/prow-aggregate-to-view
+  - ../../../base/rbac.authorization.k8s.io/clusterroles/pulp-operator
   - ../../../base/rbac.authorization.k8s.io/clusterroles/ray-aggregate-to-admin
   - ../../../base/security.openshift.io/securitycontextconstraints/uky-hpc-workload-generator-hostpath
   - ../../../base/storage.k8s.io/csidrivers/org.democratic-csi.nfs

--- a/pulp-operator/base/kustomization.yaml
+++ b/pulp-operator/base/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://raw.githubusercontent.com/pulp/pulp-operator/main/deploy/operator.yaml
+- https://raw.githubusercontent.com/pulp/pulp-operator/main/deploy/service_account.yaml

--- a/pulp-operator/overlays/moc/zero/kustomization.yaml
+++ b/pulp-operator/overlays/moc/zero/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: pulp-operator
+resources:
+- ../../../base


### PR DESCRIPTION
Direct deployment of Pulp at cluster scope

Resolves: https://github.com/operate-first/support/issues/176
Competition PR: 

/hold until it's decided which way (this or the competition PR) is more maintainable for the Pulp team