### PR TITLE
Install Horreum operator to mwperf-horreum namespace

### DIFF
--- a/cluster-scope/base/operators.coreos.com/operatorgroups/mwperf-horreum/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/mwperf-horreum/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - operatorgroup.yaml
+namespace: mwperf-horreum

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/mwperf-horreum/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/mwperf-horreum/operatorgroup.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+    name: mwperf-horreum
+spec:
+    targetNamespaces:
+        - mwperf-horreum

--- a/cluster-scope/base/operators.coreos.com/subscriptions/horreum-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/horreum-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - subscription.yaml
+namespace: mwperf-horreum

--- a/cluster-scope/base/operators.coreos.com/subscriptions/horreum-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/horreum-operator/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+    name: horreum-operator
+spec:
+    channel: alpha
+    installPlanApproval: Automatic
+    name: horreum-operator
+    source: community-operators
+    sourceNamespace: openshift-marketplace

--- a/cluster-scope/overlays/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/moc/zero/kustomization.yaml
@@ -101,6 +101,7 @@ resources:
   - ../../../base/operators.coreos.com/operatorgroups/cluster-logging
   - ../../../base/operators.coreos.com/operatorgroups/koku-metrics-operator
   - ../../../base/operators.coreos.com/operatorgroups/local-storage-operator-group
+  - ../../../base/operators.coreos.com/operatorgroups/mwperf-horreum
   - ../../../base/operators.coreos.com/operatorgroups/openshift-cnv-rn5jf
   - ../../../base/operators.coreos.com/operatorgroups/openshift-metering
   - ../../../base/operators.coreos.com/operatorgroups/openshift-operators-redhat
@@ -109,6 +110,7 @@ resources:
   - ../../../base/operators.coreos.com/operatorgroups/pulp-operator
   - ../../../base/operators.coreos.com/subscriptions/cluster-logging
   - ../../../base/operators.coreos.com/subscriptions/elasticsearch-operator
+  - ../../../base/operators.coreos.com/subscriptions/horreum-operator
   - ../../../base/operators.coreos.com/subscriptions/koku-metrics-operator
   - ../../../base/operators.coreos.com/subscriptions/kubevirt-hyperconverged
   - ../../../base/operators.coreos.com/subscriptions/local-storage-operator


### PR DESCRIPTION
Created through

```
opfcli install-operator horreum-operator community-operators -n mwperf-horreum -s -c alpha
```

@HumairAK Please review.

I hope that as a project admin I'll have the necessary privileges to create a CR brought by the operator (if not I'll try file another PR).