### PR TITLE
fix: change scheme for prometheus serviemonitor

### DIFF
--- a/odh-manifests/prometheus/operator/base/service-monitors/application-service-monitor.yaml
+++ b/odh-manifests/prometheus/operator/base/service-monitors/application-service-monitor.yaml
@@ -8,6 +8,9 @@ metadata:
 spec:
   endpoints:
     - port: oauth-proxy     # Prometheus
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
     - port: web             # Alertmanager
     - port: metrics         # Argo
     - port: grafana         # grafana


### PR DESCRIPTION
After the oauth proxy was added, the service was changed to https from http, this needs to be reflected in the servicemonitor as well.
Resolves https://github.com/operate-first/apps/issues/641