### PR TITLE
Update the CPU limit graph

### DIFF
--- a/kfdefs/overlays/moc/zero/opf-monitoring/dashboards/odh/jupyterhub-user.yaml
+++ b/kfdefs/overlays/moc/zero/opf-monitoring/dashboards/odh/jupyterhub-user.yaml
@@ -245,7 +245,7 @@ spec:
           "repeatDirection": "h",
           "targets": [
             {
-              "expr": "scalar(pod:container_cpu_usage:sum{namespace=\"$namespace\",pod=\"jupyterhub-nb-$account\"}) / scalar(kube_pod_resource_request{resource=\"cpu\", exported_namespace=\"$namespace\", exported_pod=\"jupyterhub-nb-$account\"})",
+              "expr": "scalar(pod:container_cpu_usage:sum{namespace=\"$namespace\",pod=\"jupyterhub-nb-$account\"}) / scalar(kube_pod_resource_limit{resource=\"cpu\", exported_namespace=\"$namespace\", exported_pod=\"jupyterhub-nb-$account\"})",
               "format": "time_series",
               "hide": false,
               "instant": false,


### PR DESCRIPTION
In the odh Jupyterhub dashboard, the query for CPU usage percentage should have ```usage / limit``` instead of ```usage / resource```  to be  consistent with the title of the graph and the graph for memory usage percentage.