### PR TITLE
increase kafka and zookeeper replicas from 3 to 5

### DIFF
--- a/odh-manifests/kafka/base/kafka-cluster.yaml
+++ b/odh-manifests/kafka/base/kafka-cluster.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   kafka:
     version: 2.7.0
-    replicas: 3
+    replicas: 5
     listeners:
       - name: plain
         port: 9092
@@ -45,7 +45,7 @@ spec:
           name: kafka-metrics-config
           key: kafka-prometheus-metrics
   zookeeper:
-    replicas: 3
+    replicas: 5
     storage:
       type: persistent-claim
       size: 2Gi


### PR DESCRIPTION
I have been seeing some issues in kafka producers
for example, in the cluster log forwarding fluentd pods:
```
2021-06-24 16:48:20 +0000 [warn]: failed to flush the buffer. retry_time=0 next_retry_seconds=2021-06-24 16:48:21 +0000 chunk="5c585c9c198761b415ab0b5c05102be0" error_class=Kafka::ConnectionError error="Could not connect to any of the seed brokers:\n- kafka://odh-message-bus-kafka-bootstrap-opf-kafka.apps.zero.massopen.cloud:443: Connection timed out"
  2021-06-24 16:48:20 +0000 [warn]: suppressed same stacktrace
2021-06-24 16:48:21 +0000 [warn]: Send exception occurred: Could not connect to any of the seed brokers:
- kafka://odh-message-bus-kafka-bootstrap-opf-kafka.apps.zero.massopen.cloud:443: Connection timed out
2021-06-24 16:48:21 +0000 [warn]: retry succeeded. chunk_id="5c585c9c198761b415ab0b5c05102be0"
```

The messages can be pushed when retried, this suggests that the existing replicas cannot handle the load of incoming messages.