### PR TITLE
fix topic prefix for kafka users

### DIFF
--- a/odh-manifests/kafka/overlays/users/audio-decoder.yaml
+++ b/odh-manifests/kafka/overlays/users/audio-decoder.yaml
@@ -10,8 +10,8 @@ spec:
       - host: '*'
         operation: All
         resource:
-          # this user has access to all topics with "audio-decoder-" prefix
-          name: audio-decoder-
+          # this user has access to all topics with "audio-decoder." prefix
+          name: audio-decoder.
           patternType: prefix
           type: topic
         type: allow

--- a/odh-manifests/kafka/overlays/users/thoth.yaml
+++ b/odh-manifests/kafka/overlays/users/thoth.yaml
@@ -10,8 +10,16 @@ spec:
       - host: '*'
         operation: All
         resource:
-          # this user has access to all topics with "thoth-" prefix
-          name: thoth-
+          # this user has access to all topics with "zero-prod.thoth." prefix
+          name: zero-prod.thoth.
+          patternType: prefix
+          type: topic
+        type: allow
+      - host: '*'
+        operation: All
+        resource:
+          # this user has access to all topics with "zero-test.thoth." prefix
+          name: zero-test.thoth.
           patternType: prefix
           type: topic
         type: allow


### PR DESCRIPTION
this should fix the incorrect topic name prefixes assigned to kafka users