### PR TITLE
Prevent usage of rgw storage class for buckets.

### DIFF
--- a/cluster-scope/base/core/namespaces/opf-ci-pipelines/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/opf-ci-pipelines/resourcequota.yaml
@@ -10,3 +10,4 @@ spec:
     requests.memory: 80Gi
     requests.storage: 30Gi
     count/taskruns.tekton.dev: 3k
+    count/objectbucketclaims.objectbucket.io: 1

--- a/cluster-scope/base/core/namespaces/opf-ci-prow/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/opf-ci-prow/resourcequota.yaml
@@ -9,3 +9,4 @@ spec:
     requests.cpu: '16'
     requests.memory: 36Gi
     requests.storage: 30Gi
+    count/objectbucketclaims.objectbucket.io: 1

--- a/cluster-scope/base/core/namespaces/opf-datacatalog/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/opf-datacatalog/resourcequota.yaml
@@ -9,3 +9,4 @@ spec:
     requests.cpu: '4'
     requests.memory: 8Gi
     requests.storage: 20Gi
+    count/objectbucketclaims.objectbucket.io: 1

--- a/cluster-scope/base/core/namespaces/osc-playground/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/osc-playground/resourcequota.yaml
@@ -9,3 +9,4 @@ spec:
     requests.cpu: 10
     requests.memory: 16Gi
     requests.storage: 30Gi
+    count/objectbucketclaims.objectbucket.io: 1

--- a/cluster-scope/base/core/namespaces/thoth-amun-inspection-prod/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/thoth-amun-inspection-prod/resourcequota.yaml
@@ -9,3 +9,4 @@ spec:
     limits.cpu: '16'
     limits.memory: 32Gi
     requests.storage: 40Gi
+    count/objectbucketclaims.objectbucket.io: 1

--- a/cluster-scope/base/core/namespaces/thoth-backend-prod/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/thoth-backend-prod/resourcequota.yaml
@@ -9,3 +9,4 @@ spec:
     requests.cpu: '24'
     requests.memory: 48Gi
     requests.storage: 30Gi
+    count/objectbucketclaims.objectbucket.io: 1

--- a/cluster-scope/base/core/namespaces/thoth-frontend-prod/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/thoth-frontend-prod/resourcequota.yaml
@@ -9,3 +9,4 @@ spec:
     requests.cpu: '8'
     requests.memory: 12Gi
     requests.storage: 40Gi
+    count/objectbucketclaims.objectbucket.io: 1

--- a/cluster-scope/base/core/namespaces/thoth-graph-prod/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/thoth-graph-prod/resourcequota.yaml
@@ -9,3 +9,4 @@ spec:
     requests.cpu: '12'
     requests.memory: 16Gi
     requests.storage: 120Gi
+    count/objectbucketclaims.objectbucket.io: 1

--- a/cluster-scope/base/core/namespaces/thoth-middletier-prod/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/thoth-middletier-prod/resourcequota.yaml
@@ -11,3 +11,4 @@ spec:
     requests.cpu: '16'
     requests.memory: 32Gi
     requests.storage: 64Gi
+    count/objectbucketclaims.objectbucket.io: 1

--- a/cluster-scope/components/resourcequotas/large/resourcequotas.yaml
+++ b/cluster-scope/components/resourcequotas/large/resourcequotas.yaml
@@ -9,3 +9,4 @@ spec:
     limits.cpu: '4'
     limits.memory: 16Gi
     requests.storage: 80Gi
+    count/objectbucketclaims.objectbucket.io: 1

--- a/cluster-scope/components/resourcequotas/medium/resourcequotas.yaml
+++ b/cluster-scope/components/resourcequotas/medium/resourcequotas.yaml
@@ -9,3 +9,4 @@ spec:
     limits.cpu: '2'
     limits.memory: 8Gi
     requests.storage: 40Gi
+    count/objectbucketclaims.objectbucket.io: 1

--- a/cluster-scope/components/resourcequotas/small/resourcequotas.yaml
+++ b/cluster-scope/components/resourcequotas/small/resourcequotas.yaml
@@ -9,3 +9,4 @@ spec:
     limits.cpu: '1'
     limits.memory: 4Gi
     requests.storage: 20Gi
+    count/objectbucketclaims.objectbucket.io: 1

--- a/cluster-scope/components/resourcequotas/x-small/resourcequotas.yaml
+++ b/cluster-scope/components/resourcequotas/x-small/resourcequotas.yaml
@@ -9,3 +9,4 @@ spec:
     limits.cpu: '500m'
     limits.memory: 2Gi
     requests.storage: 10Gi
+    count/objectbucketclaims.objectbucket.io: 1


### PR DESCRIPTION
~Resolve: https://github.com/operate-first/SRE/issues/324~

I also added a cap of 1 objectbucketclaim for each quota. I also updated existing user custom quotas, a brief skim through indicated they already respected these restrictions so it should not affect them. 

Reference: https://kubernetes.io/docs/concepts/policy/resource-quotas/#storage-resource-quota