### PR TITLE
Increase system reserved memory for worker nodes

### DIFF
--- a/cluster-scope/overlays/moc/zero/kubeletconfigs/increase-worker-system-reserved-memory.yaml
+++ b/cluster-scope/overlays/moc/zero/kubeletconfigs/increase-worker-system-reserved-memory.yaml
@@ -1,0 +1,11 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: increase-worker-system-reserved-memory
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/worker: ""
+  kubeletConfig:
+    systemReserved:
+      memory: 4Gi

--- a/cluster-scope/overlays/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/moc/zero/kustomization.yaml
@@ -149,6 +149,7 @@ resources:
 
   - clusterversion.yaml
   - nodenetworkconfigurationpolicies/moc-nfs-network.yaml
+  - kubeletconfigs/increase-worker-system-reserved-memory.yaml
 
 generators:
   - secret-generator.yaml


### PR DESCRIPTION
We've been seeing a number of errors of the form:

    System memory usage of 1.209G on os-ctrl-1 exceeds 90% of the
    reservation...

See e.g. [1]. According to [2], we can adjust the system reserved
memory by creating a custom Kubeletconfig resource. This commit
adds the necessary resource and applies it to the worker nodes.

According to [3], this may or may not take effect immediately:

> If dynamically updating this field, consider that it may not be
> possible to increase the reserved resources, because this requires
> resizing cgroups. Always look for a NodeAllocatableEnforced event
> after updating this field to ensure that the update was successful.

[1]: https://github.com/operate-first/alerts/issues/7738
[2]: https://docs.openshift.com/container-platform/4.7/nodes/nodes/nodes-nodes-managing.html
[3]: https://github.com/kubernetes/kubelet/blob/master/config/v1beta1/types.go#L744
