### PR TITLE
Add data-science team to the opf-observatorium-view rolebinding

### DIFF
--- a/observatorium/overlays/moc/zero/rolebindings/opf-observatorium-view.yaml
+++ b/observatorium/overlays/moc/zero/rolebindings/opf-observatorium-view.yaml
@@ -14,3 +14,6 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: apicurio
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: data-science


### PR DESCRIPTION
This will give the data-science permissions to query logs from opf-observatorium loki instance

cc @Shreyanand 

Resolves https://github.com/operate-first/support/issues/250