### PR TITLE
Add data-science group as project admins for the opf-seldon namespace

### DIFF
--- a/cluster-scope/base/core/namespaces/opf-seldon/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/opf-seldon/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
 - namespace.yaml
 
 components:
+- ../../../../components/project-admin-rolebindings/data-science
 - ../../../../components/project-admin-rolebindings/operate-first
 - ../../../../components/project-admin-rolebindings/odh-admin


### PR DESCRIPTION
Resolves https://github.com/operate-first/support/issues/259