### PR TITLE
fix: Don't sync acme operator configmap

### DIFF
--- a/acme-operator/overlays/moc/zero/issuer-letsencrypt-live.yaml
+++ b/acme-operator/overlays/moc/zero/issuer-letsencrypt-live.yaml
@@ -3,7 +3,8 @@ apiVersion: v1
 metadata:
   name: letsencrypt-live
   annotations:
-    "acme.openshift.io/priority": "100"
+    acme.openshift.io/priority: "100"
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
     managed-by: "openshift-acme"
     type: "CertIssuer"


### PR DESCRIPTION
Resolves: https://github.com/operate-first/apps/issues/783