### PR TITLE
increase ray node mem to 3Gi, idle-timeout to 30min

### DIFF
--- a/kfdefs/base/jupyterhub/ray-odh-integration/ray-cluster-template-cm.yaml
+++ b/kfdefs/base/jupyterhub/ray-odh-integration/ray-cluster-template-cm.yaml
@@ -20,7 +20,7 @@ data:
       # This number should be > 0.
       upscalingSpeed: 1.0
       # If a node is idle for this many minutes, it will be removed.
-      idleTimeoutMinutes: 5
+      idleTimeoutMinutes: 30
       # Specify the pod type for the ray head node (as configured below).
       headPodType: head-node
       # Specify the allowed pod types for this ray cluster and the resources they provide.
@@ -106,7 +106,7 @@ data:
       # Note dashboard-host is set to 0.0.0.0 so that Kubernetes can port forward.
       headStartRayCommands:
           - cd /opt/ray; pipenv run ray stop
-          - ulimit -n 65536; cd /opt/ray; pipenv run ray start --head --no-monitor --port=6379 --object-manager-port=8076 --dashboard-host 0.0.0.0
+          - ulimit -n 65536; cd /opt/ray; pipenv run ray start --head --no-monitor --port=6379 --object-manager-port=8076 --dashboard-host=0.0.0.0
       # Commands to start Ray on worker nodes. You don't need to change this.
       workerStartRayCommands:
           - cd /opt/ray; pipenv run ray stop

--- a/kfdefs/base/jupyterhub/ray-odh-integration/ray-ml-profile-cm.yaml
+++ b/kfdefs/base/jupyterhub/ray-odh-integration/ray-ml-profile-cm.yaml
@@ -23,8 +23,8 @@ data:
               ray_image: 'ray-ml-node:experimental'
               # number of workers currently disabled due to json/jinja bug in JH launcher
               #max_workers: 5
-              memory_request: '1024Mi'
-              memory_limit: '1024Mi'
+              memory_request: '3Gi'
+              memory_limit: '3Gi'
               cpu_request: '1'
               cpu_limit: '1'
             return:


### PR DESCRIPTION
to support slightly larger use cases, this PR proposes to increase the memory for ray cluster nodes to 3Gi.  This corresponds roughly to a working mem of 2.1Gi and object-store mem of 0.9Gi.  Additionally, it increases the node timeout to 30 minutes to reduce churn of ray cluster pods.

I am submitting this somewhat as part of https://github.com/operate-first/support/issues/254 but as a separate PR since it is not an image update, just a resourcing change.