### PR TITLE
Apply resource quotas to namespaces that are without one.

### DIFF
--- a/cluster-scope/base/core/namespaces/apicurio-apicurio-registry/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/apicurio-apicurio-registry/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/apicurio
 - ../../../../components/monitoring-rbac
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: apicurio-apicurio-registry
 resources:

--- a/cluster-scope/base/core/namespaces/as-pushgateway/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/as-pushgateway/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/ai-services
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: as-pushgateway
 resources:

--- a/cluster-scope/base/core/namespaces/cnv-testing/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/cnv-testing/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/cnv-testing
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/medium
 kind: Kustomization
 namespace: cnv-testing
 resources:

--- a/cluster-scope/base/core/namespaces/ds-black-flake/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/ds-black-flake/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/operate-first
 - ../../../../components/project-admin-rolebindings/data-science
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: ds-black-flake
 resources:

--- a/cluster-scope/base/core/namespaces/ds-example-project/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/ds-example-project/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/operate-first
 - ../../../../components/project-admin-rolebindings/data-science
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: ds-example-project
 resources:

--- a/cluster-scope/base/core/namespaces/ds-ml-workflows-ws/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/ds-ml-workflows-ws/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/operate-first
 - ../../../../components/project-admin-rolebindings/data-science
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/medium
 kind: Kustomization
 namespace: ds-ml-workflows-ws
 resources:

--- a/cluster-scope/base/core/namespaces/fde-audio-decoder-demo/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/fde-audio-decoder-demo/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/fde
 - ../../../../components/project-view-public
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/large
 kind: Kustomization
 namespace: fde-audio-decoder-demo
 resources:

--- a/cluster-scope/base/core/namespaces/lab-cicd-1-jump-app-cicd/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/lab-cicd-1-jump-app-cicd/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/lab-cicd
 - ../../../../components/project-view-public
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: lab-cicd-1-jump-app-cicd
 resources:

--- a/cluster-scope/base/core/namespaces/lab-cicd-1-jump-app-dev/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/lab-cicd-1-jump-app-dev/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/lab-cicd
 - ../../../../components/project-view-public
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: lab-cicd-1-jump-app-dev
 resources:

--- a/cluster-scope/base/core/namespaces/lab-cicd-2-jump-app-cicd/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/lab-cicd-2-jump-app-cicd/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/lab-cicd
 - ../../../../components/project-view-public
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: lab-cicd-2-jump-app-cicd
 resources:

--- a/cluster-scope/base/core/namespaces/lab-cicd-2-jump-app-dev/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/lab-cicd-2-jump-app-dev/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/lab-cicd
 - ../../../../components/project-view-public
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: lab-cicd-2-jump-app-dev
 resources:

--- a/cluster-scope/base/core/namespaces/lab-cicd-3-jump-app-cicd/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/lab-cicd-3-jump-app-cicd/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/lab-cicd
 - ../../../../components/project-view-public
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: lab-cicd-3-jump-app-cicd
 resources:

--- a/cluster-scope/base/core/namespaces/lab-cicd-3-jump-app-dev/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/lab-cicd-3-jump-app-dev/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/lab-cicd
 - ../../../../components/project-view-public
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: lab-cicd-3-jump-app-dev
 resources:

--- a/cluster-scope/base/core/namespaces/lab-cicd-4-jump-app-cicd/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/lab-cicd-4-jump-app-cicd/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/lab-cicd
 - ../../../../components/project-view-public
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: lab-cicd-4-jump-app-cicd
 resources:

--- a/cluster-scope/base/core/namespaces/lab-cicd-4-jump-app-dev/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/lab-cicd-4-jump-app-dev/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/lab-cicd
 - ../../../../components/project-view-public
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: lab-cicd-4-jump-app-dev
 resources:

--- a/cluster-scope/base/core/namespaces/m4d-blueprints/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/m4d-blueprints/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/mesh-for-data
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: m4d-blueprints
 resources:

--- a/cluster-scope/base/core/namespaces/m4d-system/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/m4d-system/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/mesh-for-data
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: m4d-system
 resources:

--- a/cluster-scope/base/core/namespaces/mesh-for-data/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/mesh-for-data/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/operate-first
 - ../../../../components/project-admin-rolebindings/mesh-for-data
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: mesh-for-data
 resources:

--- a/cluster-scope/base/core/namespaces/open-aiops/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/open-aiops/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/operate-first
 - ../../../../components/project-admin-rolebindings/open-aiops
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: open-aiops
 resources:

--- a/cluster-scope/base/core/namespaces/ray-odh-integration/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/ray-odh-integration/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/ray
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: ray-odh-integration
 resources:

--- a/cluster-scope/base/core/namespaces/sa-dach-anwendertreffen/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/sa-dach-anwendertreffen/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/sa-dach
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: sa-dach-anwendertreffen
 resources:

--- a/cluster-scope/base/core/namespaces/sa-dach-openshift-examples/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/sa-dach-openshift-examples/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/sa-dach
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: sa-dach-openshift-examples
 resources:

--- a/cluster-scope/base/core/namespaces/sdap/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/sdap/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/sdap-mslsp
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: sdap
 resources:

--- a/cluster-scope/base/core/namespaces/tufts-dcc-6/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/tufts-dcc-6/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/tufts-dcc-6
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: tufts-dcc-6
 resources:

--- a/cluster-scope/base/core/namespaces/uky-hpc-workload-generator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/uky-hpc-workload-generator/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/uky-redhat
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: uky-hpc-workload-generator
 resources:

--- a/cluster-scope/base/core/namespaces/ws-ml-prague/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/ws-ml-prague/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/workshops
 - ../../../../components/project-view-public
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/x-small
 kind: Kustomization
 namespace: ws-ml-prague
 resources:


### PR DESCRIPTION
Applied quotas to namespaces as specified: https://github.com/operate-first/apps/issues/574#issuecomment-827497979

I didn't touch `openshift-*` or `opf-*` namespaces. 

I also tried to peek in to some of the namespaces to see if they are active/maintained, and tried to approximate a quota that's better fitting then just `x-small`, if it was either unclear, or a namespace not in use, then I defaulted to `x-small`. 