### PR TITLE
chore: Update cluster version updater script when multiple updates are available

### DIFF
--- a/scripts/update-cluster-version.sh
+++ b/scripts/update-cluster-version.sh
@@ -7,23 +7,33 @@ set -o pipefail
 
 if [ $# -lt 1 ] || [ "$#" == "--help" ] || [ "$#" == "-h" ] || [ ! -f "$1" ]; then
     echo "Change ClusterVersion manifest based on availableUpdates"
-    echo -e "\nUsage: $0 PATH"
-    echo -e "PATH\tPath to the ClusterVersion manifest to upgrade\n"
+    echo "Usage: $0 PATH"
+    echo 
+    echo -e "PATH\tPath to the ClusterVersion manifest to upgrade"
     exit 0
 fi
 
-echo "Updating resource file '$1'"
+echo -e "Updating resource file '$1'\n"
 
 cluster_version=$(oc get -o yaml clusterversion/version)
 
 available_updates=$(echo "$cluster_version" | yq e ".status.availableUpdates | length" -)
 if [ $available_updates == "0" ]; then
     echo "No updates available"
+    exit 1
+else
+    echo "Available updates:"
+    echo "$cluster_version" | yq e "[.status.availableUpdates[].version]" -
+
+    echo
+    echo -n "Select version: "
+    read -r new_version
 fi
 
-new_image=$(echo "$cluster_version" | yq e ".status.availableUpdates[0].image" -)
-new_version=$(echo "$cluster_version" | yq e ".status.availableUpdates[0].version" -)
+new_image=$(echo "$cluster_version" | yq e ".status.availableUpdates[] | select(.version == \"$new_version\")| .image" -)
 
+echo
+echo "Updating cluster version manifest to:"
 echo "Image:   $new_image"
 echo "Version: $new_version"
 


### PR DESCRIPTION
Just a quick update to the cluster version updater script, before it gets eventually converted to the golang version.

Offer a choice if there are multiple updates available:
![Peek 2021-06-03 16-10](https://user-images.githubusercontent.com/7453394/120659125-5a06f800-c486-11eb-8d8d-15bafb7da484.gif)
