### PR TITLE
Increase kustomize-build test prow cpu resource

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -16,7 +16,7 @@ presubmits:
               cpu: "200m"
             limits:
               memory: "500Mi"
-              cpu: "300m"
+              cpu: "1"
 
   - name: pre-commit
     decorate: true


### PR DESCRIPTION
kustomize build tests are taking > 20mins to run. This should increase the available cpu for it and make them faster.