### PR TITLE
fix: team access to namespaces

### DIFF
--- a/cluster-scope/base/core/namespaces/curator-engine/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/curator-engine/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: curator-engine
 resources:
     - namespace.yaml
 components:

--- a/cluster-scope/base/core/namespaces/koku-metrics-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/koku-metrics-operator/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: koku-metrics-operator
 resources:
     - namespace.yaml
 components:


### PR DESCRIPTION
Caused by: https://github.com/operate-first/opfcli/issues/38

Causing project admin roles not to propagate to a namespaces (ArgoCD uses `open-cluster-management-agent`)