### PR TITLE
Add tls authentication for opf-kafka with example users

### DIFF
--- a/kfdefs/overlays/moc/zero/opf-kafka/kustomization.yaml
+++ b/kfdefs/overlays/moc/zero/opf-kafka/kustomization.yaml
@@ -13,6 +13,7 @@ patchesJson6902:
           kustomizeConfig:
             overlays:
               - topics
+              - users
             repoRef:
               name: opf
               path: odh-manifests/kafka

--- a/odh-manifests/kafka/base/kafka-cluster.yaml
+++ b/odh-manifests/kafka/base/kafka-cluster.yaml
@@ -16,10 +16,16 @@ spec:
         port: 9093
         type: internal
         tls: true
+        authentication:
+          type: tls
       - name: external
         port: 9094
         type: route
         tls: true
+        authentication:
+          type: tls
+    authorization:
+      type: simple
     config:
       auto.create.topics.enable: false
       offsets.topic.replication.factor: 3
@@ -53,4 +59,5 @@ spec:
           key: zookeeper-prometheus-metrics
   entityOperator:
     topicOperator: {}
-    userOperator: {}
+    userOperator:
+      secretPrefix: kafka-user-

--- a/odh-manifests/kafka/overlays/topics/kustomization.yaml
+++ b/odh-manifests/kafka/overlays/topics/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  strimzi.io/cluster: odh-message-bus
 resources:
 - audio-decoder-decoded-speech.yaml
 - audio-decoder-sentiment-text.yaml

--- a/odh-manifests/kafka/overlays/users/audio-decoder.yaml
+++ b/odh-manifests/kafka/overlays/users/audio-decoder.yaml
@@ -1,0 +1,18 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: audio-decoder
+spec:
+  authentication:
+    type: tls
+  authorization:
+    acls:
+      - host: '*'
+        operation: All
+        resource:
+          # this user has access to all topics with "audio-decoder-" prefix
+          name: audio-decoder-
+          patternType: prefix
+          type: topic
+        type: allow
+    type: simple

--- a/odh-manifests/kafka/overlays/users/kustomization.yaml
+++ b/odh-manifests/kafka/overlays/users/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  strimzi.io/cluster: odh-message-bus
+resources:
+- audio-decoder.yaml
+- thoth.yaml

--- a/odh-manifests/kafka/overlays/users/thoth.yaml
+++ b/odh-manifests/kafka/overlays/users/thoth.yaml
@@ -1,0 +1,18 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: thoth
+spec:
+  authentication:
+    type: tls
+  authorization:
+    acls:
+      - host: '*'
+        operation: All
+        resource:
+          # this user has access to all topics with "thoth-" prefix
+          name: thoth-
+          patternType: prefix
+          type: topic
+        type: allow
+    type: simple


### PR DESCRIPTION
Resolves #482 

This:
* sets up simple tls authentication for Operate First Kafka cluster
* adds 2 example users for thoth team (@harshad16) and for fde audio decoder demo (@Gkrumbach07)

More documentation on how the tls authentication works: https://strimzi.io/docs/operators/0.22.0/using.html#tls_client_authentication