### PR TITLE
switch the targetport with port name for thoth service monitor

### DIFF
--- a/kfdefs/overlays/moc/zero/opf-monitoring/servicemonitors/thoth-station-servicemonitor.yaml
+++ b/kfdefs/overlays/moc/zero/opf-monitoring/servicemonitors/thoth-station-servicemonitor.yaml
@@ -7,10 +7,7 @@ metadata:
     monitor-component: thoth-station
 spec:
   endpoints:
-    - targetPort: 8080
-    - targetPort: 6066
-    - targetPort: 9187
-    - targetPort: 2746
+    - port: metrics
   namespaceSelector:
     matchNames:
       - thoth-frontend-prod


### PR DESCRIPTION
switch the targetport with port name for thoth service monitor
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>