### PR TITLE
update ray images to use ray 1.4 and include ibm codeflare

### DIFF
--- a/kfdefs/base/jupyterhub/notebook-images/ray-ml-notebook.yaml
+++ b/kfdefs/base/jupyterhub/notebook-images/ray-ml-notebook.yaml
@@ -18,4 +18,4 @@ spec:
       from:
         kind: DockerImage
         # can rebuild with newer nightly SHAs periodically
-        name: 'quay.io/erikerlandson/ray-ml-notebook:py-3.6-ray-ea6bdfb9'
+        name: 'quay.io/erikerlandson/ray-ml-notebook:py-3.8-ray-1.4.0'

--- a/kfdefs/base/jupyterhub/ray-odh-integration/ray-ml-node-imagestream.yaml
+++ b/kfdefs/base/jupyterhub/ray-odh-integration/ray-ml-node-imagestream.yaml
@@ -11,4 +11,4 @@ spec:
       from:
         kind: DockerImage
         # can rebuild with newer nightly SHAs periodically
-        name: 'quay.io/erikerlandson/ray-ml-ubi:py-3.6-ray-ea6bdfb9'
+        name: 'quay.io/erikerlandson/ray-ml-ubi:py-3.8-ray-1.4.0'

--- a/kfdefs/base/jupyterhub/ray-odh-integration/ray-operator-imagestream.yaml
+++ b/kfdefs/base/jupyterhub/ray-odh-integration/ray-operator-imagestream.yaml
@@ -10,4 +10,4 @@ spec:
       from:
         kind: DockerImage
         # can rebuild with newer nightly SHAs periodically
-        name: 'quay.io/erikerlandson/ray-operator-ubi:py-3.6-ray-ea6bdfb9'
+        name: 'quay.io/erikerlandson/ray-operator-ubi:py-3.8-ray-1.4.0'


### PR DESCRIPTION
Recent versions of ray 1.x (e.g. the latest, 1.4) support the ray client-server connect, and so I am updating all the images to use ray 1.4.0 instead of nightly wheel builds.  I have also included IBM's codeflare, which they released to pypi this week.
