### PR TITLE
feat: Onboard Zero cluster to Keycloak

### DIFF
--- a/cluster-scope/overlays/prod/moc/zero/oauths/cluster_patch.yaml
+++ b/cluster-scope/overlays/prod/moc/zero/oauths/cluster_patch.yaml
@@ -15,9 +15,27 @@ spec:
             - name
           preferredUsername:
             - preferred_username
-        clientID: moc-openshift-zero
+        clientID: moc-openshift-infra
         clientSecret:
           name: moc-sso-client-secret
         extraScopes: []
         issuer: https://sso.massopen.cloud/auth/realms/moc
+      type: OpenID
+    - mappingMethod: claim
+      name: operate-first
+      openID:
+        ca:
+          name: kube-root-ca.crt
+        claims:
+          email:
+            - email
+          name:
+            - name
+          preferredUsername:
+            - preferred_username
+        clientID: zero
+        clientSecret:
+          name: operate-first-sso-secret
+        extraScopes: []
+        issuer: https://keycloak-opf-auth.apps.moc-infra.massopen.cloud/auth/realms/operate-first
       type: OpenID

--- a/cluster-scope/overlays/prod/moc/zero/oauths/operate-first-sso-secret.enc.yaml
+++ b/cluster-scope/overlays/prod/moc/zero/oauths/operate-first-sso-secret.enc.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: operate-first-sso-secret
+    namespace: openshift-config
+    annotations:
+        argocd.argoproj.io/compare-options: IgnoreExtraneous
+        argocd.argoproj.io/sync-options: Prune=false
+type: Opaque
+stringData:
+    clientSecret: ENC[AES256_GCM,data:Y+tttNS3CEvcK5X6jcfgoly4JiSZC9w22W3Tfyx/oePouYrk,iv:B0fwTFjD0v4nyv9TudabhzadV7nZAW3vvSJIhqUMGK8=,tag:cRfXb9F3GS2ZzJTVRJcTuQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2021-07-14T15:51:30Z"
+    mac: ENC[AES256_GCM,data:FO+fc50pzJKba5o9CzjgFySpm+AG6AJ1WtNBAz9gjsiFKqOc6wkQ0N5QyG9O0+f8XsE90s4QxiNgGJfUBVrn/PzdEhoC7RwB12GlU8SGDm1pSGqIb3zjIbf3X6uCmrS25GBpZjFo8VZfVsFu7fVAsBxLjcQSruaVsHt466cPQb0=,iv:ZVLpc938G0xhnqyocy5FolimevbyX6HuX1EXR5ZPdDg=,tag:c+N5yLw/So6/eFGjCp75wg==,type:str]
+    pgp:
+        - created_at: "2021-02-18T18:10:36Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA9aKBcudqifiARAAaMniOMlq49oKYeDlFN50uVd1qGgr+OKUYP6w++eEc8Iv
+            rC2Z3Cjby65WoV7Txf+xrhfM4rLf7J6N2jRH5+MuuV/DAkIYXR1CTkhZlGRtDwdN
+            OpTum1n9NDOW4pgxR8md9jhx7z/r447r4SHQkNQyVNzwyGBNAEeBxeagysFRhZjK
+            OpAdB/pkH3fNZaI642cIXYm/bwgPjiHisxNMuJ7EqYoIQ2smD6Kqt7yI2BBO0tqm
+            9LBMbsCiQFHr1N0LoDmkAxucf5DcYVFYk2Tnp+w/LaF33TQLHYpjP0LB/G+79Vnl
+            9Y5jZuKKs1vlDsefLFwynqFCIvriGDbl2ZIOJ3J7TjmXoSMBnNeEUp9WNCv0kxXu
+            vQfHj8tGmsqW60dhs/Ppg5N8SZ8vppIRCV4TWRtU0Iu2vIGGuhzZcu3NURXezgoI
+            kTU54trgvdrTI9eGc6yH0RJHddCukPVz7G3gtIGSFU5CiMEuk2x36QvZcgddm3Z2
+            vZKSDoSNUtLTkyZYzgew9Jp7FKLpR4INphaXdIq3Kn56LBl/VftD22ayDcT80XXX
+            y+Ym2OtlUTUGUCd4C45PN1vOiKkSnIKUMG6p4ttdWoemkudpBQpflyGn1kWTC2tm
+            Mxc4qpokCrPsy3c3PwzXhtqa5BJYYqI3NjzyP/PIB92Qcs8vzhOjltqO/mSjvo/S
+            4AHk+hVBQGj6KRg1g/BDvoMdE+H2jeD64LzhczPgz+KiwdOv4NPl7elmuIwqgVgG
+            OKGWx6f7qtjNXBdxJ+Og2mLYBt7aA0DgW+SAC4NfA3i5p7TSU48rt8g84vLTQ4zh
+            W5IA
+            =LzVM
+            -----END PGP MESSAGE-----
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-03-11T14:06:44Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcDMA7rAHYSMKfAZAQwAuaTA74FBUUb+VnGg5AH6LKjiqqMIWSxe8j1TO6Ytyh+f
+            D7bCmo4NbDLFk2Mzj2KbUjuUaAY/502bCtUOmRPwt9LHpc3QkttEAtyOVwy4nNqT
+            uqW86Ltt8IXVim4WnM6VxzPK3CitRVutW7eyrv3+3nZztIV+lhUPO6FC9uskhG/p
+            QuBffSd9jEyVeHX/1P0BS7C/yiuKAPCIuS9ggrAIfj6m95llhJvbjPFnqiD06eSF
+            TRgjl62IXju2SaaszJs7wQFKKWIEwdlSUOyP5CWorR4RhqXXP2iRkdQ4J1q1f+HU
+            5UDdBmpJ479ZxsQXffHMGKyOYw9a+itSrFYhG+KiG9R2h9Y19vyOF662ICtvImPD
+            PGZI0eHl5BHbJOsv1ktHcydWA0aMJPcIO++JC2c0Uai8cxN+AlK4atGvjU6UXJy+
+            btp57EXXM6VVBchlkCNTPrehqPlCtPRoVqYXjqgNWDo/7hpDEDg6mjR9Sq+ocKH4
+            I9HxkwEP+brLTGavoEN+0uAB5FocQJZFVICp23Dx5Ub//Xzhu7bgb+DO4X914Jvi
+            dNyfpeCo5VQSYYgam7Imq4Q3n4gBU3whw6Eun19qpN2m4qSUv+jz4GvkLhGt/xVi
+            59fCAzne1ZaCdOKZVZVn4a3MAA==
+            =jfC4
+            -----END PGP MESSAGE-----
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-03-11T14:06:44Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMAyzcsT8FUYakARAAYcQ3YiET2haUCgY4F4Dnxs7PDe9gME0BLDVwhOLeAFmo
+            h8CEnhgBsbOeNdQoXFBC0+yx+JijZZZ9CHPJKSum5o2LALtN+qTCE/JmmYrl6646
+            gEpOaPU2RIgrvFvI+QTlVc+4Rze9y4/NyD2QS3pV3PbvfKpAvC5EKoDq94IQ6ZBi
+            td0NvMf++BTjqY2xpHYc2AJogdtXsAzZsmsIBR/i0PfqmnfM2/HYjm8T1zY+ty5H
+            0kUuShfvUbSKtG9JpMK/kreEAMiEGx5UUSSy6eAd+MUdLLRMQu2n90NY1VOZRt0c
+            a5S74mzGLeWGj2LBT08zLwGGzTREr/LkF3pWwpk197hymjND6Z+Qt1qsdSluo0/j
+            E5CUZnLsCvx36qYileUw7lV7kZedRoWyf2n0EzZU8zz/mcZ5eEBASzaw551ML4/3
+            SUwJ+lIL11meR8UYUSqh+79rXcjLr8P1RIu1HNKtAaAIlAXoRbYdwLtHuzslbgKq
+            GwgvCxhM0/Q8YcpvPpwrzScE4yaK1RrWZuv4CfGeyx7kqtsZyM8dXwy6gnhH4Pdv
+            eEIdP4u/N7uMYiF+x7ZVUvKH9Y+E8plteJfn/PVaIr4wg7fxiE1Hx9AiaVSvKb1t
+            Zm/F0fvnq73tUpVP9kXXxC+Kt5C50fWJuIc+jx4+siYcCk6fZ81Nf6GQvHTpGfHS
+            4AHk7ZEHpCj85qmAQXc0hlotiOGqeuCa4J3hL4XgzeLpW4Ko4JHl5gy8f1GZFVsQ
+            Af3j9B12wNnZ4Kvw1fr495QgTl0iiKzgP+QehsR9UOCYoEVanydxVPkQ4pYiYdDh
+            eqkA
+            =psy1
+            -----END PGP MESSAGE-----
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-03-11T14:06:44Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcBMA77Gn+FOVmJYAQgAetfoLNygzx0DTlUOelLCTzRG5C3m0HuFVEeriRLFcxwV
+            ombw43Gqdo/UDg7xxJyMLX73XHbdyevMQVJW5qjuITlnOMPLSM+LsfcL4fx7Fmol
+            jpBVEL7ClMLAHKwQFZfM7unv04IQzrQgZxGphVaFR8mld1X2YUQt89/aJLSX4ipo
+            y2s1l2Q9T+/TigkFWkMvlcPlczfHhGm1vo+Quz02B9Ttl/hSNPmjJsZ0P/nPHRoU
+            NdaY4egamw1Kfy9d9PJnn0hNYalAZawzF04KxmhOMAjMWR4GNJNdUf+rqqCKx5x4
+            /ajDDLZlTY4pc9ZrpohiyLbUYsOYAiddsrHUm1JVwdLgAeQZ17QY961nhDoEBfTF
+            kfGF4TD/4Lrgo+EYauBn4kPJzNngC+U0u2AbjwHHIrn9q/YcTJgGcOcMswkMx6bR
+            iDWPS7L/e+A65AcHesUb1n3kwDdKLiuKCOvi1cDLGeGuKQA=
+            =tzqc
+            -----END PGP MESSAGE-----
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+    encrypted_regex: ^(users|data|stringData)$
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/moc/zero/secret-generator.yaml
+++ b/cluster-scope/overlays/prod/moc/zero/secret-generator.yaml
@@ -6,4 +6,5 @@ metadata:
 files:
   - groups/cluster-admins.enc.yaml
   - oauths/moc-sso-client-secret.enc.yaml
+  - oauths/operate-first-sso-secret.enc.yaml
   - ingresscontrollers/default-ingress-certificate.enc.yaml

--- a/keycloak/overlays/moc/infra/clients/zero.enc.yaml
+++ b/keycloak/overlays/moc/infra/clients/zero.enc.yaml
@@ -1,0 +1,52 @@
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakClient
+metadata:
+    name: zero
+    labels:
+        client: zero
+spec:
+    client:
+        clientId: ENC[AES256_GCM,data:mFvpig==,iv:EFG81wt/201mMyKDrHV6/nTqoRXXw+sWzE0Km7t/coE=,tag:shsOwUnOcs0zdfQBDtXzEQ==,type:str]
+        defaultClientScopes:
+            - profile
+        description: MOC Zero OpenShift cluster
+        name: Zero cluster
+        protocol: openid-connect
+        secret: ENC[AES256_GCM,data:BuFDJc52OmYPtfUYZ1dxSva17hIaUDv9zuYEXOyrdl92y90Y,iv:iNc2tmdmdT9LaO+voKYGNnwLQBU31Oq7YCq8b6r4FYs=,tag:aqC5jOQJdxvZ55iFRRDc0g==,type:str]
+        standardFlowEnabled: true
+        redirectUris:
+            - https://oauth-openshift.apps.zero.massopen.cloud/oauth2callback/operate-first
+    realmSelector:
+        matchLabels:
+            realm: operate-first
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2021-06-22T20:28:24Z"
+    mac: ENC[AES256_GCM,data:5x4BGPi9MkNqUANJIuIlbM1ZZ4Ky49OqWxAbfutpDfpZWFu47MosodP/HImTbk7Y0nHtjDpDZZkleoDfp6hYjS8DSHtgUBkhiJfQGf1CPXxQGc+sTXVXulAe1pxn9L0/DlIPkym9IyW3Rti8PXwQs3DE/GfS/IZVs1Uvs9TONJU=,iv:cAmU2kP4ebE0qFb92lKdyQ4K7CMYnoYATRpoLokAs08=,tag:UfG1QsWBmwoh92gxYdxdpg==,type:str]
+    pgp:
+        - created_at: "2021-06-16T22:13:59Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA9aKBcudqifiARAAtsJvD2FFO724wGspw+1StnWk+JlkyuCE78UMQ3ajoWzV
+            M0qNbaqd1eBWiuyXwPJHm/6YPmVmSrKgo857IBXmU8NEsTAs3PyxZ7W7t7tE6COX
+            xZrW8gle2a7RbDAnJ9mvV16RA/xXQnKnu9hqOlMqWU/qvjsM6nS0UVHiaFvy0nYq
+            gbWv4XAa/Z0ygwozq7/sKvfVYoB8zc/sztMwjU041ogdzpmKAidO7pn5w/ONKalG
+            y/NcLMZl9ckNBgiwAVLebequZuQ4omxj7zWV6qppfLRC23+tJQRGQYOjE97brBKM
+            iJIuWKIrDuhApTZ+voXgZDap81qolJADaQ4zcSYEmvVP1druUNaDdOIUpF0dOsEX
+            38UMtwDj4J725J24ouUVvVUYcOkig7p59z0OaIEXTeKME2WWp5IDxbF6EFrBWnDy
+            82L2yzr6Ch1pEVqINJjBF4Qg8pqbio4qrSGg5HrHLghFAAV0wUS24ILbDbbilKYI
+            CjBQbhitIs8vdv6kAwmisTLRWSNB+VXEFEnjfjL8V3Hn0PyQ+91qP9fslPkPpW22
+            6iJbHPahSk9D7xuOwAnehiNXhW+ZYiv5reMu31j4XYZ+gpLSTtJNSMF0STzHlkoa
+            d7JRKr0ugQXuCnWP4ahFzCtDlrDkpg0Ljmx34dgK4uQpiBKAw6LrH/7q22OPTVvS
+            5gGCoxfykfXsmTEAPShfg8st5p0BrA608yFLfgYzh0p6HtK0WqcWDjBS1mE2BWrl
+            wKOxlBtYOBYW3aaJCPRmbbPk8ZK33s6oZZ3N7edqmFjX9+IuI/VKAA==
+            =BcQ5
+            -----END PGP MESSAGE-----
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^(clientId|clientSecret|secret)$
+    version: 3.7.1


### PR DESCRIPTION
Part of: https://github.com/operate-first/apps/issues/790

Onboard Infra cluster to Keycloak providing Operate First's SSO as an additional option to MOC SSO for now.

/hold 

1. until Keycloak is deployed (https://github.com/operate-first/apps/issues/789) and until groups are imported
2. requires `KeycloakClient` to be added into `keycloak/overlays/moc/infra/secret-generator.yaml` to unwip