### PR TITLE
overlays/infra: Increase system reserved memory for worker nodes

### DIFF
--- a/cluster-scope/overlays/moc/infra/kubeletconfigs/increase-worker-system-reserved-memory.yaml
+++ b/cluster-scope/overlays/moc/infra/kubeletconfigs/increase-worker-system-reserved-memory.yaml
@@ -1,0 +1,11 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: increase-worker-system-reserved-memory
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/worker: ""
+  kubeletConfig:
+    systemReserved:
+      memory: 4Gi

--- a/cluster-scope/overlays/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/moc/infra/kustomization.yaml
@@ -31,6 +31,7 @@ resources:
   - crc-provisioning-vlan.yaml
   - zero-provisioning-vlan.yaml
   - clusterversion.yaml
+  - kubeletconfigs/increase-worker-system-reserved-memory.yaml
 
 generators:
   - secret-generator.yaml


### PR DESCRIPTION
This is the same as #673, but for the moc-infra cluster.

Part of #671.
