### PR TITLE
fix(blackbox-exporter): Secret generator is not a resource

### DIFF
--- a/kfdefs/base/monitoring/blackbox-exporter/kustomization.yaml
+++ b/kfdefs/base/monitoring/blackbox-exporter/kustomization.yaml
@@ -5,7 +5,6 @@ namespace: opf-monitoring
 resources:
   - blackbox.yaml
   - blackbox-service.yaml
-  - es-secret-generator.yaml
   - probe.yaml
 configMapGenerator:
   - name: blackbox-prober-config
@@ -13,3 +12,5 @@ configMapGenerator:
     - blackbox-prober-config.yaml
 generatorOptions:
   disableNameSuffixHash: true
+generators:
+  - es-secret-generator.yaml


### PR DESCRIPTION
Fixes #578 that broke the `kfdef-zero` ArgoCD app