### PR TITLE
Give apicurio team permissions to access loki

### DIFF
--- a/observatorium/overlays/moc/zero/rolebindings/opf-observatorium-view.yaml
+++ b/observatorium/overlays/moc/zero/rolebindings/opf-observatorium-view.yaml
@@ -11,3 +11,6 @@ subjects:
   - kind: ServiceAccount
     name: grafana-datasource
     namespace: opf-monitoring
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: apicurio


### PR DESCRIPTION
This will add `apicurio` openshift group to the `opf-observatorium-view` rolebinding, giving the team access to Loki.