### PR TITLE
Upgrade quota for ns ds-ml-workflows-ws.

### DIFF
--- a/cluster-scope/base/core/namespaces/ds-ml-workflows-ws/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/ds-ml-workflows-ws/kustomization.yaml
@@ -3,7 +3,7 @@ components:
 - ../../../../components/project-admin-rolebindings/operate-first
 - ../../../../components/project-admin-rolebindings/data-science
 - ../../../../components/limitranges/default
-- ../../../../components/resourcequotas/medium
+- ../../../../components/resourcequotas/large
 kind: Kustomization
 namespace: ds-ml-workflows-ws
 resources:


### PR DESCRIPTION
Context: 

> **Isabel Zimmerman wrote:**
> Hi gang-- Looking into the `ds-ml-workflows-ws` namespace and my JH server keeps getting HTTP 500 (when trying to spawn default/large/medium sized servers) and HTTP 403 (when trying to spawn small server) errors. All of the errors have the HTTP response body of `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pods \"jupyterhub-nb-izimmerm-40redhat-2ecom\" is forbidden: exceeded quota: medium, requested: limits.cpu=1, used: limits.cpu=1500m, limited: limits.cpu=2","reason":"Forbidden","details":{"name":"jupyterhub-nb-izimmerm-40redhat-2ecom","kind":"pods"},"code":403}` any help would be appreciated :disguised_face:
> 
> **1st Operator wrote:**
> Hey Tom Coufal, can you please help Isabel Zimmerman?
> 
> **Humair Khan wrote:**
> looks like you need a higher quota
> 
> **Humair Khan wrote:**
> I can upgrade it to large: <https://github.com/operate-first/support/blob/main/docs/quotas.md>
> 

_Transcript of Slack thread: https://operatefirst.slack.com/archives/C01RMPVUUK1/p1624634142253000?thread_ts=1624634142.253000&cid=C01RMPVUUK1_