### PR TITLE
feat: Install Koku operator to Zero cluster

### DIFF
--- a/cluster-scope/base/core/namespaces/koku-metrics-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/koku-metrics-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - namespace.yaml
+components:
+    - ../../../../components/project-admin-rolebindings/operate-first

--- a/cluster-scope/base/core/namespaces/koku-metrics-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/koku-metrics-operator/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: koku-metrics-operator
+    annotations:
+        openshift.io/requester: operate-first

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/koku-metrics-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/koku-metrics-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - operatorgroup.yaml
+namespace: koku-metrics-operator

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/koku-metrics-operator/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/koku-metrics-operator/operatorgroup.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+    name: koku-metrics-operator
+spec:
+    targetNamespaces:
+        - koku-metrics-operator

--- a/cluster-scope/base/operators.coreos.com/subscriptions/koku-metrics-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/koku-metrics-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - subscription.yaml
+namespace: koku-metrics-operator

--- a/cluster-scope/base/operators.coreos.com/subscriptions/koku-metrics-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/koku-metrics-operator/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+    name: koku-metrics-operator
+spec:
+    channel: beta
+    installPlanApproval: Automatic
+    name: koku-metrics-operator
+    source: community-operators
+    sourceNamespace: openshift-marketplace

--- a/cluster-scope/overlays/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/moc/zero/kustomization.yaml
@@ -22,6 +22,7 @@ resources:
   - ../../../base/core/namespaces/ds-example-project
   - ../../../base/core/namespaces/ds-ml-workflows-ws
   - ../../../base/core/namespaces/fde-audio-decoder-demo
+  - ../../../base/core/namespaces/koku-metrics-operator
   - ../../../base/core/namespaces/kubeflow
   - ../../../base/core/namespaces/lab-cicd-1-jump-app-cicd
   - ../../../base/core/namespaces/lab-cicd-1-jump-app-dev
@@ -97,6 +98,7 @@ resources:
   - ../../../base/operator.openshift.io/ingresscontrollers/default
   - ../../../base/operators.coreos.com/catalogsources/pulp-catalog
   - ../../../base/operators.coreos.com/operatorgroups/cluster-logging
+  - ../../../base/operators.coreos.com/operatorgroups/koku-metrics-operator
   - ../../../base/operators.coreos.com/operatorgroups/local-storage-operator-group
   - ../../../base/operators.coreos.com/operatorgroups/openshift-cnv-rn5jf
   - ../../../base/operators.coreos.com/operatorgroups/openshift-metering
@@ -106,6 +108,7 @@ resources:
   - ../../../base/operators.coreos.com/operatorgroups/pulp-operator
   - ../../../base/operators.coreos.com/subscriptions/cluster-logging
   - ../../../base/operators.coreos.com/subscriptions/elasticsearch-operator
+  - ../../../base/operators.coreos.com/subscriptions/koku-metrics-operator
   - ../../../base/operators.coreos.com/subscriptions/kubevirt-hyperconverged
   - ../../../base/operators.coreos.com/subscriptions/local-storage-operator
   - ../../../base/operators.coreos.com/subscriptions/metering-operator


### PR DESCRIPTION
Created via https://github.com/operate-first/opfcli/pull/22
Part of: https://github.com/operate-first/support/issues/265

Install and enables operator on Curator cluster

/cc @skanthed