### PR TITLE
Define MachineHealthCheck for worker nodes

### DIFF
--- a/cluster-scope/overlays/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/moc/zero/kustomization.yaml
@@ -159,6 +159,7 @@ resources:
   - clusterversion.yaml
   - nodenetworkconfigurationpolicies/moc-nfs-network.yaml
   - kubeletconfigs/increase-worker-system-reserved-memory.yaml
+  - machinehealthchecks/work-healthcheck.yaml
 
 generators:
   - secret-generator.yaml

--- a/cluster-scope/overlays/moc/zero/machinehealthchecks/work-healthcheck.yaml
+++ b/cluster-scope/overlays/moc/zero/machinehealthchecks/work-healthcheck.yaml
@@ -1,0 +1,25 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: worker-healthcheck
+  namespace: openshift-machine-api
+  annotations:
+    machine.openshift.io/remediation-strategy: external-baremetal
+spec:
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: "zero-n88km"
+      machine.openshift.io/cluster-api-machine-role: "worker"
+      machine.openshift.io/cluster-api-machine-type: "worker"
+  unhealthyConditions:
+    # Machine is unhealthy if Ready is False for > 10 minutes
+    - type: Ready
+      status: 'False'
+      timeout: 10m
+
+    # Or if Ready is Unknown for > 10 minutes
+    - type: Ready
+      status: Unknown
+      timeout: 10m
+  maxUnhealthy: 40%
+  nodeStartupTimeout: 15m


### PR DESCRIPTION
This defines a healthcheck for the worker nodes such that they will be
rebooted in they are unavailable (NotReady or state unknown) for more
than 10 minutes.

Closes #operate-first/SRE#112
