### PR TITLE
update retention to match cache time for advises and provenance

### DIFF
--- a/odh-manifests/kafka/overlays/topics/thoth-adviser-trigger.yaml
+++ b/odh-manifests/kafka/overlays/topics/thoth-adviser-trigger.yaml
@@ -8,4 +8,4 @@ spec:
   partitions: 1
   replicas: 1
   config:
-    retention.ms: 86400000
+    retention.ms: 14400000

--- a/odh-manifests/kafka/overlays/topics/thoth-provenance-checker-trigger.yaml
+++ b/odh-manifests/kafka/overlays/topics/thoth-provenance-checker-trigger.yaml
@@ -8,4 +8,4 @@ spec:
   partitions: 1
   replicas: 1
   config:
-    retention.ms: 86400000
+    retention.ms: 14400000


### PR DESCRIPTION
If messages are still around after cache expires they will no longer provide info to users. Cache retention time is 4hours, I adjusted topic retention time to match this.