### PR TITLE
increase the resource limit for the graph namespace

### DIFF
--- a/cluster-scope/base/core/namespaces/thoth-graph-prod/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/thoth-graph-prod/resourcequota.yaml
@@ -4,9 +4,9 @@ metadata:
   name: thoth-graph-prod-custom
 spec:
   hard:
-    limits.cpu: '12'
-    limits.memory: 16Gi
     requests.cpu: '12'
-    requests.memory: 16Gi
+    requests.memory: 20Gi
     requests.storage: 120Gi
-    count/objectbucketclaims.objectbucket.io: 1
+    limits.cpu: '14'
+    limits.memory: 24Gi
+    count/objectbucketclaims.objectbucket.io: 2


### PR DESCRIPTION
increase the resource limit for the graph namespace
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Require some cushion in resource quota for newer deployments. 

![a-graph](https://user-images.githubusercontent.com/14028058/123281079-6277af00-d4d7-11eb-88fb-00fc724a95d1.png)
