### PR TITLE
Update odh servicemonitors

### DIFF
--- a/odh-manifests/prometheus/operator/base/service-monitors/application-service-monitor.yaml
+++ b/odh-manifests/prometheus/operator/base/service-monitors/application-service-monitor.yaml
@@ -2,13 +2,16 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: odhservicemonitor
+  labels:
+    team: opendatahub
+  name: odh-application-servicemonitor
 spec:
   endpoints:
-    - port: web             # Prometheus
+    - port: oauth-proxy     # Prometheus
+    - port: web             # Alertmanager
     - port: metrics         # Argo
     - port: grafana         # grafana
-    - port: http-metrics    # grafana-operator, Open Data Hub operator
+    - port: http-metrics    # grafana-operator
     - port: 8080-tcp        # Jupyterhub
       path: "/metrics"
   selector: {}
@@ -17,4 +20,3 @@ spec:
       - opf-jupyterhub
       - opf-argo
       - opf-monitoring
-      - openshift-operators

--- a/odh-manifests/prometheus/operator/base/service-monitors/operator-service-monitor.yaml
+++ b/odh-manifests/prometheus/operator/base/service-monitors/operator-service-monitor.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    team: opendatahub
+  name: odh-operator-servicemonitor
+spec:
+  endpoints:
+    - port: http-metrics    # Open Data Hub operator
+    - port: cr-metrics      # Open Data Hub Operator
+  selector:
+    matchLabels:
+      name: opendatahub-operator
+  namespaceSelector:
+    matchNames:
+      - opendatahub-operator

--- a/odh-manifests/prometheus/operator/overlays/alerts/prometheus-rules.yaml
+++ b/odh-manifests/prometheus/operator/overlays/alerts/prometheus-rules.yaml
@@ -11,7 +11,7 @@ spec:
     - name: Operate First Availability
       rules:
         - alert: Prometheus Service Down
-          expr: absent(up{service="prometheus-operated", pod=~"prometheus-odh-monitoring.*"} > 0)
+          expr: absent(up{service="prometheus-proxy", pod=~"prometheus-odh-monitoring.*"} > 0)
           for: 10m
           annotations:
             summary: "Prometheus service is no longer available"


### PR DESCRIPTION
The [upstream directory](https://github.com/opendatahub-io/odh-manifests/tree/master/prometheus/operator/base/service-monitors) for servicemonitor manifests has changed, they need to be changed here as well.
This has resulted into multiple servicemonitors looking for same services.

Resolves https://github.com/operate-first/apps/issues/641