### PR TITLE
expose ray dashboard

### DIFF
--- a/kfdefs/base/jupyterhub/ray-odh-integration/ray-cluster-template-cm.yaml
+++ b/kfdefs/base/jupyterhub/ray-odh-integration/ray-cluster-template-cm.yaml
@@ -111,3 +111,17 @@ data:
       workerStartRayCommands:
           - cd /opt/ray; pipenv run ray stop
           - ulimit -n 65536; cd /opt/ray; pipenv run ray start --address=$RAY_HEAD_IP:6379 --object-manager-port=8076
+  rayDashboardRouteTemplate: |
+    kind: Route
+    apiVersion: route.openshift.io/v1
+    metadata:
+      name: 'ray-dashboard-{{ user }}'
+      labels:
+        # allows me to return name of service that Ray operator creates
+        odh-ray-cluster-service: 'ray-cluster-{{ user }}-ray-head'
+    spec:
+      to:
+        kind: Service
+        name: 'ray-cluster-{{ user }}-ray-head'
+      port:
+        targetPort: dashboard

--- a/kfdefs/base/jupyterhub/ray-odh-integration/ray-ml-profile-cm.yaml
+++ b/kfdefs/base/jupyterhub/ray-odh-integration/ray-ml-profile-cm.yaml
@@ -11,6 +11,9 @@ data:
         images:
           - 'ray-ml-notebook:experimental'
         env:
+          # expose to jupyter users as a convenience
+          - name: RAY_DASH_URL
+            value: 'http://$(RAY_DASH_HOST)'
           # this is a workaround that may not be neccesary in the future
           - name: RAY_CLIENT_MODE
             value: '1'
@@ -19,6 +22,9 @@ data:
             resources:
               - name: ray-cluster-template
                 path: rayClusterResourceTemplate
+              # dashboard route must come last on this list or 'return' below will break
+              - name: ray-cluster-template
+                path: rayDashboardRouteTemplate
             configuration:
               ray_image: 'ray-ml-node:experimental'
               # number of workers currently disabled due to json/jinja bug in JH launcher
@@ -28,5 +34,7 @@ data:
               cpu_request: '1'
               cpu_limit: '1'
             return:
-              # This path applies to the last item in 'resources' list above
+              # Paths are applied to the last item in 'resources' list above
+              # These assume the dashboard route entry above is listed last
               RAY_CLUSTER: 'metadata.labels[odh-ray-cluster-service]'
+              RAY_DASH_HOST: 'spec.host'


### PR DESCRIPTION
Adds a `Route` for the Ray dashboard, and exposes an environment var `RAY_DASH_URL` that jupyter users can display to get the dashboard URL for their browser.