### PR TITLE
Apply sre-p alertmanager config to openshift-monitoring's prometheus.

### DIFF
--- a/cluster-scope/overlays/moc/common/alertmanager-main-secret.yaml
+++ b/cluster-scope/overlays/moc/common/alertmanager-main-secret.yaml
@@ -9,34 +9,193 @@ stringData:
     global:
       resolve_timeout: 5m
     inhibit_rules:
-      - equal:
-          - namespace
-          - alertname
-        source_match:
-          severity: critical
-        target_match_re:
-          severity: warning|info
-      - equal:
-          - namespace
-          - alertname
-        source_match:
-          severity: warning
-        target_match_re:
-          severity: info
+    - source_match:
+        severity: critical
+      target_match_re:
+        severity: warning|info
+      equal:
+      - namespace
+      - alertname
+    - source_match:
+        severity: warning
+      target_match_re:
+        severity: info
+      equal:
+      - namespace
+      - alertname
+    - source_match:
+        alertname: ClusterOperatorDegraded
+      target_match_re:
+        alertname: ClusterOperatorDown
+      equal:
+      - namespace
+      - name
+    - source_match:
+        alertname: KubeNodeNotReady
+      target_match_re:
+        alertname: KubeNodeUnreachable
+      equal:
+      - node
+      - instance
+    - source_match:
+        alertname: KubeNodeUnreachable
+      target_match_re:
+        alertname: SDNPodNotReady|TargetDown
+    - source_match:
+        alertname: KubeNodeNotReady
+      target_match_re:
+        alertname: KubeDaemonSetRolloutStuck|KubeDaemonSetMisScheduled|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubePodNotReady
+      equal:
+      - instance
+    - source_match:
+        alertname: KubeDeploymentReplicasMismatch
+      target_match_re:
+        alertname: KubePodNotReady|KubePodCrashLooping
+      equal:
+      - namespace
+    - source_match:
+        alertname: ElasticsearchOperatorCSVNotSuccessful
+      target_match_re:
+        alertname: ElasticsearchClusterNotHealthy
+      equal:
+      - dummylabel
     receivers:
-      - name: Default
+      - name: Watchdog
+      - name: "null"
+      - name: Github
         webhook_configs:
           - url: 'http://github-receiver-service.opf-alertreceiver.svc.cluster.local:9393/v1/receiver'
-      - name: Watchdog
     route:
+      receiver: "null"
       group_by:
         - namespace
         - alertname
-      group_interval: 5m
-      group_wait: 30s
-      receiver: Default
-      repeat_interval: 12h
       routes:
-        - match:
+        - receiver: "null"
+          group_by:
+            - namespace
+            - severity
+          continue: true
+          routes:
+            # Alerts we do not want to receive
+            - receiver: "null"
+              match:
+                alertname: CPUThrottlingHigh
+            - receiver: "null"
+              match:
+                namespace: openshift-customer-monitoring
+            - receiver: "null"
+              match:
+                namespace: openshift-operators
+            - receiver: "null"
+              match:
+                exported_namespace: openshift-operators
+            - receiver: "null"
+              match:
+                alertname: CustomResourceDetected
+            - receiver: "null"
+              match:
+                alertname: ImagePruningDisabled
+            - receiver: "null"
+              match:
+                severity: info
+            - receiver: "null"
+              match:
+                severity: warning
+              match_re:
+                alertname: ^etcd.*
+            - receiver: "null"
+              match:
+                alertname: PodDisruptionBudgetLimit
+              match_re:
+                namespace: ^redhat-.*
+            - receiver: "null"
+              match:
+                alertname: PodDisruptionBudgetAtLimit
+              match_re:
+                namespace: ^redhat-.*
+            - receiver: "null"
+              match:
+                alertname: TargetDown
+              match_re:
+                namespace: ^redhat-.*
+            - receiver: "null"
+              match:
+                alertname: KubeJobFailed
+                namespace: openshift-logging
+              match_re:
+                job_name: ^elasticsearch.*
+            - receiver: "null"
+              match:
+                alertname: HAProxyReloadFail
+                severity: critical
+            - receiver: "null"
+              match:
+                alertname: PrometheusRuleFailures
+            - receiver: "null"
+              match:
+                alertname: ClusterOperatorDegraded
+                name: authentication
+                reason: IdentityProviderConfig_Error
+            - receiver: "null"
+              match:
+                alertname: ClusterOperatorDegraded
+                name: authentication
+                reason: OAuthServerConfigObservation_Error
+            - receiver: "null"
+              match:
+                alertname: CannotRetrieveUpdates
+            - receiver: "null"
+              match:
+                alertname: PrometheusNotIngestingSamples
+                namespace: openshift-user-workload-monitoring
+            - receiver: "null"
+              match:
+                alertname: PrometheusRemoteStorageFailures
+                namespace: openshift-monitoring
+            - receiver: "null"
+              match:
+                alertname: PrometheusRemoteWriteDesiredShards
+                namespace: openshift-monitoring
+            - receiver: "null"
+              match:
+                alertname: PrometheusRemoteWriteBehind
+                namespace: openshift-monitoring
+            - receiver: "null"
+              match:
+                alertname: UpdateAvailable
+            # Alerts we want to send to github
+            - receiver: Github
+              match:
+                alertname: KubeAPILatencyHigh
+                severity: critical
+            - receiver: Github
+              match:
+                prometheus: openshift-monitoring/k8s
+              match_re:
+                exported_namespace: ^kube.*|^openshift.*|^redhat-.*
+            - receiver: Github
+              match:
+                exported_namespace: ""
+                prometheus: openshift-monitoring/k8s
+              match_re:
+                namespace: ^kube.*|^openshift.*|^redhat-.*
+            - receiver: Github
+              match:
+                job: fluentd
+                prometheus: openshift-monitoring/k8s
+            - receiver: Github
+              match:
+                alertname: FluentdNodeDown
+                prometheus: openshift-monitoring/k8s
+            - receiver: Github
+              match:
+                cluster: elasticsearch
+                prometheus: openshift-monitoring/k8s
+        - receiver: Watchdog
+          match:
             alertname: Watchdog
-          receiver: Watchdog
+          repeat_interval: 5m
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 12h


### PR DESCRIPTION
I've updated our alertmanager config to use the one provided by SRE-P, basically everything that goes to pagerduty for them would go to github for us. We are being a bit more selective on what routes go to github rather then sending everything. 

Also looking for more suggestions on what alerts we ought to include/exclude. 