### PR TITLE
Add custom resourcequota for osc.

### DIFF
--- a/cluster-scope/base/core/namespaces/osc-playground/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/osc-playground/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
     - namespace.yaml
+    - resourcequota.yaml
 namespace: osc-playground
 components:
     - ../../../../components/project-admin-rolebindings/osc
     - ../../../../components/limitranges/default
-    - ../../../../components/resourcequotas/large

--- a/cluster-scope/base/core/namespaces/osc-playground/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/osc-playground/resourcequota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: osc-playground-custom
+spec:
+  hard:
+    limits.cpu: 10
+    limits.memory: 16Gi
+    requests.cpu: 10
+    requests.memory: 16Gi
+    requests.storage: 30Gi


### PR DESCRIPTION
Large quota is not enough, need at least 8 + 2 cores for a large notebook + the jh pods. 