### PR TITLE
Switch all Subscriptions to automatic approval

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/acm-operator-subscription/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/acm-operator-subscription/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: acm-operator-subscription
 spec:
   channel: release-2.2
-  installPlanApproval: Manual
+  installPlanApproval: Automatic
   name: advanced-cluster-management
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/kubevirt-hyperconverged/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/kubevirt-hyperconverged/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: kubevirt-hyperconverged
 spec:
   channel: DEFINED_IN_OVERLAY
-  installPlanApproval: Manual
+  installPlanApproval: Automatic
   name: kubevirt-hyperconverged
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/local-storage-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/local-storage-operator/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: local-storage-operator
 spec:
   channel: DEFINED_IN_OVERLAY
-  installPlanApproval: Manual
+  installPlanApproval: Automatic
   name: local-storage-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/metering-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/metering-operator/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: metering-operator
 spec:
   channel: DEFINED_IN_OVERLAY
-  installPlanApproval: Manual
+  installPlanApproval: Automatic
   name: metering-ocp
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/ocs-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/ocs-operator/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ocs-operator
 spec:
   channel: DEFINED_IN_OVERLAY
-  installPlanApproval: Manual
+  installPlanApproval: Automatic
   name: ocs-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-scope/base/operators.coreos.com/subscriptions/serverless-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/serverless-operator/subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   name: serverless-operator
 spec:
   channel: DEFINED_IN_OVERLAY
-  installPlanApproval: Manual
+  installPlanApproval: Automatic
   name: serverless-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
I believe we had previously determined to switch all our operator
subscriptions to automatic approval. This takes care of the few cases
that were still configured for Manual approval.
