### PR TITLE
increase limit to better utilize the namespace

### DIFF
--- a/cluster-scope/base/core/namespaces/thoth-middletier-prod/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/thoth-middletier-prod/resourcequota.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   hard:
     count/pods: '625'
-    count/workflows.argoproj.io: 1k
+    count/workflows.argoproj.io: 1.5k
     limits.cpu: '16'
-    limits.memory: 32Gi
+    limits.memory: 48Gi
     requests.cpu: '16'
     requests.memory: 32Gi
     requests.storage: 64Gi


### PR DESCRIPTION
increase limit to better utilize the namespace
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

we are working on optimizing our usage in the `thoth-middletier-namespace`, we have reduce our requests requirement and matched our limit to the `peak` , with this pr we would be able to utilize more efficiently.

![custom-middletier](https://user-images.githubusercontent.com/14028058/123272889-2b51cf80-d4d0-11eb-8911-bcd709c64242.png)


Related-to: https://github.com/operate-first/SRE/issues/346