### PR TITLE
Add cpu usage dashboard to grafana.

### DIFF
--- a/kfdefs/overlays/moc/zero/opf-monitoring/dashboards/operate-first/cpu_usage.yaml
+++ b/kfdefs/overlays/moc/zero/opf-monitoring/dashboards/operate-first/cpu_usage.yaml
@@ -1,0 +1,800 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: cpu-usage
+  labels:
+    app: grafana
+spec:
+  plugins:
+    - name: grafana-piechart-panel
+      version: 1.6.2
+  json: |
+    {
+      "annotations": {
+        "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+        ]
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": 24,
+      "iteration": 1625774958398,
+      "links": [],
+      "panels": [
+      {
+        "datasource": "$datasource",
+        "description": "Total cpu cores available for user workload scheduling, master nodes are not included.",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {},
+            "mappings": [],
+            "max": 192,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 7,
+          "x": 0,
+          "y": 0
+        },
+        "id": 14,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "mean"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "7.1.1",
+        "targets": [
+        {
+          "expr": "sum(kube_node_status_capacity_cpu_cores{node!~\"os-ctrl.*\", prometheus_replica=\"prometheus-k8s-0\"})",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Total Schedulable CPU cores",
+        "type": "stat"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "The total amount of cpu requests that have been requested by ResourceQuotas currently active.",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {},
+            "mappings": [],
+            "max": 192,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 180
+              },
+              {
+                "color": "dark-red",
+                "value": 192
+              }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 6,
+          "x": 7,
+          "y": 0
+        },
+        "id": 13,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "mean"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "7.1.1",
+        "targets": [
+        {
+          "expr": "sum(kube_resourcequota{type=\"hard\", resource=\"requests.cpu\", prometheus_replica=\"prometheus-k8s-0\"})",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Total CPU requests from ResourceQuotas",
+        "type": "stat"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Cores currently not in use. This does not take into account ResourceQuotas, rather -- it takes into account cores available for the scheduler to reserve for pods.",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {},
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 4,
+          "x": 13,
+          "y": 0
+        },
+        "id": 11,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "mean"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "7.1.1",
+        "targets": [
+        {
+          "expr": "(sum(kube_node_status_capacity_cpu_cores{node!~\"os-ctrl.*\"}) - sum(kube_pod_resource_request{node!~\"os-ctrl.*\", resource=\"cpu\"}))/2",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Free Cores (Approx)",
+        "type": "stat"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "$datasource",
+        "description": "Cores currently not in use. This does not take into account ResourceQuotas, rather -- it takes into account cores available for the scheduler to reserve for pods.",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {},
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 8,
+          "w": 7,
+          "x": 17,
+          "y": 0
+        },
+        "hiddenSeries": false,
+        "id": 16,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "percentage": false,
+        "pluginVersion": "7.1.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+        {
+          "expr": "(sum(kube_node_status_capacity_cpu_cores{node!~\"os-ctrl.*\"}) - sum(kube_pod_resource_request{node!~\"os-ctrl.*\", resource=\"cpu\"}))/2",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Free Cores (Approx)",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "breakPoint": "50%",
+        "cacheTimeout": null,
+        "combine": {
+          "label": "Others",
+          "threshold": ".01"
+        },
+        "datasource": "$datasource",
+        "description": "This graph shows the sum of cpu being requested by pods per namespace. ",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fontSize": "80%",
+        "format": "short",
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 8
+        },
+        "id": 9,
+        "interval": null,
+        "legend": {
+          "percentage": true,
+          "show": true,
+          "sort": "current",
+          "sortDesc": true,
+          "values": true
+        },
+        "legendType": "Right side",
+        "links": [],
+        "nullPointMode": "connected",
+        "pieType": "pie",
+        "pluginVersion": "7.1.1",
+        "strokeWidth": ".05",
+        "targets": [
+        {
+          "expr": "sort_desc(sum(kube_pod_resource_request{resource=\"cpu\",  prometheus_replica=\"prometheus-k8s-1\"}) by (exported_namespace))",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{exported_namespace}}",
+          "refId": "A"
+        }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Pod CPU Requested By Namespace",
+        "type": "grafana-piechart-panel",
+        "valueName": "current"
+      },
+      {
+        "aliasColors": {},
+        "breakPoint": "50%",
+        "cacheTimeout": null,
+        "combine": {
+          "label": "Others",
+          "threshold": ".01"
+        },
+        "datasource": "$datasource",
+        "description": "This graph shows the sum of cpu being requested by resourcequotas. I.e. how much CPU can be requested per namespace in total.",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fontSize": "80%",
+        "format": "short",
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 8
+        },
+        "id": 15,
+        "interval": null,
+        "legend": {
+          "percentage": true,
+          "show": true,
+          "sort": "current",
+          "sortDesc": true,
+          "values": true
+        },
+        "legendType": "Right side",
+        "links": [],
+        "nullPointMode": "connected",
+        "pieType": "pie",
+        "pluginVersion": "7.1.1",
+        "strokeWidth": ".05",
+        "targets": [
+        {
+          "expr": "sum(kube_resourcequota{type=\"hard\", resource=\"requests.cpu\", prometheus_replica=\"prometheus-k8s-1\"}) by (namespace)",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{namespace}}",
+          "refId": "A"
+        }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "CPU Requests by ResourceQuotas",
+        "type": "grafana-piechart-panel",
+        "valueName": "current"
+      },
+      {
+        "datasource": "$datasource",
+        "description": "Approximate CPU requests on each node by summing CPU requests on all PENDING and RUNNING pods.\n\n\nMaximum value is found by running: \n\nsum(kube_node_status_allocatable_cpu_cores{cluster=\"\", prometheus_replica=\"prometheus-k8s-1\"}) by (node)",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {},
+            "mappings": [],
+            "max": 32,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 25
+              }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 16
+        },
+        "id": 7,
+        "options": {
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "mean"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showThresholdLabels": false,
+          "showThresholdMarkers": true
+        },
+        "pluginVersion": "7.1.1",
+        "targets": [
+        {
+          "expr": "sort(sum(sum(kube_pod_container_resource_requests_cpu_cores{prometheus_replica=\"prometheus-k8s-1\"}) by (namespace, pod, node) * on (pod, namespace) group_left()  (sum(kube_pod_status_phase{phase=~\"Pending|Running\", prometheus_replica=\"prometheus-k8s-1\"}) by (pod, namespace) == 1)) by (node))",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{node}}",
+          "refId": "A"
+        }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Total CPU Requests",
+        "type": "gauge"
+      },
+      {
+        "collapsed": false,
+        "datasource": null,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 23
+        },
+        "id": 5,
+        "panels": [],
+        "repeat": "namespace",
+        "scopedVars": {
+          "namespace": {
+            "selected": true,
+            "text": "openshift-storage",
+            "value": "openshift-storage"
+          }
+        },
+        "title": "CPU Usage vs Requests for namespace: $namespace",
+        "type": "row"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "$datasource",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 24
+        },
+        "hiddenSeries": false,
+        "id": 2,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "percentage": false,
+        "pluginVersion": "7.1.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "repeat": null,
+        "repeatDirection": "v",
+        "scopedVars": {
+          "namespace": {
+            "selected": true,
+            "text": "openshift-storage",
+            "value": "openshift-storage"
+          }
+        },
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+        {
+          "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\"}) by (namespace)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Usage",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(kube_pod_resource_request{resource=\"cpu\", prometheus_replica=\"prometheus-k8s-0\", exported_namespace=\"$namespace\"}) by (exported_namespace)",
+          "interval": "",
+          "legendFormat": "Requests",
+          "refId": "B"
+        }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "CPU",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "$datasource",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {},
+            "unit": "bytes"
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 24
+        },
+        "hiddenSeries": false,
+        "id": 3,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "percentage": false,
+        "pluginVersion": "7.1.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "repeat": null,
+        "repeatDirection": "v",
+        "scopedVars": {
+          "namespace": {
+            "selected": true,
+            "text": "openshift-storage",
+            "value": "openshift-storage"
+          }
+        },
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+        {
+          "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\"})",
+          "interval": "",
+          "legendFormat": "Usage",
+          "refId": "A"
+        },
+        {
+          "expr": "namespace:kube_pod_container_resource_requests_memory_bytes:sum{namespace=\"$namespace\", pod=\"prometheus-k8s-0\"}",
+          "interval": "",
+          "legendFormat": "Requests",
+          "refId": "B"
+        }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Memory",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      }
+      ],
+      "schemaVersion": 26,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+        {
+          "current": {
+            "selected": false,
+            "text": "opf-prometheus",
+            "value": "opf-prometheus"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "datasource",
+          "options": [],
+          "query": "prometheus",
+          "queryValue": "",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "type": "datasource"
+        },
+        {
+          "allValue": null,
+          "current": {
+            "selected": true,
+            "text": "openshift-storage",
+            "value": "openshift-storage"
+          },
+          "datasource": "opf-prometheus",
+          "definition": "label_values(kube_namespace_created{}, namespace)",
+          "hide": 0,
+          "includeAll": false,
+          "label": "Namespace",
+          "multi": false,
+          "name": "namespace",
+          "options": [],
+          "query": "label_values(kube_namespace_created{}, namespace)",
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+        ]
+      },
+      "time": {
+        "from": "now-30m",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ]
+      },
+      "timezone": "",
+      "title": "Cluster CPU Usage",
+      "uid": "vBauwggnk",
+      "version": 20
+    }

--- a/kfdefs/overlays/moc/zero/opf-monitoring/dashboards/operate-first/kustomization.yaml
+++ b/kfdefs/overlays/moc/zero/opf-monitoring/dashboards/operate-first/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - argocd.yaml
   - cluster-logs-quick-search.yaml
   - opf-availability.yaml
+  - cpu_usage.yaml


### PR DESCRIPTION
Resolve: https://github.com/operate-first/SRE/issues/241

see it live [here](https://grafana-route-opf-monitoring.apps.zero.massopen.cloud/d/vBauwggnk/cluster-cpu-usage?orgId=1&var-datasource=opf-prometheus&var-namespace=openshift-storage)