### PR TITLE
Added group adoptium to common kustomization.

### DIFF
--- a/cluster-scope/overlays/moc/common/kustomization.yaml
+++ b/cluster-scope/overlays/moc/common/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../../../base/machineconfiguration.openshift.io/machineconfigs/99-worker-ssh
   - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners/
   - ../../../base/rbac.authorization.k8s.io/clusterroles/events-aggregate-to-edit
+  - ../../../base/user.openshift.io/groups/adoptium
   - ../../../base/user.openshift.io/groups/ai-services
   - ../../../base/user.openshift.io/groups/apicurio
   - ../../../base/user.openshift.io/groups/argocd-admins


### PR DESCRIPTION
This was missed here: https://github.com/operate-first/apps/pull/752

Probably missed by CI because we ignore the secrets.