### PR TITLE
Add alertname group by label to alert config.

### DIFF
--- a/cluster-scope/overlays/moc/common/alertmanager-main-secret.yaml
+++ b/cluster-scope/overlays/moc/common/alertmanager-main-secret.yaml
@@ -75,6 +75,7 @@ stringData:
           group_by:
             - namespace
             - severity
+            - alertname
           continue: true
           routes:
             # Alerts we do not want to receive


### PR DESCRIPTION
Need this label to add properly title issue in alerts repo. Otherwise we get this: https://github.com/operate-first/alerts/issues/8791