### PR TITLE
Add cluster-monitoring-config 

### DIFF
--- a/cluster-scope/overlays/prod/moc/zero/configmaps/cluster-monitoring-config.yaml
+++ b/cluster-scope/overlays/prod/moc/zero/configmaps/cluster-monitoring-config.yaml
@@ -1,0 +1,16 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    prometheusK8s:
+      volumeClaimTemplate:
+       spec:
+         storageClassName: moc-nfs-csi
+         volumeMode: Filesystem
+         resources:
+           requests:
+             storage: 100Gi

--- a/cluster-scope/overlays/prod/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/zero/kustomization.yaml
@@ -168,6 +168,7 @@ resources:
   - ../../../../base/user.openshift.io/groups/cluster-admins
 
   - clusterversion.yaml
+  - configmaps/cluster-monitoring-config.yaml
   - nodenetworkconfigurationpolicies/moc-nfs-network.yaml
   - kubeletconfigs/increase-worker-system-reserved-memory.yaml
   - machinehealthchecks/work-healthcheck.yaml


### PR DESCRIPTION
This will attach PVCs to openshift-monitoring prometheus instances.
There are 2 replicas of openshift-monitoring prometheus so this will create 2 PVCs of size 100Gi each.