### PR TITLE
Update osc quota to large.

### DIFF
--- a/cluster-scope/base/core/namespaces/osc-playground/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/osc-playground/kustomization.yaml
@@ -6,4 +6,4 @@ namespace: osc-playground
 components:
     - ../../../../components/project-admin-rolebindings/osc
     - ../../../../components/limitranges/default
-    - ../../../../components/resourcequotas/medium
+    - ../../../../components/resourcequotas/large


### PR DESCRIPTION
Medium is apparently not enough for the full JH deployment we define in the base kfdef. CPU seems to require >2 cores.