### PR TITLE
fix: Semi-revert #722

### DIFF
--- a/cluster-scope/overlays/moc/common/alertmanager-main-secret.yaml
+++ b/cluster-scope/overlays/moc/common/alertmanager-main-secret.yaml
@@ -23,10 +23,12 @@ stringData:
       equal:
       - namespace
       - alertname
+    # https://github.com/openshift/configure-alertmanager-operator/blob/c9032fd13a9dcd7d374d1491db4b23af1120ba11/pkg/controller/secret/secret_controller.go#L349-L350
+    # The degraded alert is critical, and usually has more details
     - source_match:
-        alertname: ClusterOperatorDown
-      target_match_re:
         alertname: ClusterOperatorDegraded
+      target_match_re:
+        alertname: ClusterOperatorDown
       equal:
       - namespace
       - name


### PR DESCRIPTION
Partially reverts #722 

Looking back at the source

https://github.com/openshift/configure-alertmanager-operator/blob/c9032fd13a9dcd7d374d1491db4b23af1120ba11/pkg/controller/secret/secret_controller.go#L349-L350

It seems there's a reason why `ClusterOperatorDegraded` is favored over `ClusterOperatorDown`

/cc @HumairAK 