### PR TITLE
fix(alerts): ClusterOperatorDown/Degraded inhibit rule dedup

### DIFF
--- a/cluster-scope/overlays/moc/common/alertmanager-main-secret.yaml
+++ b/cluster-scope/overlays/moc/common/alertmanager-main-secret.yaml
@@ -24,9 +24,9 @@ stringData:
       - namespace
       - alertname
     - source_match:
-        alertname: ClusterOperatorDegraded
-      target_match_re:
         alertname: ClusterOperatorDown
+      target_match_re:
+        alertname: ClusterOperatorDegraded
       equal:
       - namespace
       - name
@@ -59,12 +59,6 @@ stringData:
         alertname: ElasticsearchClusterNotHealthy
       equal:
       - dummylabel
-    - source_match:
-        alertname: ClusterOperatorDown
-      target_match_re:
-        alertname: ClusterOperatorDegraded
-      equal:
-        - namespace
     receivers:
       - name: Watchdog
       - name: "null"


### PR DESCRIPTION
https://github.com/operate-first/apps/pull/718 introduced a duplicity in attempt to correct SRE-P rule - this made both `ClusterOperatorDown` and `ClusterOperatorDegraded` alerts suppressed. And we don't want that. I hope this will correct things.