### PR TITLE
Add Jupyterhub to osc playground.

### DIFF
--- a/kfdefs/overlays/moc/zero/kustomization.yaml
+++ b/kfdefs/overlays/moc/zero/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - opf-kafka
   - opf-monitoring
   - opf-superset
+  - osc-playground

--- a/kfdefs/overlays/moc/zero/osc-playground/kustomization.yaml
+++ b/kfdefs/overlays/moc/zero/osc-playground/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: osc-playground
+
+resources:
+  - ../../../../base/jupyterhub
+
+patchesJson6902:
+  - patch: |
+      - op: add
+        path: /spec/applications/2/kustomizeConfig/overlays/-
+        value: storage-class
+      - op: add
+        path: /spec/applications/2/kustomizeConfig/parameters/-
+        value:
+          name: storage_class
+          value: moc-nfs-csi
+    target:
+      group: kfdef.apps.kubeflow.org
+      kind: KfDef
+      name: opendatahub
+      version: v1


### PR DESCRIPTION
Add Jupyterhub for OS-C playground. A separate environment is needed to allow for experimentation with JH itself if needed, and some flexibility. 