### PR TITLE
fix: missing namespace in kustomization

### DIFF
--- a/cluster-scope/base/core/namespaces/hostpath-provisioner/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/hostpath-provisioner/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: hostpath-provisioner
 resources:
 - namespace.yaml

--- a/cluster-scope/base/core/namespaces/metallb-system/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/metallb-system/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: metallb-system
 resources:
 - namespace.yaml

--- a/cluster-scope/base/core/namespaces/opf-google-spark-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/opf-google-spark-operator/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: opf-google-spark-operator
 resources:
     - namespace.yaml
 components:


### PR DESCRIPTION
Before https://github.com/operate-first/opfcli/issues/38 was fixed it got propagated to `opf-google-spark-operator` namespace (and now to https://github.com/operate-first/apps/pull/757 as well).

Setting `namespace:` for `hostpath-provisioner` and `metallb-system` for house keeping.