### PR TITLE
Add spark3.0.1 notebook image

### DIFF
--- a/kfdefs/base/jupyterhub/notebook-images/kustomization.yaml
+++ b/kfdefs/base/jupyterhub/notebook-images/kustomization.yaml
@@ -16,4 +16,5 @@ resources:
   - openshift-anomaly-detection.yaml
   - pet-image-detection.yaml
   - ray-ml-notebook.yaml
+  - s2i-spark3.0.1-minimal-notebook.yaml
   - time-series.yaml

--- a/kfdefs/base/jupyterhub/notebook-images/s2i-spark3.0.1-minimal-notebook.yaml
+++ b/kfdefs/base/jupyterhub/notebook-images/s2i-spark3.0.1-minimal-notebook.yaml
@@ -1,0 +1,20 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-name:
+      "s2i-spark-minimal-notebook:py36-spark3.0.1-hadoop3.2.0"
+    opendatahub.io/notebook-image-desc:
+      "Jupyter notebook image based on spark3.0.1 with xskipper examples"
+  name: spark3.0.1-xskipper
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations:
+      openshift.io/imported-from: quay.io/llasmith/s2i-spark-container
+    from:
+      kind: DockerImage
+      name: quay.io/llasmith/s2i-spark-container:py36-spark3.0.1-hadoop3.2.0


### PR DESCRIPTION
Current spark base notebook image is 2.4.5 which is not up to date.
Adds spark3.0.1 base notebook image. Spark version configurable Image created by @anishasthana and Landon (https://github.com/opendatahub-io/odh-manifests/issues/293)
Next up is adding xskipper sample use ipynb to it, and perhaps configure the pyspark jars to include needed jars automatically.

* I wonder if it should be added to https://github.com/aicoe-aiops or to opendatahub-io/odh-manifests instead

