### PR TITLE
chore: Migrate users to dual identity

### DIFF
--- a/cluster-scope/overlays/prod/common/groups/adoptium.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/adoptium.enc.yaml
@@ -5,15 +5,16 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-    - ENC[AES256_GCM,data:8VNtvhkj/d+FDiRHqF9L12ZuNw==,iv:W5ahLP6HrCk1Hg31yPoeXsggf0x5uLqA/eI4xr/oSxM=,tag:ukqfMxrdjdURjsVROnLhdQ==,type:str]
+    - ENC[AES256_GCM,data:ED4JfgIef/0=,iv:bi4Xj0rtQQbFYY75gtVYZ01IhBCqMywfzOPgK2ixdsU=,tag:ZD8lK6l6qROAxHAWrIKqig==,type:str]
+    - ENC[AES256_GCM,data:DLd0cxylT+WiwoyLbBxb/Z+O2A==,iv:/Wm7Ysgw84t9Ip5oYoVZ6CRZN14W2TIvPYYCVte8sW8=,tag:aUe0bJDTc6YI1l0RJ8R7sw==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-06-17T18:25:11Z"
-    mac: ENC[AES256_GCM,data:3XWjT4paMsxXXvRBeVBisc52WvT/ZlGXBnSG31bVQbOTfDCDdS2qPldBmxCrxdiwBdUQj4oaEKA6m94eM7Usbq37deocuYLZWYHWNLRxVZRs8Jb2L9RPqhV2tyBtzYvg3V7NmxWGgdilBWK0IW10w0nxYt+4LpCcYsjTYUHuviI=,iv:/ByxNSAE4dLqQYpRcj2gUNNuURXudn2qsVfMVTQtkvY=,tag:sjCmlT1L/h5XasGDeqrtTQ==,type:str]
+    lastmodified: "2021-07-14T20:18:25Z"
+    mac: ENC[AES256_GCM,data:5y9nuvhu4fQ6JdMc/5/dbfSJoINIiWs7Qibi09ZpRGeloYK+JIsRKx3XOgqhSgHtfTcWbX1Dm0p0Ry19fgljfi2z0Vo71JZhGLGGIx3Qaf40+RdF+wOdFFgaS96sfLlDkXj+k+B6kQESn5nphOj7Ea5f4w33PztESdaadhl95Vc=,iv:tigkzq0a+Ih2oFl4S9uH+o+UK/GXP1p1DYOhDcS57KQ=,tag:eIMnw5G8zxtYRyEyy5PUwQ==,type:str]
     pgp:
         - created_at: "2021-06-17T18:25:10Z"
           enc: |-

--- a/cluster-scope/overlays/prod/common/groups/ai-services.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/ai-services.enc.yaml
@@ -5,17 +5,19 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:zScrZklhMNkK+zkZqJmR,iv:katObZP+S2hWRsa8Oavd5UNalbPCAQLuM2sXoKb4ke4=,tag:A5wdKzPJLSK96rpGLUv9sA==,type:str]
+    - ENC[AES256_GCM,data:nO13qu8=,iv:l6jLqaJqtHszKydII15BuPV96esIF349ZuGB+GlXuZM=,tag:G2lAK6+MM1toOl5yxSoj3Q==,type:str]
+    - ENC[AES256_GCM,data:zScrZklhMNkK+zkZqJmR,iv:katObZP+S2hWRsa8Oavd5UNalbPCAQLuM2sXoKb4ke4=,tag:A5wdKzPJLSK96rpGLUv9sA==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-03-17T13:13:30Z'
-    mac: ENC[AES256_GCM,data:Y3VzhtF8eIgQCmQ0zzDtWhi9nrNUSZITwt7B10ZE3pCRMnQwckd6MRaZZsTYLFTDdk5WT0DAVy3hmjA1drGnb3IqbMt5te9mP0Scqj+Fwg2NOcomayboSsm4p/4K2nbDQz5cnqY0zFHdfQZvA1nrm2CHGIeiQ60jJd/LMoHv/HA=,iv:+DNNIXg1dmoBuHfDgqfvjP/mIDL3KbHyp9hSHAPxXo4=,tag:rxzFLH7QCCy9sWjJgfxj8w==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:18:39Z"
+    mac: ENC[AES256_GCM,data:R8xJ6G2Po9ffGAMq/QXECultL+leNbDSkTjRqbKtj37DLoGG49lzLXQv9I209oWCE6Am+fVkEq+oHN3vBjWjyQk2WuX+cBWfenVtvTt6i74B7CjugwaCBt61xsD78NZ3R9/eIbLxASbJkESQXLoej48F3eFdz7YQJximYtGes20=,iv:xsirQvEI1Gt1EJtyrBh/UNgrvw22f9yC+kHnQ6MrNCE=,tag:kfk1Vad8HFxp+oSWKWhXLA==,type:str]
     pgp:
-    -   created_at: '2021-03-17T13:13:29Z'
-        enc: |
+        - created_at: "2021-03-17T13:13:29Z"
+          enc: |
             -----BEGIN PGP MESSAGE-----
 
             hQIMA9aKBcudqifiAQ//bNAPPsCdKW42Cz9ewynP/oNt72pcG6zpTnceD3eaMMja
@@ -33,9 +35,9 @@ sops:
             3o3M1VCzFxee36Q1EkllRoTiUZ/f0Redcv1SSwas7mBj3YN14P6/aLSRBeyx
             =/kGa
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-03-17T13:13:29Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-03-17T13:13:29Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAm85yHfecZ0TLD1O37RakGWUZc1qCMbDoSsWzuiaQcXKT
@@ -54,9 +56,9 @@ sops:
             sSIA
             =ZENa
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-03-17T13:13:29Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-03-17T13:13:29Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgActgaputTve3Fbt4vwR5tRswYeSENSKh/dn20npCuJrea
@@ -69,9 +71,9 @@ sops:
             Hnum6wJ0Y+DS5CAujiihRRmIq+bg0I4UroHijsoXM+FTLwA=
             =Igbc
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
-    -   created_at: '2021-03-17T13:13:29Z'
-        enc: |-
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+        - created_at: "2021-03-17T13:13:29Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAKrDzJ3Uix8bYk2iXeOzTjJ0N9Fg7ouVugpHZe8AvKVv9
@@ -87,6 +89,6 @@ sops:
             +be105co4Dkbe+Lf1YeQ4RZaAA==
             =0HPd
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
     encrypted_regex: ^(users|data|stringData)
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/apicurio.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/apicurio.enc.yaml
@@ -7,7 +7,7 @@ metadata:
 users:
     - ENC[AES256_GCM,data:iSm8cGhZq+TQ9ow=,iv:M9ymXVc3cNzGAHIMpEDuDKS4OG2IydytKFekKGF8Y7c=,tag:silR0tyqVa6VY/Xb2bFsXQ==,type:str]
     - ENC[AES256_GCM,data:t1VMJJjGVLHMgMpKQbsYSv9FvQ==,iv:5pUAoutLHVKA2i7TRyNV4qkdM0YmYd3A6G1Cmt2aTlE=,tag:0tqxOKTqOkmF6WFJM0fpyg==,type:str]
-    - ENC[AES256_GCM,data:RWLw2dxXBojThLid,iv:WtShq1x/qcSObiV2qThM3IFs2vuBK0zwA6FbJqirO80=,tag:72dsKolyjNY5zMHg2E2WUw==,type:str]
+    - ENC[AES256_GCM,data:ljlhYpTentPxojh9,iv:OojBLur6HWBp9qZiFZpbUDHQ9CUxnkJRTiIOGTGgOYk=,tag:/Xvwp7lk3EB5Nt45lFXV3g==,type:str]
     - ENC[AES256_GCM,data:ZxpWM4Dtx8ByRz2lSR4J0rpL2w==,iv:XGy5xncTJKGumfh85AhhaLcVTp5a2kiruhOzf4B3Rxc=,tag:4/xcifF7yDjylt51GnATOA==,type:str]
     - ENC[AES256_GCM,data:2Y3E2UhviOz7xN0xUB4FmtIvmw==,iv:rC8V2vlc9H4f3bh6lTd5yWTUidAIAfXw6OeIxSEUqRU=,tag:DzMBK0dWFBBGxAxBMapu4g==,type:str]
     - ENC[AES256_GCM,data:SU5dfx3UyRT5dw==,iv:B63sMlTmJEN8vMFughmrmTIbYR7bbqzU1JIcPTAxaS0=,tag:2N/WNscb/HAQpFxO8m8YoQ==,type:str]
@@ -23,8 +23,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-07-14T20:19:14Z"
-    mac: ENC[AES256_GCM,data:ZFsOOI7ZR5PbxeqTVYj7dVMYeKYe6QjKieS9zDBm2/LfW7U20DbTyKC45PPPOEh+0nCJKRxwQbJptPRacTYtVqbU8AyEynmPbZMc+J25cUtPCXK3O+mkRJnN1O6F1hRjJmzz4n2uiRAlceCABNEMh1shf0wTRhmKpAERZX+Ppo4=,iv:Rqyb7cFTRLrgh0PxMeKq0lIgifhnIWBolgR7GcLc0+g=,tag:eEG5mmgHw5YYoFbQTolFnw==,type:str]
+    lastmodified: "2021-08-12T12:49:43Z"
+    mac: ENC[AES256_GCM,data:T15tySe/YOR+xPiWVJjjAb2fPX/f/+8xIFHzWOGYEnsEOjTiO29whf1AEzqWJElzkbAUZBqtL/u1gMylgtD3I77+wt/g8TbPiOv07Jn/oBu5mV3DLabA1I0mc/lUDKq6Ky/2HtCqh8zAyuOjuk62aduC3tFqqzYmuGsgo67lm2E=,iv:EIEHcQ5jSE7zJq3sWtVrHd4YREz4/9yga5MKkaseU3k=,tag:QsqozXhc3bzTBkVjJq/TmQ==,type:str]
     pgp:
         - created_at: "2021-04-06T12:49:12Z"
           enc: |-

--- a/cluster-scope/overlays/prod/common/groups/apicurio.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/apicurio.enc.yaml
@@ -5,22 +5,29 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:t1VMJJjGVLHMgMpKQbsYSv9FvQ==,iv:5pUAoutLHVKA2i7TRyNV4qkdM0YmYd3A6G1Cmt2aTlE=,tag:0tqxOKTqOkmF6WFJM0fpyg==,type:str]
-- ENC[AES256_GCM,data:ZxpWM4Dtx8ByRz2lSR4J0rpL2w==,iv:XGy5xncTJKGumfh85AhhaLcVTp5a2kiruhOzf4B3Rxc=,tag:4/xcifF7yDjylt51GnATOA==,type:str]
-- ENC[AES256_GCM,data:2Y3E2UhviOz7xN0xUB4FmtIvmw==,iv:rC8V2vlc9H4f3bh6lTd5yWTUidAIAfXw6OeIxSEUqRU=,tag:DzMBK0dWFBBGxAxBMapu4g==,type:str]
-- ENC[AES256_GCM,data:f7WhbtBnf3MIchsR9wxQqrw=,iv:A2r6Z2+igpW+/KlQrfyE+kFBAm6HCoR19DPQ9LT1jBk=,tag:t5+DchNnUTDbOBQtR7dtwA==,type:str]
-- ENC[AES256_GCM,data:2ZMRD1AqAzXVIsLU/Gx6P+p14w==,iv:c8uVKNNIPu+u0mdnlQC74l9/QDIPTHjN6738fboxySo=,tag:+Qd+T1V/2Ll8jZ1SzQq33w==,type:str]
-- ENC[AES256_GCM,data:S/wBIDjUFJ1Gi4d6s8eXIpCklg==,iv:2lRsQeeCIyA5TZuvuarRMOdNAznXosM2P2A5gEmO3lo=,tag:5jDLhEAA4kAahk9TH6vk2Q==,type:str]
+    - ENC[AES256_GCM,data:iSm8cGhZq+TQ9ow=,iv:M9ymXVc3cNzGAHIMpEDuDKS4OG2IydytKFekKGF8Y7c=,tag:silR0tyqVa6VY/Xb2bFsXQ==,type:str]
+    - ENC[AES256_GCM,data:t1VMJJjGVLHMgMpKQbsYSv9FvQ==,iv:5pUAoutLHVKA2i7TRyNV4qkdM0YmYd3A6G1Cmt2aTlE=,tag:0tqxOKTqOkmF6WFJM0fpyg==,type:str]
+    - ENC[AES256_GCM,data:RWLw2dxXBojThLid,iv:WtShq1x/qcSObiV2qThM3IFs2vuBK0zwA6FbJqirO80=,tag:72dsKolyjNY5zMHg2E2WUw==,type:str]
+    - ENC[AES256_GCM,data:ZxpWM4Dtx8ByRz2lSR4J0rpL2w==,iv:XGy5xncTJKGumfh85AhhaLcVTp5a2kiruhOzf4B3Rxc=,tag:4/xcifF7yDjylt51GnATOA==,type:str]
+    - ENC[AES256_GCM,data:2Y3E2UhviOz7xN0xUB4FmtIvmw==,iv:rC8V2vlc9H4f3bh6lTd5yWTUidAIAfXw6OeIxSEUqRU=,tag:DzMBK0dWFBBGxAxBMapu4g==,type:str]
+    - ENC[AES256_GCM,data:SU5dfx3UyRT5dw==,iv:B63sMlTmJEN8vMFughmrmTIbYR7bbqzU1JIcPTAxaS0=,tag:2N/WNscb/HAQpFxO8m8YoQ==,type:str]
+    - ENC[AES256_GCM,data:f7WhbtBnf3MIchsR9wxQqrw=,iv:A2r6Z2+igpW+/KlQrfyE+kFBAm6HCoR19DPQ9LT1jBk=,tag:t5+DchNnUTDbOBQtR7dtwA==,type:str]
+    - ENC[AES256_GCM,data:eC0h3USj,iv:wIcaCE2tqOomOayxKBbkC5Pf9FooZZcaYxeW6IW3PfM=,tag:7G13Vfclf3O/VakZbwjH2g==,type:str]
+    - ENC[AES256_GCM,data:2ZMRD1AqAzXVIsLU/Gx6P+p14w==,iv:c8uVKNNIPu+u0mdnlQC74l9/QDIPTHjN6738fboxySo=,tag:+Qd+T1V/2Ll8jZ1SzQq33w==,type:str]
+    - ENC[AES256_GCM,data:j7+3g8qmpTYPlTCTNQ==,iv:RaG+UVbW+Z8UYvlznlDXeGACrDg/QkAbeotIsPiYRGU=,tag:u0pCyddkVuqZKGKWtoGpSA==,type:str]
+    - ENC[AES256_GCM,data:S/wBIDjUFJ1Gi4d6s8eXIpCklg==,iv:2lRsQeeCIyA5TZuvuarRMOdNAznXosM2P2A5gEmO3lo=,tag:5jDLhEAA4kAahk9TH6vk2Q==,type:str]
+    - ENC[AES256_GCM,data:M2Msqv807jA=,iv:/LqWxispyW6dmh/FDmxQHCakwrcu97NR4Aj9liU7bgE=,tag:REKxMbiiIKd79/kEuNkI2w==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-04-06T12:49:12Z'
-    mac: ENC[AES256_GCM,data:txUOuiDxS9i+gofd1teNfJJejFQP/1tbFhK16IXCJAvRaJlEVXPMukbDUQKCeVTDb34uZnTy8z0+qBNIJkjE3O7T5WG919l2VV0fVkBgR6mL8lVtpwFyr3uCBYzO61rDuISBCFdFqTVjgzPIUsJxnK2+RWTPtJ6Xx4o6gT8jhaA=,iv:7Wi2NDXuibfbjFwtyePWZ93bZOoYJFPeawL3xO6H9vI=,tag:yLeXM4ijabpXogRWQdFF+w==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:19:14Z"
+    mac: ENC[AES256_GCM,data:ZFsOOI7ZR5PbxeqTVYj7dVMYeKYe6QjKieS9zDBm2/LfW7U20DbTyKC45PPPOEh+0nCJKRxwQbJptPRacTYtVqbU8AyEynmPbZMc+J25cUtPCXK3O+mkRJnN1O6F1hRjJmzz4n2uiRAlceCABNEMh1shf0wTRhmKpAERZX+Ppo4=,iv:Rqyb7cFTRLrgh0PxMeKq0lIgifhnIWBolgR7GcLc0+g=,tag:eEG5mmgHw5YYoFbQTolFnw==,type:str]
     pgp:
-    -   created_at: '2021-04-06T12:49:12Z'
-        enc: |-
+        - created_at: "2021-04-06T12:49:12Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAsYXAlSudZaNSo+/BkMh7K97P3BwHDekooCAF4M5vV+GN
@@ -39,9 +46,9 @@ sops:
             xzcA
             =2prS
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-04-06T12:49:12Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-04-06T12:49:12Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA43ffXK023rrARAATsvTIhjOs4o2f6j4zFpZKt9G8OULZZwo6TNn04xQuWki
@@ -60,6 +67,6 @@ sops:
             c8AA
             =nvE3
             -----END PGP MESSAGE-----
-        fp: 4B6A81C7D1711864408480CEC37C8EDF9301474C
+          fp: 4B6A81C7D1711864408480CEC37C8EDF9301474C
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/argocd-admins.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/argocd-admins.enc.yaml
@@ -9,7 +9,7 @@ users:
     - ENC[AES256_GCM,data:H4LOK7FnnX+8cTno27+1mnh3fQ==,iv:uIT3fE86S3pbIDf+r6clRrymuU3DzJLZnA5tUJ/U0YM=,tag:hN0Sqa2crOt///3VeHNczQ==,type:str]
     - ENC[AES256_GCM,data:noAM2zg=,iv:ldhGGXBikrqf0FuSkn3UdpoBE9RwY6ABridzMDzKops=,tag:40cWXH7u0Qbwwl60+MlIhQ==,type:str]
     - ENC[AES256_GCM,data:TU5ZEOn9rg+atbEo0Jqwx4KhLA==,iv:EJV8Nw6feLZlFWEle7g6S8/lRcAfoCjG9JI3QbR/c1k=,tag:q5Jqz1dJrEYbkIqIjnSJTQ==,type:str]
-    - ENC[AES256_GCM,data:oSx+2MEeEhw=,iv:Ggppb1D4W78VZW3d6DpmeiasKP3jtaiCJPAhYCJBw0w=,tag:Rdl6J7lqzcXCiaDO3p2xKA==,type:str]
+    - ENC[AES256_GCM,data:35WNFBsp+6w=,iv:/5eWEynjLI4fzTX+gQV78HqKItGW3V/JF554etnapXk=,tag:qhP+0zSA0FTZR714tX1J8w==,type:str]
     - ENC[AES256_GCM,data:svmF3Bg1mE7eWWrA2q8RQ6M=,iv:vBmddr+WIEh2OGxpypAAsW5OeNTKPQKv05rHqDQAYQo=,tag:BFIO+585WbF0Uc10X2h7mw==,type:str]
     - ENC[AES256_GCM,data:OFABjcZu,iv:vOwf80a8311V9nY39rbF6O7q/BPm4GjCmltlEGVRKdk=,tag:GHDZryVFUu4KlucXUpZhdw==,type:str]
     - ENC[AES256_GCM,data:60SCFoXx76DpOA4=,iv:ob06MCEVNeG9thiJoL6px4eHF3U88luNoA/cl9JRVsw=,tag:pjDPhZ/NT5uMFqmkP+89qg==,type:str]
@@ -21,8 +21,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-07-14T20:20:20Z"
-    mac: ENC[AES256_GCM,data:HRo8pEWuxdlWvsAyE2rLoIXLD1NSuVL6k8cDW6+0rDNK5S2+qQIbECK5ZCm1R42b94Xfl3cyW9f62tutrmjZwwewZHTn+/U5WUrZU6BI68F91GhbJetYj9FSv2rBnF/WhGA9B/2VsS+l3p7EheL8+Imt1ZArNKX15qXfW/nQTIw=,iv:1V0vKG7YivwU31GGIlU/qkEdVMmaTKBvM9JHIAmsfUM=,tag:hvrmO0z09axUIaXhJNf30g==,type:str]
+    lastmodified: "2021-08-12T12:49:54Z"
+    mac: ENC[AES256_GCM,data:+nZ/1yYwH0m/tss4x7+CErmN9bLsk6PG4PY3uOf2sotzTWEHfJ3tLRd438rYA7X1FsBPAhC+aScKlIAEVhMLSKNu2eMwo2KYmVoShi5RkJlZF+GL8P2Bgh1Wk2sYy2xSzcYOUK03Bu18QEbAZDrheWwsDza+VQxO1Hf/lTt5DrU=,iv:Y1ECkcaILhxOTMvJerMgvKGo2mbqwn2Ffjs3ZAPsW6Y=,tag:DdvWiuPhVDnTwyBMCzezLw==,type:str]
     pgp:
         - created_at: "2021-01-12T17:24:03Z"
           enc: |-

--- a/cluster-scope/overlays/prod/common/groups/argocd-admins.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/argocd-admins.enc.yaml
@@ -5,21 +5,27 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:H4LOK7FnnX+8cTno27+1mnh3fQ==,iv:uIT3fE86S3pbIDf+r6clRrymuU3DzJLZnA5tUJ/U0YM=,tag:hN0Sqa2crOt///3VeHNczQ==,type:str]
-- ENC[AES256_GCM,data:TU5ZEOn9rg+atbEo0Jqwx4KhLA==,iv:EJV8Nw6feLZlFWEle7g6S8/lRcAfoCjG9JI3QbR/c1k=,tag:q5Jqz1dJrEYbkIqIjnSJTQ==,type:str]
-- ENC[AES256_GCM,data:svmF3Bg1mE7eWWrA2q8RQ6M=,iv:vBmddr+WIEh2OGxpypAAsW5OeNTKPQKv05rHqDQAYQo=,tag:BFIO+585WbF0Uc10X2h7mw==,type:str]
-- ENC[AES256_GCM,data:60SCFoXx76DpOA4=,iv:ob06MCEVNeG9thiJoL6px4eHF3U88luNoA/cl9JRVsw=,tag:pjDPhZ/NT5uMFqmkP+89qg==,type:str]
-- ENC[AES256_GCM,data:kIZdx5dhU91jyhXWxsmSQxmB,iv:AamSo3p2IfuKx17EsBcnzJuZfts1/A4SKSHSCmztEQU=,tag:necyTw5FGSgghisDxz+PRQ==,type:str]
+    - ENC[AES256_GCM,data:YijS12WPJLeprNVd,iv:iaVIWREjG+bWfWzEvInihHsY9Igje6Iprk6eGZlfBNM=,tag:UaRyTX3PxyzZQ1e6ZNwtEw==,type:str]
+    - ENC[AES256_GCM,data:H4LOK7FnnX+8cTno27+1mnh3fQ==,iv:uIT3fE86S3pbIDf+r6clRrymuU3DzJLZnA5tUJ/U0YM=,tag:hN0Sqa2crOt///3VeHNczQ==,type:str]
+    - ENC[AES256_GCM,data:noAM2zg=,iv:ldhGGXBikrqf0FuSkn3UdpoBE9RwY6ABridzMDzKops=,tag:40cWXH7u0Qbwwl60+MlIhQ==,type:str]
+    - ENC[AES256_GCM,data:TU5ZEOn9rg+atbEo0Jqwx4KhLA==,iv:EJV8Nw6feLZlFWEle7g6S8/lRcAfoCjG9JI3QbR/c1k=,tag:q5Jqz1dJrEYbkIqIjnSJTQ==,type:str]
+    - ENC[AES256_GCM,data:oSx+2MEeEhw=,iv:Ggppb1D4W78VZW3d6DpmeiasKP3jtaiCJPAhYCJBw0w=,tag:Rdl6J7lqzcXCiaDO3p2xKA==,type:str]
+    - ENC[AES256_GCM,data:svmF3Bg1mE7eWWrA2q8RQ6M=,iv:vBmddr+WIEh2OGxpypAAsW5OeNTKPQKv05rHqDQAYQo=,tag:BFIO+585WbF0Uc10X2h7mw==,type:str]
+    - ENC[AES256_GCM,data:OFABjcZu,iv:vOwf80a8311V9nY39rbF6O7q/BPm4GjCmltlEGVRKdk=,tag:GHDZryVFUu4KlucXUpZhdw==,type:str]
+    - ENC[AES256_GCM,data:60SCFoXx76DpOA4=,iv:ob06MCEVNeG9thiJoL6px4eHF3U88luNoA/cl9JRVsw=,tag:pjDPhZ/NT5uMFqmkP+89qg==,type:str]
+    - ENC[AES256_GCM,data:CWmGJG/n,iv:9cqjkX4WbGu0zlYlKoYkVe4N/pzSELwsc7nAbjElgmg=,tag:qEgWL96z/mdl89xCmaPNNQ==,type:str]
+    - ENC[AES256_GCM,data:kIZdx5dhU91jyhXWxsmSQxmB,iv:AamSo3p2IfuKx17EsBcnzJuZfts1/A4SKSHSCmztEQU=,tag:necyTw5FGSgghisDxz+PRQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-03-11T14:06:12Z'
-    mac: ENC[AES256_GCM,data:Fnb56CIE4NlgCPRYPVLAlo9JjUrLymUfAuNpFpVtJZRzgwVk868/5xZd1W2HgaXg7BbNIdVDfrx399r6WKf5Ht0PQHBl9pOKm1eNsO25HTJnHID6oWQeYtphiJpyfp+yFA9A+zsJOOYnuiVvNz0cGGw+W6fgrgeATGTZTAqJKxg=,iv:r7kTYKJzWSZAKQUCpKnf1baov1uzSNbQBjbDwHqYDyk=,tag:mZWTSGXYxYJuYY0OjNu53w==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:20:20Z"
+    mac: ENC[AES256_GCM,data:HRo8pEWuxdlWvsAyE2rLoIXLD1NSuVL6k8cDW6+0rDNK5S2+qQIbECK5ZCm1R42b94Xfl3cyW9f62tutrmjZwwewZHTn+/U5WUrZU6BI68F91GhbJetYj9FSv2rBnF/WhGA9B/2VsS+l3p7EheL8+Imt1ZArNKX15qXfW/nQTIw=,iv:1V0vKG7YivwU31GGIlU/qkEdVMmaTKBvM9JHIAmsfUM=,tag:hvrmO0z09axUIaXhJNf30g==,type:str]
     pgp:
-    -   created_at: '2021-01-12T17:24:03Z'
-        enc: |-
+        - created_at: "2021-01-12T17:24:03Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAsCWmOg9ddRAsdIFiHuPJkjUOEm142zb0tFkzBe0VBtrw
@@ -38,9 +44,9 @@ sops:
             TSkA
             =KeSG
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-03-11T14:06:09Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-03-11T14:06:09Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAUHuVywFHfq5JpGBMJog9JuXHkCMaNJkbn86+TKEqoJtA
@@ -56,9 +62,9 @@ sops:
             /xDjUHY516L4WuKp3spd4S8cAA==
             =iDAB
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-03-11T14:06:09Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-03-11T14:06:09Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAANqc6Xfza17icBTwmYHH1i66ZaT/BhW+6EuDl+x6iiWds
@@ -77,9 +83,9 @@ sops:
             D0gA
             =lMlk
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-03-11T14:06:09Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-03-11T14:06:09Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAJ6XmZ+zt3i//NlwzbJMz68ePBHEDix3icHiJD4Wid+z3
@@ -92,6 +98,6 @@ sops:
             clAzPTel2ODA5L1I9HJWZURTpE5OCZs2+WTiN3DAd+GJLgA=
             =pRuk
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/argocd-readonly.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/argocd-readonly.enc.yaml
@@ -5,19 +5,23 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:mRRqFLm6FDJyhsYH1ZSA,iv:d3tytCWH/8evXISxfSe6cueo7JoV8cTu1/vJ56uhuuo=,tag:izueExJBVJ67zhx2E6ZdRA==,type:str]
-- ENC[AES256_GCM,data:fvYFi22eNjKbfs7+6JLSlbkRow==,iv:h6xy+BzeRMV+MIkCTeYGxinZB8K9l+mq0xKyRHC6WvI=,tag:ehIBOzNY61PgzCn2nYcMqg==,type:str]
-- ENC[AES256_GCM,data:Hy+muB0cgff9ehUhDRr2xl0=,iv:TZTb8EJETTl6k4AU706gVL8K386kG1bd4yuToWjAUQU=,tag:B7nrrx7O4TcR1AEkTUto/Q==,type:str]
+    - ENC[AES256_GCM,data:KbwpY1/6gC4=,iv:UIl59OGz2unlenbkK33PG/beU8my8VNlDTQNgy1YY1Q=,tag:1vnMm+0IRrRa2qYs2XNktg==,type:str]
+    - ENC[AES256_GCM,data:mRRqFLm6FDJyhsYH1ZSA,iv:d3tytCWH/8evXISxfSe6cueo7JoV8cTu1/vJ56uhuuo=,tag:izueExJBVJ67zhx2E6ZdRA==,type:str]
+    - ENC[AES256_GCM,data:Ce+SLxUh,iv:A/4K3LpnHJ+Mq+SwW1Wx/9KDCMlWosF8URlF8qisuI8=,tag:pfVt5zXGlUK7XAvSbT/2gA==,type:str]
+    - ENC[AES256_GCM,data:fvYFi22eNjKbfs7+6JLSlbkRow==,iv:h6xy+BzeRMV+MIkCTeYGxinZB8K9l+mq0xKyRHC6WvI=,tag:ehIBOzNY61PgzCn2nYcMqg==,type:str]
+    - ENC[AES256_GCM,data:0KRU,iv:JUs67Mh3mQHhKJQV/6nhHOFp8aMOxSa7ohex1tClO/8=,tag:qcmxKwdS9yHoeJdKJbOmfw==,type:str]
+    - ENC[AES256_GCM,data:Hy+muB0cgff9ehUhDRr2xl0=,iv:TZTb8EJETTl6k4AU706gVL8K386kG1bd4yuToWjAUQU=,tag:B7nrrx7O4TcR1AEkTUto/Q==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-07-09T13:45:35Z'
-    mac: ENC[AES256_GCM,data:lY3RXaQxB/mC9oWX7Ix0upIzWhoqXtIzphFX0aSWM+yz/3rYvAwFU4BpxTcrbLy/mep81aTO08ud+WSKgAQ5d7bA0aF+1PGQGSYQ7mqulEYyLRa+tzwQTOdO5j7Vi3k1zhX62D8vpGeeeOY1HXTvN9f8TomizA5QvZFRQMXBMvs=,iv:nU+dhgZau4eI3jpCl3zs4CuG/6o0OpLloLAWkvvya24=,tag:4K24AkxOe2ry3R2mZHTYOg==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:20:49Z"
+    mac: ENC[AES256_GCM,data:Qi3KmuKPgvJmQQe4RmgJQOigKdfSwNLxWDvw7pnCOYqBXwNkntUidWxFOrqdvxVsS4dRGpfuDPzg3D3ISnz/cmvcJGUsLgl/PeX25hA2thSNmdFP5OKOKtOhkMC7f7wR+ue+Dv7CKUzEnBMlKo9d3j1l7uqF8txrKp7yPzuu9DM=,iv:hEQUmzq6dHz8K9F/YYGDczowDmbcexhR1cIJRcgmzWc=,tag:c+oO9iubCRBi9WKu3JZO4A==,type:str]
     pgp:
-    -   created_at: '2021-06-11T18:39:52Z'
-        enc: |-
+        - created_at: "2021-06-11T18:39:52Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAp3oWcoRxrewaQ5IWf/1/q4Q6ox7ocBG5WVarHd51jEzS
@@ -36,9 +40,9 @@ sops:
             wyMA
             =iXGl
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-06-11T18:39:52Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-06-11T18:39:52Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAG1Dnmz5oxiJP9vv7nEjyd9yx1YOPhg6SF1rlnrgCOMIq
@@ -57,9 +61,9 @@ sops:
             +2cA
             =BrRK
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-06-11T18:39:52Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-06-11T18:39:52Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAUNutEWZC80SDSXVr/uELz8KMyVov/prgPw+b0ZOhHCM7
@@ -75,9 +79,9 @@ sops:
             a1lKcHXn9ANm9eLKk0P14YH5AA==
             =HHci
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-06-11T18:39:52Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-06-11T18:39:52Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAYDBl8GFUqddvG6CsiyE70Q3pG5pmHBSjnLsCpRWGgZp9
@@ -90,6 +94,6 @@ sops:
             zupZ9XZdrOD05Cm3AduzKJNUCi6bm2ccE83iEgdv0uHg1gA=
             =3zjb
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^(users|data|stringData)$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/b4mad.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/b4mad.enc.yaml
@@ -5,18 +5,21 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:whFHoW4oFlJY1a81cm4tz0Q=,iv:lG660FbTzyGYnNWPnji8dMB4E4B98ehFawdZzeTCFc8=,tag:R3fOEJ/xAFS4bCGSOFrWUQ==,type:str]
-- ENC[AES256_GCM,data:c41623yCgf1QIHqtIgoBpw==,iv:looqCe4pNtykiFWxc7UzZSmd5IoPqVXjRc4oFOd8id8=,tag:OuC655z5wBXSPuhobPBX3A==,type:str]
+    - ENC[AES256_GCM,data:9GVbhQ0=,iv:nEKUVNoKIp2gxuiHBr2KecnDB08OkjA89wu+4TBaf/k=,tag:1T1EQdM79cOPlvQKg77Beg==,type:str]
+    - ENC[AES256_GCM,data:whFHoW4oFlJY1a81cm4tz0Q=,iv:lG660FbTzyGYnNWPnji8dMB4E4B98ehFawdZzeTCFc8=,tag:R3fOEJ/xAFS4bCGSOFrWUQ==,type:str]
+    - ENC[AES256_GCM,data:yyDjcuNqfTY=,iv:HSAq1uBHQ3fewK4xcVy89iEEWksqM1Tcf+eSErlpbIs=,tag:ha7SPvOMlGMtWyinU8SM/g==,type:str]
+    - ENC[AES256_GCM,data:c41623yCgf1QIHqtIgoBpw==,iv:looqCe4pNtykiFWxc7UzZSmd5IoPqVXjRc4oFOd8id8=,tag:OuC655z5wBXSPuhobPBX3A==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-03-21T12:29:59Z'
-    mac: ENC[AES256_GCM,data:YczQpJyLhs6pVpvEZ6yZob1rq2Nc/2y7UJ8LMMCqUTgXJHpSTEcXSQTzQm96wY+cNBESevEieuRjnf0jTiK/Na7EF1zVnb3aFbz61vbxPQPKqTqy1PrCr9PHghh7aowSiRXdKn3+EMrJUJ0jXicD1nyNXyJoXbuP35qi2A+Gza4=,iv:Ldz28E7Gg3ZFSe2dE9IMK2q0aHPl/BT7VQcF276AgKw=,tag:alOFklN/HV8vVc3L0d3XKQ==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:21:05Z"
+    mac: ENC[AES256_GCM,data:rXgwQhcGnqzdn2ufgDY6YtnNV9SgQBjNhcN5zT1uP6FxzO8fVrluwiOXRjircx60DYmqxln3qnYHCu6OIa+pc9RRzCBGWDVi6fjuuCx46FMdQtY9Zz6wdkVNwfP/rltcwwbS4teFhmLWE8eDbCKEdHdGmYsMGW64o0g8tmxZa3c=,iv:iypktYqtJcDk2cMfDxIZTucWWNTwppj6x+RGxgQWwak=,tag:zyNB/sR0PNBVOnk/jjvZsQ==,type:str]
     pgp:
-    -   created_at: '2021-03-20T18:29:45Z'
-        enc: |
+        - created_at: "2021-03-20T18:29:45Z"
+          enc: |
             -----BEGIN PGP MESSAGE-----
 
             hQIMA9aKBcudqifiARAAwb2HEyyOPpUDBHedPagqHgZgkSFz+K8oSdJWk2zYFEpM
@@ -34,6 +37,6 @@ sops:
             YdBOV1JaYkTgnmMVG28pxDDaD4VKEgyJtW/0oMx6nQUzCq5UumgO4C9e9s4elKE=
             =pAFx
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
     encrypted_regex: ^(users|data|stringData)$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/ccx.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/ccx.enc.yaml
@@ -5,9 +5,13 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
+    - ENC[AES256_GCM,data:Nr2QGsRi,iv:+iq6u9mVbAmXh5vJLFTEzwTbF9gQUJWz/bo2ny7HWuo=,tag:n7KBrU6QyzEgdWTDFWTZEQ==,type:str]
     - ENC[AES256_GCM,data:5JsshpjaQQf6DFw3Sz2J2eQ=,iv:pVs4GHNG/7A8vr8/tmiI5Zj+ZQHnVcXLmhHNNVnBsow=,tag:YCm7JlTYY/vJjhJtwlH/yA==,type:str]
+    - ENC[AES256_GCM,data:QjMTwkEZOg==,iv:EVuDIpvpTbPvjmk8PKjkRVb4exbCadg9SOFAkZH0Vrw=,tag:rjvUQzx5cSxg3nS9iG40gA==,type:str]
     - ENC[AES256_GCM,data:oATK89pErkKDgJxJofqzRDHcZA==,iv:2+4Mu/mhW7lBRL5FwP7hLLJEbdZ4DMteJdmLFI0+j2k=,tag:Ch9q4MS1F91DHDrt2DKZOw==,type:str]
+    - ENC[AES256_GCM,data:NGmmj4B2jNc0Uu0jLA==,iv:SsKWFLa0D1JdhaabcrRmMT6KY7IrL+ibgRZ1OB/hOI4=,tag:sG8bCZ44xvHGXKhs+RqWzw==,type:str]
     - ENC[AES256_GCM,data:pzMFoqsP7LJNTku4CL78BBMVKg==,iv:y6787OMSwrRr9e8JZ6g5f4zw8zkFfSJR59HzxPAdTFU=,tag:GpmT8Xd7LeFbFg2LaVrYCQ==,type:str]
+    - ENC[AES256_GCM,data:b7AV9txkqA==,iv:3D9DbKYxxzzYEYRbHEwy/jT/T9tDHVfhICOhR1p9IHs=,tag:KG2oNedLpBXvuH6AcZsUKQ==,type:str]
     - ENC[AES256_GCM,data:LjLzgaYRQVCxfMnAD12Gpzuo,iv:oL/2oS7/kNDox91HRr7X62BOrKqCUx97lPc0iDDHEBc=,tag:S5DZJQ6OWAsKhiDjLSs4gA==,type:str]
 sops:
     kms: []
@@ -15,8 +19,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-05-20T12:32:54Z"
-    mac: ENC[AES256_GCM,data:ltnEXsJPdaZp7rYJN+1boz6uS7pwCvVsj/1FOIc9Iqz4aGW0Ukx3vEtmo2CtAYqj9vw3HP/536fRCBE8URrd8lV4JYyM9Iz588k1WiA1gWxRMddf9sTYyuyuDlUsIi3a1BuYQKZvq+OF2TR2B1V35gQjPQ23WdKP/Jr7M4CmBgs=,iv:TAT2RENWoocFGN0y4jVEgQYKmE6+0eyqj3ohMVYciDY=,tag:jYSD302QPzXyBw9emaHvDw==,type:str]
+    lastmodified: "2021-07-14T20:21:37Z"
+    mac: ENC[AES256_GCM,data:2DpSUzJPEXffdzzIS5JJruIUYrYQJz/buhqDdZL5VDedGZmKMcnjJXRB9tWaHJYwFyqkg0m+4Zdno9TMQQWYKpt/lE1ej+00V5zjw6CaRq83SwOCXQNuC0uoS0jv1YjRTWuPWgVzKhnGymHUwU141IH9aCb6Qq0EoRecSM30tRg=,iv:i8b4oKugVX8oU+CieBx29spfpymW8P6+TZaAgBh5OpA=,tag:4gGX9hdb7WV+oAA2oGiTPA==,type:str]
     pgp:
         - created_at: "2021-03-17T13:13:29Z"
           enc: |

--- a/cluster-scope/overlays/prod/common/groups/ccx.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/ccx.enc.yaml
@@ -9,7 +9,7 @@ users:
     - ENC[AES256_GCM,data:5JsshpjaQQf6DFw3Sz2J2eQ=,iv:pVs4GHNG/7A8vr8/tmiI5Zj+ZQHnVcXLmhHNNVnBsow=,tag:YCm7JlTYY/vJjhJtwlH/yA==,type:str]
     - ENC[AES256_GCM,data:QjMTwkEZOg==,iv:EVuDIpvpTbPvjmk8PKjkRVb4exbCadg9SOFAkZH0Vrw=,tag:rjvUQzx5cSxg3nS9iG40gA==,type:str]
     - ENC[AES256_GCM,data:oATK89pErkKDgJxJofqzRDHcZA==,iv:2+4Mu/mhW7lBRL5FwP7hLLJEbdZ4DMteJdmLFI0+j2k=,tag:Ch9q4MS1F91DHDrt2DKZOw==,type:str]
-    - ENC[AES256_GCM,data:NGmmj4B2jNc0Uu0jLA==,iv:SsKWFLa0D1JdhaabcrRmMT6KY7IrL+ibgRZ1OB/hOI4=,tag:sG8bCZ44xvHGXKhs+RqWzw==,type:str]
+    - ENC[AES256_GCM,data:Jkzj6NXuiQVZbb12JQ==,iv:BYle/9uKh/CgNs0VfmVFxn8HMdhvV7n1zjSc9xM4zBw=,tag:36ik3j/WzWEjsTwE3j5Kkw==,type:str]
     - ENC[AES256_GCM,data:pzMFoqsP7LJNTku4CL78BBMVKg==,iv:y6787OMSwrRr9e8JZ6g5f4zw8zkFfSJR59HzxPAdTFU=,tag:GpmT8Xd7LeFbFg2LaVrYCQ==,type:str]
     - ENC[AES256_GCM,data:b7AV9txkqA==,iv:3D9DbKYxxzzYEYRbHEwy/jT/T9tDHVfhICOhR1p9IHs=,tag:KG2oNedLpBXvuH6AcZsUKQ==,type:str]
     - ENC[AES256_GCM,data:LjLzgaYRQVCxfMnAD12Gpzuo,iv:oL/2oS7/kNDox91HRr7X62BOrKqCUx97lPc0iDDHEBc=,tag:S5DZJQ6OWAsKhiDjLSs4gA==,type:str]
@@ -19,8 +19,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-07-14T20:21:37Z"
-    mac: ENC[AES256_GCM,data:2DpSUzJPEXffdzzIS5JJruIUYrYQJz/buhqDdZL5VDedGZmKMcnjJXRB9tWaHJYwFyqkg0m+4Zdno9TMQQWYKpt/lE1ej+00V5zjw6CaRq83SwOCXQNuC0uoS0jv1YjRTWuPWgVzKhnGymHUwU141IH9aCb6Qq0EoRecSM30tRg=,iv:i8b4oKugVX8oU+CieBx29spfpymW8P6+TZaAgBh5OpA=,tag:4gGX9hdb7WV+oAA2oGiTPA==,type:str]
+    lastmodified: "2021-08-12T12:50:22Z"
+    mac: ENC[AES256_GCM,data:AHKLQdky5b6rOWjOj1r8PtS2+1LRg1MXwg7eYvwrg+5cM4ZlW3VO3JYiXmeHzCok3AdiFQ0WtJn97yXVTWwTRMDdm8hkuIC4t2U8K1xj5/eej4O8oLttoVTEYUo+91SINUvSzm5j1vhvmZbkWL9Vdi8wZOnPQ87yt1WFgs1M/XY=,iv:8/TOiUogHxCJ/wsZyiiUEVrKZmWyxfoGIaoZUlxPO6o=,tag:pbvce6jGA9brRreFVJL8pQ==,type:str]
     pgp:
         - created_at: "2021-03-17T13:13:29Z"
           enc: |

--- a/cluster-scope/overlays/prod/common/groups/chi-rhug.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/chi-rhug.enc.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
+    - ENC[AES256_GCM,data:eq9rePpo,iv:2vWlMxvip4zjLt0TG42RzxbXqxJpGMPI0AL86bKd0e4=,tag:QdiJxC1F7urqooIy0ZNQqQ==,type:str]
     - ENC[AES256_GCM,data:JfMZU2UVE4Yfllwm99fI8CgBmQ==,iv:zX2824KD5wazmM8rMETf4PRByFfEv3/DgHNieadEJMI=,tag:OvrcA2AGYS0AoR2y5TVe9g==,type:str]
 sops:
     kms: []
@@ -12,8 +13,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-06-22T13:32:26Z"
-    mac: ENC[AES256_GCM,data:YXQs+ZAM54Fr9MXP5DnLNmjpjnQfeJlZMPh5qGtnfirA0bdzcyEh5YdD+3pMcBEVfp+JC6NyBciBRN3Z9KBZl7gAH9dJTWPW+uGvaT8qGmuqa3jm6loyxc6aZfFJPfh+Fy51ZJX2oGdRD+6rm2PiMVicY52rh9K45V4sq0BMpHo=,iv:OJSz7JacB50Pe9HC096S68s3OmD/7w9CblS4yn1ykbQ=,tag:x2ybv/ZMEEvQhxR+hGLrkQ==,type:str]
+    lastmodified: "2021-07-14T20:21:50Z"
+    mac: ENC[AES256_GCM,data:GNP2lHhdDhmPFvitULaVEu9JLDG8w08WWzMNKBvKgrO3/v5RYucL368ohMMZIlMwGGrWkhHZJ/Zb39VzeVb1UomsL/oOXm1rp1HtvMojiK6wbR2zeJj91L8iSfxz4dvJDhZ32ASYAyY3NJ2+bYDG8F753JRgC16LZQUoD4H/wIo=,iv:9pAWLecoK+W0w0zLE4BfW6QW6Uv+1TTT1rht+oMui+A=,tag:awLRjJIVSXhAR5EoSzeZdQ==,type:str]
     pgp:
         - created_at: "2021-03-17T13:13:29Z"
           enc: |

--- a/cluster-scope/overlays/prod/common/groups/cnv-testing.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/cnv-testing.enc.yaml
@@ -5,17 +5,19 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:Uj0/16qooDIwK6RzmRLAGDLDDA==,iv:z460STqeWkA7j5F3epgOxA3z7G4JHXoDcViT3nNQ/mI=,tag:NsgqX+IRIi1wEe6tNAAbjQ==,type:str]
+    - ENC[AES256_GCM,data:/UUDPZnj77NIldhLow==,iv:3OYSZYM1ctiyq/Hrr/0/62TvY5pTIkNbltBAwqwvh20=,tag:IizcFtuNNNJPq5ZJID/VrQ==,type:str]
+    - ENC[AES256_GCM,data:Uj0/16qooDIwK6RzmRLAGDLDDA==,iv:z460STqeWkA7j5F3epgOxA3z7G4JHXoDcViT3nNQ/mI=,tag:NsgqX+IRIi1wEe6tNAAbjQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-03-26T13:57:54Z'
-    mac: ENC[AES256_GCM,data:NbufULOG0b8zMyXZjIL3/TcmtNnttrx0G0DA+WMfKiEDRdXRWhXefeRu7g4Za101NxIV4EPyr1CXgsDT3V9JEIC3DPSUPDL30ezsb++k5Cy0Dxw+WD2tE8Y94Nu1kW9/AnvQAUoHfH3GWuLLy+I6c/gPgm/s4EBFlWsl91svOHQ=,iv:YEZ8uX1MQ3YCYrIdyCvRziD02/K6utiVpi42YNhTCxY=,tag:H7+a4pND0mNlMJZiAretwA==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:22:24Z"
+    mac: ENC[AES256_GCM,data:ootEPvcXJf0JU8a6j4qnx9FN22mmo1yMBPJq6VtegdJR1RUwsw9xmb7xMCRgfk0CvNG3f0a0uXqQRI/FGv4WN1OPuse9efAlaDoFLaK0jrTw0AaWm8HU27xhsx3ihFwEt6ZCm8Uv5FlF/tdCM8cK08fGBwnUwuwqoiji9hP3uIg=,iv:DrW1bfDb/DyHM9DfdxRq7jY69Odhtf0r3EtmwQM3lL0=,tag:nc+DHAemO+MyIb8+rTO11A==,type:str]
     pgp:
-    -   created_at: '2021-03-26T13:57:17Z'
-        enc: |-
+        - created_at: "2021-03-26T13:57:17Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAjBypEgMBl+ku6Wh8rkM43HfNa2xZ5BjhjZhICGLy8BNe
@@ -34,9 +36,9 @@ sops:
             t34A
             =z6f7
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-03-26T13:57:17Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-03-26T13:57:17Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAnuZLTwcTCw2HkP7D7vT8MeENEwCIhJCQVEmLv7sTu0+H
@@ -52,9 +54,9 @@ sops:
             osJyILv+YmKSh+KfU7/B4RxvAA==
             =QnsC
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-03-26T13:57:17Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-03-26T13:57:17Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAcmvZdx3tfDimmP/mcv9KUBEImj2Jsw2ONsw4RAkFQJBN
@@ -73,9 +75,9 @@ sops:
             pIgA
             =qpQ9
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-03-26T13:57:17Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-03-26T13:57:17Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAm+C6IQ+miFD0ED1nJhRQsgL+xsGetIh7GPYXnfv4enVp
@@ -88,9 +90,9 @@ sops:
             N6wAz8oGQOBA5P/548ROVms2mUBLoJU6bLXi3g+2OuFOtAA=
             =3SA3
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
-    -   created_at: '2021-03-26T13:57:50Z'
-        enc: |-
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+        - created_at: "2021-03-26T13:57:50Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA6Oo6f1bBrdyAQgAkLvhxGusmxRXFcEWV/xTVsa+WykrHCEVU+uCGZW9ay/E
@@ -103,6 +105,6 @@ sops:
             O5j052bxy+Cc5Ez49gTZk0rQYfaSZq7+roziEWFVOeGiwwA=
             =6pcL
             -----END PGP MESSAGE-----
-        fp: 773375437C1226AEF1B424785E0A4F8F1494CE0B
+          fp: 773375437C1226AEF1B424785E0A4F8F1494CE0B
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/codait-advo.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/codait-advo.enc.yaml
@@ -5,17 +5,19 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:gRIa4Vvl6PerIq661IXs6Vu7IaZhHg==,iv:tLb4QhG39JMXt51KCbfxENpsUrLYybs7OdvcH5Bcrro=,tag:apcJ+znbjGpWltU1rlJWRQ==,type:str]
+    - ENC[AES256_GCM,data:2Oc7Rs1B/D4=,iv:EYoleZqGOgVdQiIN7+c2vwh5LxMzGXtyNS+jH4i7/Yg=,tag:OjdqAwMFt2VBj78WbqrrCA==,type:str]
+    - ENC[AES256_GCM,data:gRIa4Vvl6PerIq661IXs6Vu7IaZhHg==,iv:tLb4QhG39JMXt51KCbfxENpsUrLYybs7OdvcH5Bcrro=,tag:apcJ+znbjGpWltU1rlJWRQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-04-12T20:53:28Z'
-    mac: ENC[AES256_GCM,data:k4h+KOw97LJvetUjtrRIFovZaBGZgf/rBr09HR4hKAETx2wgL4mReL6wJvU5ineVcNRjejxgg6Dgtdgb09OjjOXoPd+ho9c0yrbcSGb1U8CWbGT1bBlqZVXNBWj02xk+kdMOzvEDgLVvsgriGoH9Spr1IRAh2MtejKjLoTZLfMM=,iv:wtgNOfBNP+DznqiJYvwyT6yHBEaBQ7/niXKZMLC4x2Q=,tag:6cp453QBj4rdh95b26xHoQ==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:22:34Z"
+    mac: ENC[AES256_GCM,data:ynZj92UdQ2mBaW2Aeffngee7unRd4BeN+pAn24EMSU8u7g3l+R7lVwYjcpfTitobUIyq1mwlIcwKmZtoE30VXfe+P+j6KM2eQ1OXk/iqEFA/zbH36engqST780PtBY4zcMSJvxxVv4va4kb1EOnkIIghNjZu1FrETBDu/3QmLNo=,iv:JtSab4QyiOTuuzoycuz3gSK4XeJkCDJMN1oa0npGHaw=,tag:qAiei5K/hnOV2xwx3jnzng==,type:str]
     pgp:
-    -   created_at: '2021-04-12T20:53:27Z'
-        enc: |
+        - created_at: "2021-04-12T20:53:27Z"
+          enc: |
             -----BEGIN PGP MESSAGE-----
 
             hQIMA9aKBcudqifiAQ/+KAUi09n1tZVrFUJhY5HxGwVNDO5Wcpr/A5jhd7h+egVF
@@ -33,9 +35,9 @@ sops:
             otJK8SBwvjmNvNqoNL7XGIbax+wScdGwTB3zBxKaKJQrOmGxbGdibPsJM/vz
             =K22w
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-04-12T20:53:27Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-04-12T20:53:27Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAqBYJX02PF0ah36ydyV+80cjQb3tyAlpLcJ8at/Akali1
@@ -51,9 +53,9 @@ sops:
             HmUaG8xXB2Pv1+JKf2jM4X1PAA==
             =K3+W
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-04-12T20:53:27Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-04-12T20:53:27Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAkDZWxjnuOkZZKYQuMTQgDrPf25AqUf3iIN5+CULaYYtZ
@@ -72,9 +74,9 @@ sops:
             g6kA
             =tlkF
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-04-12T20:53:27Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-04-12T20:53:27Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAvPuj0L9n5AaOzJXI86bP572MWGgbdLPbKa53D7RSBefF
@@ -87,6 +89,6 @@ sops:
             xWjR9FskfeCQ5D9FggQ8ziumBKuQ1+9yXU7iRQ6I/uFTnQA=
             =ECFR
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/curator.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/curator.enc.yaml
@@ -5,20 +5,25 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:cAHRz7B/Uo8CGqudfS5sO54f9Q==,iv:/5qXetOQcE8HeZHtiRo65Zx3EVCFTDA7SWQZRW5Zdbw=,tag:ZZULFLV4wI5kOlzelgzzSw==,type:str]
-- ENC[AES256_GCM,data:MQmu+dKluLEIANP89ZBxNKgd,iv:YWPgF9DCqSgEskkfVD4gEeXBBwD2ku/uC2J+uwuUnsI=,tag:VwWWw10rmqMnKrc/QB/6VQ==,type:str]
-- ENC[AES256_GCM,data:VuaztcAwuZ62pqO/FrDmXVbhuA==,iv:P0UUWFaiScsrQBakqX0y2fNN60W8VsZI17uW92OkG3M=,tag:yfd0ZOBQ0ZgUUp75s1XTBg==,type:str]
-- ENC[AES256_GCM,data:r+7IMa4wEM6gftJbbPzkj9+hBg==,iv:ZPzGp8zMMOAn7I57dC94JWueA3vRLGRfVUVLutRJL8A=,tag:8tEzYw55sDYm1MpSVVDpWA==,type:str]
+    - ENC[AES256_GCM,data:q2od1nebuEo=,iv:P24jKNaBZ+vlf4w9SP6GskJaetGDAxJXnhncd5MS79s=,tag:1H3R+tlzMruQonjJ2qL0yQ==,type:str]
+    - ENC[AES256_GCM,data:cAHRz7B/Uo8CGqudfS5sO54f9Q==,iv:/5qXetOQcE8HeZHtiRo65Zx3EVCFTDA7SWQZRW5Zdbw=,tag:ZZULFLV4wI5kOlzelgzzSw==,type:str]
+    - ENC[AES256_GCM,data:QPEsN3+0YA==,iv:GdMWdZQzV031AkKbSC2CujjWNiWi0JXbXLH+6Y3Rr8g=,tag:KTKlwxt2ucQhTlytyY2mhQ==,type:str]
+    - ENC[AES256_GCM,data:MQmu+dKluLEIANP89ZBxNKgd,iv:YWPgF9DCqSgEskkfVD4gEeXBBwD2ku/uC2J+uwuUnsI=,tag:VwWWw10rmqMnKrc/QB/6VQ==,type:str]
+    - ENC[AES256_GCM,data:9U4FJrWGxg==,iv:a75XirAfHeVpUQcjaMA5p3PkdTAV5WEZg4mM/1JZOz0=,tag:SSpRnYdrzfrwjbqaZm3H0A==,type:str]
+    - ENC[AES256_GCM,data:VuaztcAwuZ62pqO/FrDmXVbhuA==,iv:P0UUWFaiScsrQBakqX0y2fNN60W8VsZI17uW92OkG3M=,tag:yfd0ZOBQ0ZgUUp75s1XTBg==,type:str]
+    - ENC[AES256_GCM,data:9kyK/Avo7jt1Gg==,iv:uskH+szAIrRbl7iFM416kUf97blaZHmpwKOhVt0muNM=,tag:NQoZyekJRsQjQ8//yo6YNQ==,type:str]
+    - ENC[AES256_GCM,data:f7sLG0WPuBd8QEuPTA2uqU3ghw==,iv:2dP/Q0g0wb99R0UekhyjSrQb3XiKReNuaUAyobYnTTU=,tag:bg1JrP6Qkls2Fl//YXweDw==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-08-17T13:42:28Z'
-    mac: ENC[AES256_GCM,data:CJZxvn3ziZ7zd7TYPruAqkjZJ6aQQ+lECx+IUaWuxIKe4iwFybezdPd1AgWGKCPG7PYNvGIppCBMnokA855MjEsBIWxYgHvRec0kBuBk48ByQui5Dq4rdqZSBgIIwxmEWywRnEG/96lo3unpYdTAzUCc5SEoc19Qybw1JEnckC0=,iv:DPy1CjD8xoV+juPGqABzzsMDPvpnvJ1ChK/UgzyHRu0=,tag:7fxkf3acncmtYWm4UxuH/Q==,type:str]
+    age: []
+    lastmodified: "2021-08-17T16:15:03Z"
+    mac: ENC[AES256_GCM,data:4oZTjFsuyrpHO8srkH99zRjqrjRhHtn645fYAolCIswT+1gMquboW5I5dbth+3iVxC/wB9Vu1AKK7Yroztk09KPHfp/S1gSxUg7HaZV7oAJ88s582qyyJbSh92JV8OpyBJ10Bnqm4hGAP/Eg1SAvPaarjKBEWl7WzjSo/IizEzs=,iv:FPiKBrTy71qc6qL+5snxrlejpWf5HnuL2II2lL6Ti8c=,tag:DcAP9I5O3CrbG8AkjQC0QQ==,type:str]
     pgp:
-    -   created_at: '2021-04-06T12:49:12Z'
-        enc: |-
+        - created_at: "2021-04-06T12:49:12Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAsYXAlSudZaNSo+/BkMh7K97P3BwHDekooCAF4M5vV+GN
@@ -37,9 +42,9 @@ sops:
             xzcA
             =2prS
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-04-06T12:49:12Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-04-06T12:49:12Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA43ffXK023rrARAATsvTIhjOs4o2f6j4zFpZKt9G8OULZZwo6TNn04xQuWki
@@ -58,6 +63,6 @@ sops:
             c8AA
             =nvE3
             -----END PGP MESSAGE-----
-        fp: 4B6A81C7D1711864408480CEC37C8EDF9301474C
+          fp: 4B6A81C7D1711864408480CEC37C8EDF9301474C
     encrypted_regex: ^users$
     version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/data-science.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/data-science.enc.yaml
@@ -9,13 +9,13 @@ users:
     - ENC[AES256_GCM,data:AvOnyFzNBnsjxoet1BPP+ZyeLA==,iv:0rlmFCpcFUI0KehHzMcZmh1N1BHgmNjkZMBRmCvhUg8=,tag:/vAGaT2hZfy7qU9ozUXDJA==,type:str]
     - ENC[AES256_GCM,data:JaaVhW7HVaU76lLLGRiE,iv:IDoEc+5CoOqQfKLbNnv+rFoUgU24vy6kT6WGzEEnfCU=,tag:1S4E07gsQPD/J3Ynl85JGg==,type:str]
     - ENC[AES256_GCM,data:gN/IdSSvwB8y5Di80eb0Yn20,iv:p/5Cr2NjOz8YViOdJGEe0bdfJrYK9ilVPKm6HIPzAHg=,tag:3Tkjfx7W47V+6FO0Zue0qw==,type:str]
-    - ENC[AES256_GCM,data:v+59mjZ7rVIY3g==,iv:o0HGF/4piVu0YkJF2hWBpRFZgSMyzNrrq9n2rm57uws=,tag:kpt3aiUZEMImHcnUxFZrAQ==,type:str]
+    - ENC[AES256_GCM,data:eUvC/Kn5addmrg==,iv:NJj69rNvZTt0nSBnXrYKtlh09J+Qv4X5A7/YPx1jeUk=,tag:7Bn9kmloXJybHDi8k8fusA==,type:str]
     - ENC[AES256_GCM,data:uucwCEX9hlZhGCX+2R/zcoXi,iv:LtHvHQEr97aX0m0dMJPei2+5FZ2xw/jwpkcllXnkg/w=,tag:1Fg5bCT+S1i6QxxPtxS8AA==,type:str]
-    - ENC[AES256_GCM,data:zouVG+6ZmyM1sczqcJtJ,iv:yTV0/s9vF74ME+H61xEjirjS9cAl2OKLZv/A5WpJR4s=,tag:Ge7dHH82D3UlVFeV68AQrg==,type:str]
+    - ENC[AES256_GCM,data:Ee5QcnkNe/AAEOH9fdIy,iv:oASHRWsYsUkSZ4G2uhd/RaHUbnKtIa6hqn2I3hA3vms=,tag:GYUcCpNnmp2WK6oKs5yNwg==,type:str]
     - ENC[AES256_GCM,data:hkrqsS4e8AFdSPwKXxq/BFppKg==,iv:N49qFph4LYZsxiHfEP2WArcUT86kU2BXTI9vAh8UCrA=,tag:RwrY0F+PkNlD0K13tuqPCw==,type:str]
     - ENC[AES256_GCM,data:zMFYrU7yADNUsETxYOgq,iv:fX9k8zv/NG6kwwZ50YZ6D0Np0uaElJQ8ODD1MjXQKZM=,tag:PEm311rFwhbjTQVhLKlF1A==,type:str]
     - ENC[AES256_GCM,data:3M/adHLnzPN7+vDNUW0buDZOig==,iv:gW9iAbvdU1rfBjY6+DqFrDyYLcoUd5X7ZgrEstfrrJw=,tag:KkE6TbwyMPci2rydxqfEfA==,type:str]
-    - ENC[AES256_GCM,data:IVCcF74wrA==,iv:Z7/smAoEb3ENSx5xTPJ6dYCebttzAX5nqZ0IHXB/4w4=,tag:zSAj/k2haDheYzbczz7wBg==,type:str]
+    - ENC[AES256_GCM,data:SSRRyCqkcA==,iv:DAQ8S4h0U0MrWx0aFhSGf5VTgfX/X6bncqWc47XAj/g=,tag:N5gM5MKbrKPaOSQOa3YDlw==,type:str]
     - ENC[AES256_GCM,data:YJ5HiI6L7mshqU24A3It+SE=,iv:iMoWu5bmg0TMARBpSHOyoOi7NbETAjK+ukSbSp9/zsA=,tag:9gy4bfK6q3JrYRPRW/cjsg==,type:str]
     - ENC[AES256_GCM,data:9gCDQeo=,iv:LpxydoOLvYEvdSfXiSOQz63/OYGBjWGgmfDMJjm4wgM=,tag:H3BfeyNHJQ4uJfuVo4pNrg==,type:str]
     - ENC[AES256_GCM,data:TRvS8oqljUcgu1OH2PDcYVc=,iv:vna7eenSL1lUpCMOe66x5ucltraJs6S+W9n8fayTZqw=,tag:QBcragHk/SpvxHgZ0RyIbg==,type:str]
@@ -33,8 +33,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-07-14T20:23:44Z"
-    mac: ENC[AES256_GCM,data:qmRxmZCArFXFEJq17F1DIwlJyzYSLq71QbTe6FBvIel1y1ePby+dYqFYtynJEnH7DwMSSz7suGPR4NBnLpMtkIp9W/EDGedBTilNJ4l8zMClMP1Gxxk7CmGWdkVkKpz8elkEmJQt0tzd3ifGjCDLt/zLj/qDZlxzy+lVkYRR8Tw=,iv:b1p0op4O0Y6MKlE6XkoARO/bnz0VlaaMpk6nNPefI/E=,tag:hX3SIEYn1JujyJhzySwz/g==,type:str]
+    lastmodified: "2021-08-12T12:50:54Z"
+    mac: ENC[AES256_GCM,data:l9q3cVWgsuPx9v//LHotVAVKXbyAsdWddjCtdcBdLu5KKEiKg2F/CjoN00+9W8OPRdQ1r7NR+pj4nV1mbM+esqbmV4eR0FD7PI8XJG0t9ZQrSRWPTugcHp1ZNPIIWxt6U91p5hNr+JyKk+sKbbnK91S3q3UQ+2D9OT+J5t24f9U=,iv:T2+BGaG4odc01XdFwPVS3EPSTNMxP7Od3qbyLGKh2GE=,tag:KYENnVm6Bg7Zah2DdOuXBQ==,type:str]
     pgp:
         - created_at: "2021-02-02T17:08:05Z"
           enc: |-

--- a/cluster-scope/overlays/prod/common/groups/data-science.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/data-science.enc.yaml
@@ -5,27 +5,39 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:AvOnyFzNBnsjxoet1BPP+ZyeLA==,iv:0rlmFCpcFUI0KehHzMcZmh1N1BHgmNjkZMBRmCvhUg8=,tag:/vAGaT2hZfy7qU9ozUXDJA==,type:str]
-- ENC[AES256_GCM,data:gN/IdSSvwB8y5Di80eb0Yn20,iv:p/5Cr2NjOz8YViOdJGEe0bdfJrYK9ilVPKm6HIPzAHg=,tag:3Tkjfx7W47V+6FO0Zue0qw==,type:str]
-- ENC[AES256_GCM,data:uucwCEX9hlZhGCX+2R/zcoXi,iv:LtHvHQEr97aX0m0dMJPei2+5FZ2xw/jwpkcllXnkg/w=,tag:1Fg5bCT+S1i6QxxPtxS8AA==,type:str]
-- ENC[AES256_GCM,data:hkrqsS4e8AFdSPwKXxq/BFppKg==,iv:N49qFph4LYZsxiHfEP2WArcUT86kU2BXTI9vAh8UCrA=,tag:RwrY0F+PkNlD0K13tuqPCw==,type:str]
-- ENC[AES256_GCM,data:3M/adHLnzPN7+vDNUW0buDZOig==,iv:gW9iAbvdU1rfBjY6+DqFrDyYLcoUd5X7ZgrEstfrrJw=,tag:KkE6TbwyMPci2rydxqfEfA==,type:str]
-- ENC[AES256_GCM,data:YJ5HiI6L7mshqU24A3It+SE=,iv:iMoWu5bmg0TMARBpSHOyoOi7NbETAjK+ukSbSp9/zsA=,tag:9gy4bfK6q3JrYRPRW/cjsg==,type:str]
-- ENC[AES256_GCM,data:TRvS8oqljUcgu1OH2PDcYVc=,iv:vna7eenSL1lUpCMOe66x5ucltraJs6S+W9n8fayTZqw=,tag:QBcragHk/SpvxHgZ0RyIbg==,type:str]
-- ENC[AES256_GCM,data:zbGzLCLXZAwf0R1tAdsXZUqT9A==,iv:TPPU26FPlPRCNJpkV9YSEYiXHUVzETpP7PjmRUmP/hw=,tag:txCzpEfo+ei7JNL3mfTmpg==,type:str]
-- ENC[AES256_GCM,data:N+PhT++ZNwUMg60hccL/qQ==,iv:+eMnYc2MlWar02h8qAPIEW6tvxV1Ib98T8gwf7EzgJQ=,tag:0eejCxO+CD/DkAELuupYYw==,type:str]
-- ENC[AES256_GCM,data:Hnv73wbYxw20BT3n7U7A0ERgyg==,iv:fykmpG2+QDO9jrger5uK4ftF1OuB1SmDvMNLnlRhasg=,tag:tqFKowN3f7U8uNDns9vkbQ==,type:str]
-- ENC[AES256_GCM,data:hbk7WHEN94wiRhKi/aMuw53BSg==,iv:05fhO8U558yfNLobDpFUNjwGMkrqNpxI2IpTGw8dk0w=,tag:LK/5mder2iwyMDKTMqMa2g==,type:str]
+    - ENC[AES256_GCM,data:yT5NVnyK7KbOxw==,iv:PB4eeWm7WnSmDaaoO13fUDYZLhV7eWhM2gYpDpWNUqQ=,tag:kY5TNJ+kAFAf8QCX1aYluQ==,type:str]
+    - ENC[AES256_GCM,data:AvOnyFzNBnsjxoet1BPP+ZyeLA==,iv:0rlmFCpcFUI0KehHzMcZmh1N1BHgmNjkZMBRmCvhUg8=,tag:/vAGaT2hZfy7qU9ozUXDJA==,type:str]
+    - ENC[AES256_GCM,data:JaaVhW7HVaU76lLLGRiE,iv:IDoEc+5CoOqQfKLbNnv+rFoUgU24vy6kT6WGzEEnfCU=,tag:1S4E07gsQPD/J3Ynl85JGg==,type:str]
+    - ENC[AES256_GCM,data:gN/IdSSvwB8y5Di80eb0Yn20,iv:p/5Cr2NjOz8YViOdJGEe0bdfJrYK9ilVPKm6HIPzAHg=,tag:3Tkjfx7W47V+6FO0Zue0qw==,type:str]
+    - ENC[AES256_GCM,data:v+59mjZ7rVIY3g==,iv:o0HGF/4piVu0YkJF2hWBpRFZgSMyzNrrq9n2rm57uws=,tag:kpt3aiUZEMImHcnUxFZrAQ==,type:str]
+    - ENC[AES256_GCM,data:uucwCEX9hlZhGCX+2R/zcoXi,iv:LtHvHQEr97aX0m0dMJPei2+5FZ2xw/jwpkcllXnkg/w=,tag:1Fg5bCT+S1i6QxxPtxS8AA==,type:str]
+    - ENC[AES256_GCM,data:zouVG+6ZmyM1sczqcJtJ,iv:yTV0/s9vF74ME+H61xEjirjS9cAl2OKLZv/A5WpJR4s=,tag:Ge7dHH82D3UlVFeV68AQrg==,type:str]
+    - ENC[AES256_GCM,data:hkrqsS4e8AFdSPwKXxq/BFppKg==,iv:N49qFph4LYZsxiHfEP2WArcUT86kU2BXTI9vAh8UCrA=,tag:RwrY0F+PkNlD0K13tuqPCw==,type:str]
+    - ENC[AES256_GCM,data:zMFYrU7yADNUsETxYOgq,iv:fX9k8zv/NG6kwwZ50YZ6D0Np0uaElJQ8ODD1MjXQKZM=,tag:PEm311rFwhbjTQVhLKlF1A==,type:str]
+    - ENC[AES256_GCM,data:3M/adHLnzPN7+vDNUW0buDZOig==,iv:gW9iAbvdU1rfBjY6+DqFrDyYLcoUd5X7ZgrEstfrrJw=,tag:KkE6TbwyMPci2rydxqfEfA==,type:str]
+    - ENC[AES256_GCM,data:IVCcF74wrA==,iv:Z7/smAoEb3ENSx5xTPJ6dYCebttzAX5nqZ0IHXB/4w4=,tag:zSAj/k2haDheYzbczz7wBg==,type:str]
+    - ENC[AES256_GCM,data:YJ5HiI6L7mshqU24A3It+SE=,iv:iMoWu5bmg0TMARBpSHOyoOi7NbETAjK+ukSbSp9/zsA=,tag:9gy4bfK6q3JrYRPRW/cjsg==,type:str]
+    - ENC[AES256_GCM,data:9gCDQeo=,iv:LpxydoOLvYEvdSfXiSOQz63/OYGBjWGgmfDMJjm4wgM=,tag:H3BfeyNHJQ4uJfuVo4pNrg==,type:str]
+    - ENC[AES256_GCM,data:TRvS8oqljUcgu1OH2PDcYVc=,iv:vna7eenSL1lUpCMOe66x5ucltraJs6S+W9n8fayTZqw=,tag:QBcragHk/SpvxHgZ0RyIbg==,type:str]
+    - ENC[AES256_GCM,data:YFufdumsoiMW,iv:vTu/m6oq06ikxTgbordbxlCVkUJViPFW+xoDI4TdWYo=,tag:CywLXH45Fz5KEKFFEtGLPA==,type:str]
+    - ENC[AES256_GCM,data:zbGzLCLXZAwf0R1tAdsXZUqT9A==,iv:TPPU26FPlPRCNJpkV9YSEYiXHUVzETpP7PjmRUmP/hw=,tag:txCzpEfo+ei7JNL3mfTmpg==,type:str]
+    - ENC[AES256_GCM,data:FJIu1b6WX6M=,iv:cDBTMyhzIPf5hhBO96Pb5j383tNAqisDzyYSGL++0zw=,tag:bdNBt54kQtmykCo+PMkAHA==,type:str]
+    - ENC[AES256_GCM,data:N+PhT++ZNwUMg60hccL/qQ==,iv:+eMnYc2MlWar02h8qAPIEW6tvxV1Ib98T8gwf7EzgJQ=,tag:0eejCxO+CD/DkAELuupYYw==,type:str]
+    - ENC[AES256_GCM,data:BOgaHE1mF4wdtbIlRw==,iv:i0XaEvgyEbbtaO81CIUmdjrH8MswsR12AQ1JDYkdOyY=,tag:KJr1UQGSUx1/VzEk6xsd7Q==,type:str]
+    - ENC[AES256_GCM,data:Hnv73wbYxw20BT3n7U7A0ERgyg==,iv:fykmpG2+QDO9jrger5uK4ftF1OuB1SmDvMNLnlRhasg=,tag:tqFKowN3f7U8uNDns9vkbQ==,type:str]
+    - ENC[AES256_GCM,data:xOm5gXlUa1vY/ps=,iv:aZ+ncnYgtepUq441BCmdOAK9hAIuxZTny072RcL5LrM=,tag:qBRavfae9F89ZHG9K2ioHA==,type:str]
+    - ENC[AES256_GCM,data:hbk7WHEN94wiRhKi/aMuw53BSg==,iv:05fhO8U558yfNLobDpFUNjwGMkrqNpxI2IpTGw8dk0w=,tag:LK/5mder2iwyMDKTMqMa2g==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-03-11T14:06:25Z'
-    mac: ENC[AES256_GCM,data:aodvbCUxCf/VNxdOCcTiS6z8ZY6xSRXnMmExdzQQPJGyqJOf2ycFeBUcLgY2xB+F3HLNPYA279HORSpw9ZXB2+mMWv0trORQSu0OvR09P2P2JyIvnhsLbzTFT1jWhTTgwxh13k3BXCwLw7SOwKlhsqA+fY7Xoy91bRnD3twpf7w=,iv:v9pPbby2csgglIhx6sTqSMfuASCWsb3j6BAjxFsJnvk=,tag:KDQqhdVPmNHMbVzU/CkLBA==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:23:44Z"
+    mac: ENC[AES256_GCM,data:qmRxmZCArFXFEJq17F1DIwlJyzYSLq71QbTe6FBvIel1y1ePby+dYqFYtynJEnH7DwMSSz7suGPR4NBnLpMtkIp9W/EDGedBTilNJ4l8zMClMP1Gxxk7CmGWdkVkKpz8elkEmJQt0tzd3ifGjCDLt/zLj/qDZlxzy+lVkYRR8Tw=,iv:b1p0op4O0Y6MKlE6XkoARO/bnz0VlaaMpk6nNPefI/E=,tag:hX3SIEYn1JujyJhzySwz/g==,type:str]
     pgp:
-    -   created_at: '2021-02-02T17:08:05Z'
-        enc: |-
+        - created_at: "2021-02-02T17:08:05Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAeGayuHiSnP8dxs6sFl8rwYXylVJngRLHPChmc1lEQl9x
@@ -44,9 +56,9 @@ sops:
             QZcA
             =db8i
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-03-11T14:06:22Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-03-11T14:06:22Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAAXRGLJH14EgcI0TX6W0n+bHI4Lw/YJsd5o3vS3YnkVGn
@@ -62,9 +74,9 @@ sops:
             FRqimNjrY3+iVeLJbkei4WRxAA==
             =1NcY
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-03-11T14:06:22Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-03-11T14:06:22Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAsqoheVfr5foiKbwOO1qH4mzLjrG233RFRW7hB+TVvEZ0
@@ -83,9 +95,9 @@ sops:
             AO8A
             =1Yi4
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-03-11T14:06:22Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-03-11T14:06:22Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAVcXFYRI5SOpxKLuSsED20uDYBGHyFsqSqFxZHjK/LPAt
@@ -98,6 +110,6 @@ sops:
             pqRGTU/YquBQ5PV2P0jypOFqjSCEAilnIlTi1w+r2OGjpQA=
             =6bd/
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/enterprise-neurosystem.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/enterprise-neurosystem.enc.yaml
@@ -5,10 +5,15 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
+    - ENC[AES256_GCM,data:fvI/AzXPiM0hm9myTQ==,iv:eCKkf0oTY07GmZq85sS7Cq1gdTKzr1BOAAGl0OJ/A6s=,tag:15vhHWKITFegsarrIfb1Hw==,type:str]
     - ENC[AES256_GCM,data:Ubd9aDk99JY3zOOvlgJmcU444Q==,iv:24rn7DSYMQWIvY/rhK173YkspcMWVGx0qAT+iAfb9OU=,tag:G3agO7U2hs1Ce7c2iSyzuQ==,type:str]
+    - ENC[AES256_GCM,data:Fbm917BGh1DQ3L4Yq+5NJzwtOZTEca4=,iv:qL7zclgJI0qxKKrXM50kUpRy9UR2SnnC4+GBH+IFfzg=,tag:m463VJTFKkdS7nzEODYo/g==,type:comment]
     - ENC[AES256_GCM,data:ww6EXEX0gmdc1vsLr2v+S/4k,iv:bDM5HnTiU12OKqLEiwNeL0NQ0KqbE2UnEYSIr1yZrd4=,tag:bXxe0tnUSqft4OvbkOTDlg==,type:str]
+    - ENC[AES256_GCM,data:TSdFiYvLb8cdRSgKZ6YmQF9z55AgEgI=,iv:d7Dpoh300NBGg/dku4WUZnoNtN7SEkeyibKNDjvHf6A=,tag:gNf+luxyFTK+PTbpNFbjSg==,type:comment]
     - ENC[AES256_GCM,data:CHfLiDPQQmgwfd6Ifcovja6PkpsEWxYjpm4=,iv:0DND4K7Ob2QzYLRxb5BBP/qcJ2nTTgbHZ5Vq/e2+Bps=,tag:U1vRkdZeoYWIp5FfBymfGQ==,type:str]
+    - ENC[AES256_GCM,data:QCS+3s9hl1rZ4xLF7Ke5FZlM1fBJyqU=,iv:qjA+PogEWNaqqHQ/IItROE2ZXsRPhY0TPIeLtci5UYE=,tag:57mjmtXwtg6g4VFOm5wWng==,type:comment]
     - ENC[AES256_GCM,data:AJeABaM07a/BWqawdN+suInXpWc3rX9QWiVPdf1xVg==,iv:aXuLfrdL+NJFa6NKMeVIbdMimTFUVYtaFB00WF7woQs=,tag:j22k1HK1hsc33I6XQ1++mA==,type:str]
+    - ENC[AES256_GCM,data:xbDP+RJjGv3fi/pY5dwIMD8Zpo/SUck=,iv:KGazzYg8kZMuRkD1mWmrlJcthpn5MQPt3HXEkuvIWKY=,tag:kAUsqIVaY4erWOkaCQ6dPw==,type:comment]
     - ENC[AES256_GCM,data:IfBZV2Bg0LmsSWlsg//GpHmvv+Bu+ourhJ3kiHM82BA=,iv:TMb0E1YOaZOtB3aBHMU+rniHmbXH2CHyQGdWCoB3Yoo=,tag:etFWUueTfA7WutkEnctXEg==,type:str]
 sops:
     kms: []
@@ -16,8 +21,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-07-29T22:53:52Z"
-    mac: ENC[AES256_GCM,data:4jLH+eJnnza8yPFyXqaiGcxiwaF3nLwxMAt54MUDV8oFWqH+5UPgyZPGPj6XyKZPn5J1wMj0etB6xkuueycF3dHRWn2HDERxaA2uwoRR4AZjx/dvt1saMU5T+hkduDN/0QwgczYEzDD9CwLkmOg7+dmEm+CIqQ+SZgb/Xmaxsu0=,iv:NPdwCMNWeLnZ8Dtp5abdDJYBqcAbNTfx7yLz8QXYD1M=,tag:rVJSFIz0nEZ+U3qlzo2m2w==,type:str]
+    lastmodified: "2021-08-12T13:07:31Z"
+    mac: ENC[AES256_GCM,data:dMThkh94pqqd5Y95RW4hTX3IRV8rQjOeB6VR/TCLjYAojSvWY1ptRXyYVWZ4he/a1S4Mz2m0mKKUGQFN29sjcLX45BQ5MdouqjTKApBI8hdA2ZTCezTuGTZn7klbA8O28pA7QMcNsk0ShAYizkM8j+GUdZyUhzD5dCutGVXETzo=,iv:GBIKf/9IEB19Pa9ElexRFUasWrojLHgB/1CWdy62AZE=,tag:2S4iLXlm0si048+bM2SqOg==,type:str]
     pgp:
         - created_at: "2021-07-29T22:53:51Z"
           enc: |-

--- a/cluster-scope/overlays/prod/common/groups/esi-project.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/esi-project.enc.yaml
@@ -13,7 +13,7 @@ users:
     - ENC[AES256_GCM,data:X7jw/DVdNjLXXTyTqcgIysnG,iv:gN/0vep13hmbAYg000wuG7mpsiZX2jcdDRA3VXOpvvw=,tag:cwyd1JNTNxvbqw38WUp9Tg==,type:str]
     - ENC[AES256_GCM,data:G2/u0zH1Muo=,iv:AzspcbchS2w6PRTuEpbMT+7Q9jRV49GKRZqk9Ieo4OU=,tag:U3yBZyrTJ+oR1gj7KpioUg==,type:str]
     - ENC[AES256_GCM,data:2VtrnU/ykkm0aj3Pcm8K,iv:qbKlPu9V7VxbYhShY05DWmOK3O5auVUP3q52Px62XzU=,tag:TIV7Xm/n0mS9hvbAVsrFSg==,type:str]
-    - ENC[AES256_GCM,data:bvoeniKpJ4g=,iv:UwNRbJlNbIwokWOpQkakm+/Eao2kOZOyUiOFBW7bqow=,tag:Ur7Y59X44eBm/m19jIDZxQ==,type:str]
+    - ENC[AES256_GCM,data:OVIE+7D1I/k=,iv:pG1XrNJVxZe+izFEzSjc1G8Sg+RKxk0SwvJH4kelUog=,tag:mEEQLCb/NRDPnik8pHhFbg==,type:str]
     - ENC[AES256_GCM,data:PJmBkqOHF+ma+rfi/AVIj1U=,iv:M5VwiAcXAesMKtWSAc/vGTi6Eb7LOgRbRoTgq3tesns=,tag:csMQwYquFFibqdZHKYG1vg==,type:str]
     - ENC[AES256_GCM,data:tobOT9TABBo=,iv:WeZmhnFDg23YVFKnjf7SZ8cemlQAXASF7OWM82YYVsI=,tag:KLQCAspqjydRZrtb5+q73A==,type:str]
     - ENC[AES256_GCM,data:CESwWw5XFzYslgCqDP6CWE52Qg==,iv:CFXxNGsyQ5oxVxW5TKyjxvURluXIypzm61LIeKqo3XU=,tag:CP9gIVJ6Gfr8UsuZHm6WoA==,type:str]
@@ -23,8 +23,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-07-14T20:25:40Z"
-    mac: ENC[AES256_GCM,data:HcCcksmfzATD7SaZqdQ42WxnMWKDjrIoXGOPujGKi6u8RCZX9X+I7Cta5b1kOmrXGfc321Y4PHMcfmPVLmDi9mwEPPOpkaRRwIhvGM9msjNgRZXXc8qOIqX4YuQvpK8Tvmmk1fvfDmEFYc3a3JVjUgvOI6+V0USzH3ESZUP2aSg=,iv:Mghi4YPETxgcQh2gdzqpM/hwjs9IyVzJQtRnSb109x8=,tag:iWXBrkDkxFTnuky3+Cp7Fg==,type:str]
+    lastmodified: "2021-08-12T12:52:16Z"
+    mac: ENC[AES256_GCM,data:ySOPCRDkGcOGJtRHyREI93D8XvW6PFtROAvmtkC+yYsrOm6x2dtoFUxAX9n7CDIK4S2v4DDy3Y5X9+PbCFcTNrIL000KuUOQeJTCk+xmEOJ+6S+Pg9fFkhAq14hODHguYgTDOl9LRRddaXgF0LycxoB3VCbleZN/s8LHABYul3k=,iv:3cAStJQccS1RuTbnAfBDrWFQkx85SRu9JrL02E2wxhs=,tag:NRWYx2LmQwq2RV8D4gE/BA==,type:str]
     pgp:
         - created_at: "2021-04-15T15:51:09Z"
           enc: |-

--- a/cluster-scope/overlays/prod/common/groups/esi-project.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/esi-project.enc.yaml
@@ -5,22 +5,29 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:A6mTFFCrR4zdHKkXk8QdpRo=,iv:acvJPc30cU/rEU2z9wIFFFOu2dlnYFXzGkDNnIXg35A=,tag:Z4Iz9pEs65SOal35jWS1jA==,type:str]
-- ENC[AES256_GCM,data:dPnih3iXB/5jbc38evpF,iv:f/kKqEsfirXo2rU/dz70V7pvYq7KYgMKEagHGv1eeaA=,tag:6YH7zDsasR3MwS66tnLHoA==,type:str]
-- ENC[AES256_GCM,data:X7jw/DVdNjLXXTyTqcgIysnG,iv:gN/0vep13hmbAYg000wuG7mpsiZX2jcdDRA3VXOpvvw=,tag:cwyd1JNTNxvbqw38WUp9Tg==,type:str]
-- ENC[AES256_GCM,data:2VtrnU/ykkm0aj3Pcm8K,iv:qbKlPu9V7VxbYhShY05DWmOK3O5auVUP3q52Px62XzU=,tag:TIV7Xm/n0mS9hvbAVsrFSg==,type:str]
-- ENC[AES256_GCM,data:PJmBkqOHF+ma+rfi/AVIj1U=,iv:M5VwiAcXAesMKtWSAc/vGTi6Eb7LOgRbRoTgq3tesns=,tag:csMQwYquFFibqdZHKYG1vg==,type:str]
-- ENC[AES256_GCM,data:CESwWw5XFzYslgCqDP6CWE52Qg==,iv:CFXxNGsyQ5oxVxW5TKyjxvURluXIypzm61LIeKqo3XU=,tag:CP9gIVJ6Gfr8UsuZHm6WoA==,type:str]
+    - ENC[AES256_GCM,data:+C6S8pvbBozi,iv:liZPr2wMVx1QmuTeRH+oA5x1VXVyttjy+/UDvLste7I=,tag:DGVYFkbPRbrAtWw+NgITWw==,type:str]
+    - ENC[AES256_GCM,data:A6mTFFCrR4zdHKkXk8QdpRo=,iv:acvJPc30cU/rEU2z9wIFFFOu2dlnYFXzGkDNnIXg35A=,tag:Z4Iz9pEs65SOal35jWS1jA==,type:str]
+    - ENC[AES256_GCM,data:WnzFnzgP,iv:W8nm/ZxcTpgubbJNprV6aX7M3evZGXz2xGXAKBaDY54=,tag:Pv+ib6X8E9dYNP8MFdlbOQ==,type:str]
+    - ENC[AES256_GCM,data:dPnih3iXB/5jbc38evpF,iv:f/kKqEsfirXo2rU/dz70V7pvYq7KYgMKEagHGv1eeaA=,tag:6YH7zDsasR3MwS66tnLHoA==,type:str]
+    - ENC[AES256_GCM,data:5aVhA0QAyiowi4zMPMv6wvY4ZvYmOOE=,iv:zmJ60KuFNAOm8fCMpbiuXpi/La+oEMLmqzhAQ2axFdU=,tag:KCUygXQmDtO9ayWb6CEB1Q==,type:comment]
+    - ENC[AES256_GCM,data:X7jw/DVdNjLXXTyTqcgIysnG,iv:gN/0vep13hmbAYg000wuG7mpsiZX2jcdDRA3VXOpvvw=,tag:cwyd1JNTNxvbqw38WUp9Tg==,type:str]
+    - ENC[AES256_GCM,data:G2/u0zH1Muo=,iv:AzspcbchS2w6PRTuEpbMT+7Q9jRV49GKRZqk9Ieo4OU=,tag:U3yBZyrTJ+oR1gj7KpioUg==,type:str]
+    - ENC[AES256_GCM,data:2VtrnU/ykkm0aj3Pcm8K,iv:qbKlPu9V7VxbYhShY05DWmOK3O5auVUP3q52Px62XzU=,tag:TIV7Xm/n0mS9hvbAVsrFSg==,type:str]
+    - ENC[AES256_GCM,data:bvoeniKpJ4g=,iv:UwNRbJlNbIwokWOpQkakm+/Eao2kOZOyUiOFBW7bqow=,tag:Ur7Y59X44eBm/m19jIDZxQ==,type:str]
+    - ENC[AES256_GCM,data:PJmBkqOHF+ma+rfi/AVIj1U=,iv:M5VwiAcXAesMKtWSAc/vGTi6Eb7LOgRbRoTgq3tesns=,tag:csMQwYquFFibqdZHKYG1vg==,type:str]
+    - ENC[AES256_GCM,data:tobOT9TABBo=,iv:WeZmhnFDg23YVFKnjf7SZ8cemlQAXASF7OWM82YYVsI=,tag:KLQCAspqjydRZrtb5+q73A==,type:str]
+    - ENC[AES256_GCM,data:CESwWw5XFzYslgCqDP6CWE52Qg==,iv:CFXxNGsyQ5oxVxW5TKyjxvURluXIypzm61LIeKqo3XU=,tag:CP9gIVJ6Gfr8UsuZHm6WoA==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-06-15T18:54:29Z'
-    mac: ENC[AES256_GCM,data:hPjfMKR6CbK49CVgfuIqs/kcstaa08EYKEDGqA3YA4PuANMBp50GbX1gJ1i4S+bJI4wdHKWFo52IZZUjid8+gkjFdBPdxo+ZvsfKUiUSxwqqayGS5RbYmEftP4DbX2LpmrZTwKPeb7oLRZmmoCSModoSmhax/WOqMqhYDfL/WrU=,iv:BH0sbWgtiiprrLKCOGiHkHZiWJIL9Bo4i2agxZmrVV4=,tag:K6egR+GoLFFjgXG/aRB9tQ==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:25:40Z"
+    mac: ENC[AES256_GCM,data:HcCcksmfzATD7SaZqdQ42WxnMWKDjrIoXGOPujGKi6u8RCZX9X+I7Cta5b1kOmrXGfc321Y4PHMcfmPVLmDi9mwEPPOpkaRRwIhvGM9msjNgRZXXc8qOIqX4YuQvpK8Tvmmk1fvfDmEFYc3a3JVjUgvOI6+V0USzH3ESZUP2aSg=,iv:Mghi4YPETxgcQh2gdzqpM/hwjs9IyVzJQtRnSb109x8=,tag:iWXBrkDkxFTnuky3+Cp7Fg==,type:str]
     pgp:
-    -   created_at: '2021-04-15T15:51:09Z'
-        enc: |-
+        - created_at: "2021-04-15T15:51:09Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAee86qTv5MBzQpObVrVGmPQ6QCMncVAsFre3wOHfikh1A
@@ -39,9 +46,9 @@ sops:
             31YA
             =PLwY
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-04-15T15:51:09Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-04-15T15:51:09Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwApXoLX6q0ivrecxdqyri3FUJtYoroWLY0+R8OvmUw+u+B
@@ -57,9 +64,9 @@ sops:
             E3FSl6R5M6evIeKByk9u4XbaAA==
             =3LUi
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-04-15T15:51:09Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-04-15T15:51:09Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAeSlJkWigP6Zt9ShVmCmMofswZm0dAxtzzNUH2eNDOZKi
@@ -78,9 +85,9 @@ sops:
             I4QA
             =VqyP
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-04-15T15:51:09Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-04-15T15:51:09Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgATdaqh3m6gB32DpJVFcLhZDNgyJEIUHK46AZkeTKz5rur
@@ -93,6 +100,6 @@ sops:
             XTvU3tqdieC55HVx/iQlD0ZLZRi75xF9wdjiunO2w+EjeQA=
             =ckNJ
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/fde.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/fde.enc.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
+    - ENC[AES256_GCM,data:HYjAh1/yD3ZQCaI=,iv:ljlrqVvePsvXv6LtoFXdbYIkrXBGXBt+kgpcnAzsKd0=,tag:vBue1MAizwo7Ly9iDAiq5w==,type:str]
     - ENC[AES256_GCM,data:m6XSLo5iYZftw7qcSH+X07DnaQ==,iv:WPgrEjd6WTFSqRTOBebzDiXt+kdY4eTAm1BA5o+Pr5g=,tag:0DYieIZh8zL+tPCaDCXrHw==,type:str]
 sops:
     kms: []
@@ -12,8 +13,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-03-26T15:33:49Z"
-    mac: ENC[AES256_GCM,data:NU9lpqcjmmxolyv+EgsTImoSNGIKUZZyF4+ugAiFW37WrKb50TJSrpDelsD8AE9qDwg6BqsgGRsTr7xoHjwMIibSc6rFlBP619zOeuljxLtc3OX7BW9QfwMjpVjGV87wmpppdZPVJSoO8XUt+oDsCouOO8i40u1Dgg0advd/Hu8=,iv:NivT3dKe9c3Y7hy4EbByjOwCe+EZEYlewWR3txfz0mI=,tag:gLCWI+c/4NFIRzbq/18pKw==,type:str]
+    lastmodified: "2021-07-14T20:25:14Z"
+    mac: ENC[AES256_GCM,data:S14m3rgqGxpTDNH2bEYMqy8hv9Ka+QFHbK4ZyFEGDGwgCpxRZyuBcsmtqZdu7h4ZWVlvvG8W5+CRkxTW+NNILjZLqgiDb1+5b5cgCQDXHWWXI1247Ms4pvpg+lvNcnfSYqxPVGXBwotign5Zt9kAmgGrg7UFWJAjlnM5PsUh/UI=,iv:sMuq/LTeAhH/gBxFfuqv/CuxAmAPdwJ9jQbG2tj3hvI=,tag:C0464+cUI7bFuX6i8ZJPOQ==,type:str]
     pgp:
         - created_at: "2021-03-17T13:13:29Z"
           enc: |
@@ -90,4 +91,4 @@ sops:
             -----END PGP MESSAGE-----
           fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
     encrypted_regex: ^(users|data|stringData)
-    version: 3.7.0
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/fde.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/fde.enc.yaml
@@ -5,7 +5,7 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-    - ENC[AES256_GCM,data:HYjAh1/yD3ZQCaI=,iv:ljlrqVvePsvXv6LtoFXdbYIkrXBGXBt+kgpcnAzsKd0=,tag:vBue1MAizwo7Ly9iDAiq5w==,type:str]
+    - ENC[AES256_GCM,data:LWBWyIwhXxDggds=,iv:+vbsCv/rLvf3nGKAYo/rMs4RDVmFcR476Dq/QK3Yyh8=,tag:Jt4D7dEOpfMarB6y+5afLw==,type:str]
     - ENC[AES256_GCM,data:m6XSLo5iYZftw7qcSH+X07DnaQ==,iv:WPgrEjd6WTFSqRTOBebzDiXt+kdY4eTAm1BA5o+Pr5g=,tag:0DYieIZh8zL+tPCaDCXrHw==,type:str]
 sops:
     kms: []
@@ -13,8 +13,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-07-14T20:25:14Z"
-    mac: ENC[AES256_GCM,data:S14m3rgqGxpTDNH2bEYMqy8hv9Ka+QFHbK4ZyFEGDGwgCpxRZyuBcsmtqZdu7h4ZWVlvvG8W5+CRkxTW+NNILjZLqgiDb1+5b5cgCQDXHWWXI1247Ms4pvpg+lvNcnfSYqxPVGXBwotign5Zt9kAmgGrg7UFWJAjlnM5PsUh/UI=,iv:sMuq/LTeAhH/gBxFfuqv/CuxAmAPdwJ9jQbG2tj3hvI=,tag:C0464+cUI7bFuX6i8ZJPOQ==,type:str]
+    lastmodified: "2021-08-12T12:51:13Z"
+    mac: ENC[AES256_GCM,data:4uxGR+7xPxZ2JP/f+YvgYzixYayNiNv04zddYeBcyTNYeX7J30GwAbwtdXRndvDi7LH4iEbIyy8peRBB0Bo6IszpR7CAs71smwqZsXhdSbsEecR7sUlHUiNhO7q+99r+Dm8oX1TxuXSLosZbA/TpkXx6anbb9beeIttZ2Nj9PfQ=,iv:8/Jdhp7+gxsudefZfvHB06EzbFS3qbQrJje7oVTUU/8=,tag:YQ1a8p4Sa6Nh7McJybLzcQ==,type:str]
     pgp:
         - created_at: "2021-03-17T13:13:29Z"
           enc: |

--- a/cluster-scope/overlays/prod/common/groups/lab-cicd.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/lab-cicd.enc.yaml
@@ -7,7 +7,7 @@ metadata:
 users:
     - ENC[AES256_GCM,data:vqjNxI1E4slV,iv:SCGbeVI4+OKgbbD2CzELBTbEPIE8BNw60hTIgM0ye0w=,tag:wuTgLLkW2U4dYoSJFICOtQ==,type:str]
     - ENC[AES256_GCM,data:V6CdnOW9YsMh181WVbZhwgplJg==,iv:0mcKkT+HDjiL9oyPqrGDT3MH1dgebAqHsbiOmBbookU=,tag:a6KLw00IEan0RlNJKogNnw==,type:str]
-    - ENC[AES256_GCM,data:jL+j/qck6Mz5hNWG2xozPK1QYhpOO9w=,iv:wnJAIKqZVB67R9S8QyUyxSw2KIdxDjLU+WozM+9pC4k=,tag:gqN4kbOtYkMuRicB+tn7ww==,type:comment]
+    - ENC[AES256_GCM,data:ralKdsLd8NPuAydYk7gX23ICSE2UQao=,iv:eS9/f7M9W5g1NrM4CT/7a3wQrWOkP6GUmYoCZPEVpTk=,tag:AuQJBfyVv9qCgoq3KRxgFw==,type:comment]
     - ENC[AES256_GCM,data:bspEbbgbqPcEVa9It16JMgCNtK4=,iv:OA8bLeXQS0p/qhaW+nSuzCgLzRWPMh2/TDUwujNO71w=,tag:NL3Az5RF9RYwZIIrh91ccQ==,type:str]
 sops:
     kms: []
@@ -15,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-07-14T20:25:32Z"
-    mac: ENC[AES256_GCM,data:0ZMBHPcineF80NKlBP/4c5XyEkT8HcdPLFyJfP2qMMH70/FKKEbVrgabckeDUPHycAo7HTi0H02TPVKMPFT/zrAl5xZ4je1RuVFw6a/Hv5Rw2EDXSXLndTPgbcRmvnyCLnWtQ95BN+tX2l8MwVfOxH3NyAbqkWxgoNDxcYbeuJE=,iv:o7IQR3Npvd6EJF/mAgOqLzGkv0euVjT73vLDxdejIzY=,tag:BsxMJmb+upXnrcOo3fzY5Q==,type:str]
+    lastmodified: "2021-08-12T12:51:45Z"
+    mac: ENC[AES256_GCM,data:76Fqiemtu3kxiACWuqjv/hdX5x0mkBXi9w/Tw32bi4DgdHRixcAFMXTV87KI0njtT5iCbPsKSXCFSd2DadP4yBA89xdOUm231ZBfqkNWY6q2n+rzA9crkYPQGT7m32TDK1DAo0COs05z+8GSLNlSkADy2v/Z+O7KApZCvmOi6Ew=,iv:hYeqKQnYu3UI/RT5qB6js7XdH5Fvt27WrWPfWlN+Whg=,tag:PDG4OmtNVgJuxAekEQ0kKg==,type:str]
     pgp:
         - created_at: "2021-04-15T15:51:09Z"
           enc: |-

--- a/cluster-scope/overlays/prod/common/groups/lab-cicd.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/lab-cicd.enc.yaml
@@ -5,18 +5,21 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:V6CdnOW9YsMh181WVbZhwgplJg==,iv:0mcKkT+HDjiL9oyPqrGDT3MH1dgebAqHsbiOmBbookU=,tag:a6KLw00IEan0RlNJKogNnw==,type:str]
-- ENC[AES256_GCM,data:bspEbbgbqPcEVa9It16JMgCNtK4=,iv:OA8bLeXQS0p/qhaW+nSuzCgLzRWPMh2/TDUwujNO71w=,tag:NL3Az5RF9RYwZIIrh91ccQ==,type:str]
+    - ENC[AES256_GCM,data:vqjNxI1E4slV,iv:SCGbeVI4+OKgbbD2CzELBTbEPIE8BNw60hTIgM0ye0w=,tag:wuTgLLkW2U4dYoSJFICOtQ==,type:str]
+    - ENC[AES256_GCM,data:V6CdnOW9YsMh181WVbZhwgplJg==,iv:0mcKkT+HDjiL9oyPqrGDT3MH1dgebAqHsbiOmBbookU=,tag:a6KLw00IEan0RlNJKogNnw==,type:str]
+    - ENC[AES256_GCM,data:jL+j/qck6Mz5hNWG2xozPK1QYhpOO9w=,iv:wnJAIKqZVB67R9S8QyUyxSw2KIdxDjLU+WozM+9pC4k=,tag:gqN4kbOtYkMuRicB+tn7ww==,type:comment]
+    - ENC[AES256_GCM,data:bspEbbgbqPcEVa9It16JMgCNtK4=,iv:OA8bLeXQS0p/qhaW+nSuzCgLzRWPMh2/TDUwujNO71w=,tag:NL3Az5RF9RYwZIIrh91ccQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-04-15T15:51:10Z'
-    mac: ENC[AES256_GCM,data:EX7q9FBMO9yEcfbN4F3QwpFrOb4ucW1IAmioMQi2lEJU+JlmIRbe8EzUlr0U+IInrU5HRPr5xl0XkDvX0o8xE3ZSMt9fK57y0AtB0YmHAaOb9G7vgsvHOzDCqVhI1nJDLGrsf8bZAyGgyK0dNRxVQSENxFLEQkfPu8vUoJ2pM20=,iv:aJ88m6dPfD57/Rd87LytHJrRnHnJ4HnRooHXm6jcAWE=,tag:lRlxH5IzZ4hI/7cV+cPNyQ==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:25:32Z"
+    mac: ENC[AES256_GCM,data:0ZMBHPcineF80NKlBP/4c5XyEkT8HcdPLFyJfP2qMMH70/FKKEbVrgabckeDUPHycAo7HTi0H02TPVKMPFT/zrAl5xZ4je1RuVFw6a/Hv5Rw2EDXSXLndTPgbcRmvnyCLnWtQ95BN+tX2l8MwVfOxH3NyAbqkWxgoNDxcYbeuJE=,iv:o7IQR3Npvd6EJF/mAgOqLzGkv0euVjT73vLDxdejIzY=,tag:BsxMJmb+upXnrcOo3fzY5Q==,type:str]
     pgp:
-    -   created_at: '2021-04-15T15:51:09Z'
-        enc: |-
+        - created_at: "2021-04-15T15:51:09Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAee86qTv5MBzQpObVrVGmPQ6QCMncVAsFre3wOHfikh1A
@@ -35,9 +38,9 @@ sops:
             31YA
             =PLwY
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-04-15T15:51:09Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-04-15T15:51:09Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwApXoLX6q0ivrecxdqyri3FUJtYoroWLY0+R8OvmUw+u+B
@@ -53,9 +56,9 @@ sops:
             E3FSl6R5M6evIeKByk9u4XbaAA==
             =3LUi
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-04-15T15:51:09Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-04-15T15:51:09Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAeSlJkWigP6Zt9ShVmCmMofswZm0dAxtzzNUH2eNDOZKi
@@ -74,9 +77,9 @@ sops:
             I4QA
             =VqyP
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-04-15T15:51:09Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-04-15T15:51:09Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgATdaqh3m6gB32DpJVFcLhZDNgyJEIUHK46AZkeTKz5rur
@@ -89,6 +92,6 @@ sops:
             XTvU3tqdieC55HVx/iQlD0ZLZRi75xF9wdjiunO2w+EjeQA=
             =ckNJ
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/mesh-for-data.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/mesh-for-data.enc.yaml
@@ -5,18 +5,20 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:0eE6QTLrbPFQhmNJrPlGabOxzTuUF48=,iv:vUdUvLTzil6CEmhaWrW0mEI1DhXpN63c7W0fT5sxHkE=,tag:VSonSLSR4XnlaWY2pGucmQ==,type:str]
-- ENC[AES256_GCM,data:20jMPbf5Y13ppr0GZ+bXxKJYmA==,iv:lIao7PxvYn0XK7RCz7dzULR2JzhYFtgQSEfl6JGGqKY=,tag:KJax1erpDJ/6FEB2nSUpHw==,type:str]
+    - ENC[AES256_GCM,data:LZbvUN+1DZ0=,iv:QloXkHsLf+e2tevVAjMmnnuwwXYu2CT4whChMUsiId0=,tag:BqlOyQHUDIgN+M1wOlrgHQ==,type:str]
+    - ENC[AES256_GCM,data:0eE6QTLrbPFQhmNJrPlGabOxzTuUF48=,iv:vUdUvLTzil6CEmhaWrW0mEI1DhXpN63c7W0fT5sxHkE=,tag:VSonSLSR4XnlaWY2pGucmQ==,type:str]
+    - ENC[AES256_GCM,data:20jMPbf5Y13ppr0GZ+bXxKJYmA==,iv:lIao7PxvYn0XK7RCz7dzULR2JzhYFtgQSEfl6JGGqKY=,tag:KJax1erpDJ/6FEB2nSUpHw==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-03-11T14:06:35Z'
-    mac: ENC[AES256_GCM,data:Jt9/t+EzRZkRfS1uXErWB7wu7un7vKBrGns0HX06qsYWjWf1MlbFd1zjxHWX8bBTApFnTay9FQTXT6MhhH3SaiZ+zwCT2i+rfz1/PoHwOeIomLIJ70qgFYPb9ZBZiV2mnweerX/mBx24kjjG+0lCJ6gsrq543fS/qcnqrZdCV2E=,iv:V3kpLlyVSGq+R1YCsMiBVQYYtF0TIHWoLTs580QJQvE=,tag:rO9J9IsWmC8iNxz8PgE1kQ==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:25:53Z"
+    mac: ENC[AES256_GCM,data:KKOyR2f1E8/rg9/wr8sE0ZMjb8FBFn9W5LHacnW5+vgmF/W7UeBJaCiUBX9pazkKMX4fh6cMhBPaSOp5HFj/Uqa/q6ZoZSlzvMn5Gdm9T5lamO1SaonPaxeIyOEjzRmvLxEJ42F5siEtzkY0h0fWFcfb58GrOGqQgm+xmiGzw0g=,iv:dtC1dLfB/RWqJ+sIqiUKKGoF5+DuB9uYDrRg2lD4lv4=,tag:O8K8qed87zkT3/t9eOOr8A==,type:str]
     pgp:
-    -   created_at: '2021-01-12T17:23:36Z'
-        enc: |-
+        - created_at: "2021-01-12T17:23:36Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAGldIZwYxh8OHoRKECtprAMMYbNyiYriXlc6I0QQ5DPhV
@@ -35,9 +37,9 @@ sops:
             XSEA
             =S9vD
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-03-11T14:06:32Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-03-11T14:06:32Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAuazbvMUk1GB8hJWqWa0iEkcqfBLQbaXy5W4GFODTHCA4
@@ -53,9 +55,9 @@ sops:
             38V9FdiBwiSnnOLn9AXv4bJcAA==
             =mVv6
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-03-11T14:06:32Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-03-11T14:06:32Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAE9BNTomKYGREolYg/9Txp5ucsJjm6xksyJpPbSnS/N3H
@@ -74,9 +76,9 @@ sops:
             0osA
             =x+w2
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-03-11T14:06:32Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-03-11T14:06:32Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAN23jMWSQ+vRlgWsqLqiHsPZCUSDGXmNLhPS2EZDBJUqZ
@@ -89,6 +91,6 @@ sops:
             hJV8UHcPeeAv5AsBkdZ0ejX//04ShICwtmbiGnuhS+GlQwA=
             =DgVR
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/mwperf.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/mwperf.enc.yaml
@@ -5,23 +5,31 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:hyGnECAFybqmiqoqcl4GcGU=,iv:2KpD2uPscnZx0Wz6XkUDp+ZBzP7NFBz0rMnYHqK4oSk=,tag:12WztZ1SV1GNf0xlIZUKLw==,type:str]
-- ENC[AES256_GCM,data:AfMaWT8vu/0TR7AsibyEzCM=,iv:y2yb4+7kXTgnlFOqm2JZRkMkVLb9yM+1PzMHPBdn8DE=,tag:IuCQOL5kceAi5Dnu+Nzieg==,type:str]
-- ENC[AES256_GCM,data:oPTojJb1/p2YYgd2hERAPvfJmw==,iv:LdYOJG9cVCCQrqM+wVlTZa5K0rAho+TUm2ndI4wgQe4=,tag:EwBlOR4ivcoY/jlbOH6+cw==,type:str]
-- ENC[AES256_GCM,data:UworjSx+zbx1PTL2NmRn6BD0JA==,iv:EbwjOIZuDVhLtDq6BC6FSzUSo3SZZYyVukByph+/MMw=,tag:Jh2drXk/Gopl7G09jGniHQ==,type:str]
-- ENC[AES256_GCM,data:au6FnpaEipqfMR+T28uZl+uleg==,iv:R6K0jOfUqg+D+Tbw1z9gFgAQpRd3fpfpGHI4NY69Im8=,tag:MDaA0qt0+w8b3wgYKMTKEQ==,type:str]
-- ENC[AES256_GCM,data:HH7CZBXhDHC9PALso/HWolVQ2g==,iv:NpSXvMomrkSF+0bSY1nzergsIq862tSU9AM8UxBWuZs=,tag:JZDNgeTddcvlVuQ9uKfJRA==,type:str]
-- ENC[AES256_GCM,data:Ml5vQ+Wvs9luXNpTMn+7HMXhjQ==,iv:53/PV506ghjly/sY6qlZhjze5Arr8ub5uFUra7UepVQ=,tag:Qv7uOvLrv47GaszcfDBvMg==,type:str]
+    - ENC[AES256_GCM,data:OuEl8Rvg,iv:IQUC5vPP7GRyj6LXF93xCSdqKF97tWmTmHSyKwb/7+4=,tag:F7wLkAa2b1WL9KTxJfKe+g==,type:str]
+    - ENC[AES256_GCM,data:hyGnECAFybqmiqoqcl4GcGU=,iv:2KpD2uPscnZx0Wz6XkUDp+ZBzP7NFBz0rMnYHqK4oSk=,tag:12WztZ1SV1GNf0xlIZUKLw==,type:str]
+    - ENC[AES256_GCM,data:77nGSo2uT5JPXQ==,iv:TkVnKW4NL16FjDPoSo6SCNljbJj5WWsJZ8RDBKLBoQI=,tag:mygy5syhbWz2LI/gYDSqXg==,type:str]
+    - ENC[AES256_GCM,data:AfMaWT8vu/0TR7AsibyEzCM=,iv:y2yb4+7kXTgnlFOqm2JZRkMkVLb9yM+1PzMHPBdn8DE=,tag:IuCQOL5kceAi5Dnu+Nzieg==,type:str]
+    - ENC[AES256_GCM,data:VOAlvObO,iv:X/nO6fICEeNEQn4CxkRqsePaHYyucOhw/qQn2X5/aBc=,tag:8kYOLtv5jjT6dCZ8RgCUBw==,type:str]
+    - ENC[AES256_GCM,data:oPTojJb1/p2YYgd2hERAPvfJmw==,iv:LdYOJG9cVCCQrqM+wVlTZa5K0rAho+TUm2ndI4wgQe4=,tag:EwBlOR4ivcoY/jlbOH6+cw==,type:str]
+    - ENC[AES256_GCM,data:djY+kRsM,iv:bLa7dvOFGFrNVfj0dvBnSycnmebQhaDteW2Y1c2wdRw=,tag:To5fCASFrvd+AIHsTfmeZw==,type:str]
+    - ENC[AES256_GCM,data:UworjSx+zbx1PTL2NmRn6BD0JA==,iv:EbwjOIZuDVhLtDq6BC6FSzUSo3SZZYyVukByph+/MMw=,tag:Jh2drXk/Gopl7G09jGniHQ==,type:str]
+    - ENC[AES256_GCM,data:0OS93OnXbmoZIkYufl0=,iv:PbNGnd6DkXKuL/lwq1VutjhkL57yiu7UV50tNUkW/AY=,tag:Prysax5d+vyXav7FbUcrZw==,type:str]
+    - ENC[AES256_GCM,data:au6FnpaEipqfMR+T28uZl+uleg==,iv:R6K0jOfUqg+D+Tbw1z9gFgAQpRd3fpfpGHI4NY69Im8=,tag:MDaA0qt0+w8b3wgYKMTKEQ==,type:str]
+    - ENC[AES256_GCM,data:5/XCtpVJ5Ayh,iv:6B8S5FM6Mq7G0dgLW8M6iW9gwFOySORsApnG8lRqMYc=,tag:/SSC2mgpFUPFoKNm4x48Wg==,type:str]
+    - ENC[AES256_GCM,data:HH7CZBXhDHC9PALso/HWolVQ2g==,iv:NpSXvMomrkSF+0bSY1nzergsIq862tSU9AM8UxBWuZs=,tag:JZDNgeTddcvlVuQ9uKfJRA==,type:str]
+    - ENC[AES256_GCM,data:ulGz6AE1bp4=,iv:Tm/eef5NJ5vXUJW3b57yu27ygOB0L0oCGOmUNde/EoI=,tag:tO1ZNhCFGT48GZX/cix99Q==,type:str]
+    - ENC[AES256_GCM,data:Ml5vQ+Wvs9luXNpTMn+7HMXhjQ==,iv:53/PV506ghjly/sY6qlZhjze5Arr8ub5uFUra7UepVQ=,tag:Qv7uOvLrv47GaszcfDBvMg==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-06-09T16:49:49Z'
-    mac: ENC[AES256_GCM,data:FFh8y1jTkv/TyCwT320oxJnPFU1CB1YrwOGxTa8xK8slsNZYN0k1zF9wHJ/rsXTs908gfVUZwhSEHSzOHHWUCtL6qUv7dPJDVnwSY4WCFdQq5IKmQm6jjNXpbyURWUHZsv0R31KObK5S39bSrmAvQ8/OyE9FFjaOFPzZyfKcEtE=,iv:SF1CIhVJ317Cw6Ai4oAWwDeXvEZjVqd8rVCLNh1bfks=,tag:bXMMJYWVi7kAdPT/tkYbdg==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:26:21Z"
+    mac: ENC[AES256_GCM,data:i9g7UabjcUVPkxlTiTlhro7KM82qrzZxmkKxR1Uv5z29LkIkcd79B+cZa6ugYGq2Hy8h8c633ZkLE3LIgYKtsTDOcM+QkUGZld7uDBjB4IWCusAJ4QdQkFieHBZ91laH+C/vkBG6Ufx+y2TTBowhcJ3i3WFHYVQ+lW6bQkhw5cA=,iv:XuDTymLneNvRVw68CisehfMIbzoRJgt70YdMXFvkr48=,tag:mSGUJ44zZOfQ2BMXRZ22vg==,type:str]
     pgp:
-    -   created_at: '2021-06-09T16:49:47Z'
-        enc: |-
+        - created_at: "2021-06-09T16:49:47Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAjwF7KxuoMVCk6h6wCxJ5mGcahGxzL0OLs5bD85dcAPr4
@@ -40,9 +48,9 @@ sops:
             XroA
             =k4/D
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-06-09T16:49:47Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-06-09T16:49:47Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwARHrw9gVmNOyS5kqCahCuusst/0U549D9BdO+x6XTRUy0
@@ -58,9 +66,9 @@ sops:
             fC6IT8V+csqepeJZyCjq4d/sAA==
             =K9IX
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-06-09T16:49:47Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-06-09T16:49:47Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAjngoB2lfX4wZ136U4vQwary4fc4qV+qr4ZXesk7oK85g
@@ -79,9 +87,9 @@ sops:
             vvIA
             =MPRz
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-06-09T16:49:47Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-06-09T16:49:47Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAqzhNcQBBBtZ1S5y7CWJIxeegUM57NeeAlYK7QjDeBTW6
@@ -94,6 +102,6 @@ sops:
             LTiOBlZ4c+A75PCmGU7q4Gjh5RJzxHhz8NniiyEgeeGkfAA=
             =cb8H
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/odh-admin.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/odh-admin.enc.yaml
@@ -5,28 +5,41 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:TvXjWeUaUNnfoFoIL3SY6mxzCg==,iv:Qs0vnvk76FkBy54MtxEoa7aw8q3Pk8FOPn4JOi5G8jo=,tag:tgjDe1SurJ23c88zcuJHIg==,type:str]
-- ENC[AES256_GCM,data:SvyuU2yg6AQTIQ72hz2pn2hO,iv:VxQS1Ci2ku1cv2hs4eO1e8jUooMXs0DcB0nqYyYuPJA=,tag:bKP2vq3Y+0zAaYilWvqKvg==,type:str]
-- ENC[AES256_GCM,data:WB9WMM5nHAtbzN3uS2Q/Rg==,iv:59Sa6v7i+OzOT7jrBnd9LyV5WeKpA+9etDWzLvXzwKA=,tag:Q6REcAyLkBTEMqWEFx/A+g==,type:str]
-- ENC[AES256_GCM,data:eRq5Py48DcB2gKp2UW7v33xd,iv:apfHuUWDcJFIkf6lAMsQSYdxtN4bZ2/glBWIvcuIgPI=,tag:XngY7wqehZoE+AA0sRo4lA==,type:str]
-- ENC[AES256_GCM,data:RuqZt5Z+UfXTLHIkJYqgFtwyNg==,iv:SDNvmpGnToBTl+AHePlDP90qSAKV5Ad+CBsBdQK2rqw=,tag:0UpY3mb8F1juFfLZpxU9Ww==,type:str]
-- ENC[AES256_GCM,data:YXHIa4Ozr2gwVTBQPBLUeGsUTQ==,iv:aj0WFcYefpZfiPFtf04TZdoswBIkdXUFv5oDiJQAnFw=,tag:Qc7mD69hxyItedsz4+bAsw==,type:str]
-- ENC[AES256_GCM,data:s0uY4awbNhfdlg5pUzNRBpFI4w==,iv:EnLyTFTU3IfjNm2eIWUXkcz+SfuUbVygJ93n5Fu7fQw=,tag:dhZLxql0YTxBF/Zh6o0Z7Q==,type:str]
-- ENC[AES256_GCM,data:hbwIe/ptLWk4jozC1jPNWRg/aw==,iv:wQHsvu031ABKJKNed4iRg7zYWQOwvHw/wvKJ0qqexCE=,tag:UrIIMwzzWVZkVNyfmeCzNg==,type:str]
-- ENC[AES256_GCM,data:qzm5vqTEDjH4FoodZDvHgKY=,iv:r2ExTRKbF+rlPADA3Y9T88e7Ox1JxN4A3PPcffcHspg=,tag:cHE0ElhtTicSUa5mLp+luA==,type:str]
-- ENC[AES256_GCM,data:ikmiViZTbcE4umVu34609ORSjg==,iv:eqLvxL3AsbcdI5ZUBK9BkuttRyHWWd/7a5WCFBVhkIM=,tag:2FInScGYCk/PuocC09eccg==,type:str]
-- ENC[AES256_GCM,data:4KyMhp7q4H/z42nFph68EISr,iv:NxelpTbTuFwlIoQr2Vxy0QQ4ChIzPOWDdOBGYa0KJAg=,tag:Hpm9xylT2NHAZi/KTInHAw==,type:str]
-- ENC[AES256_GCM,data:B7GJylNNucH37uXXxC/CkZcNYA==,iv:KzzgJUwVv6YW4T69CcefRf52DRpyrNK/C6nuWq253nA=,tag:OntsaB3DljghQIYPPLYSTw==,type:str]
+    - ENC[AES256_GCM,data:nrv3q0qUsEZOwCbD,iv:M56rpBmEVCGlwRo/Cdlw00Ql+one71QDslZI4bZacZ4=,tag:9bJe1d8SYxMx2EWUqzNUvA==,type:str]
+    - ENC[AES256_GCM,data:TvXjWeUaUNnfoFoIL3SY6mxzCg==,iv:Qs0vnvk76FkBy54MtxEoa7aw8q3Pk8FOPn4JOi5G8jo=,tag:tgjDe1SurJ23c88zcuJHIg==,type:str]
+    - ENC[AES256_GCM,data:nct9cOytX6s=,iv:sLkCnPuieMuqfRcm49mwFGGZ7mZKhVQZ6a6fsgnowSY=,tag:fkHn2G3pmavtl/v6Xp000w==,type:str]
+    - ENC[AES256_GCM,data:SvyuU2yg6AQTIQ72hz2pn2hO,iv:VxQS1Ci2ku1cv2hs4eO1e8jUooMXs0DcB0nqYyYuPJA=,tag:bKP2vq3Y+0zAaYilWvqKvg==,type:str]
+    - ENC[AES256_GCM,data:TcsupMnLIg8=,iv:1hOlUbX0yD/4xc4oZw6PrbdcFIhkfaVwwm5GXy55y5g=,tag:gblLr/S5rf8HtPY/f2o+CA==,type:str]
+    - ENC[AES256_GCM,data:WB9WMM5nHAtbzN3uS2Q/Rg==,iv:59Sa6v7i+OzOT7jrBnd9LyV5WeKpA+9etDWzLvXzwKA=,tag:Q6REcAyLkBTEMqWEFx/A+g==,type:str]
+    - ENC[AES256_GCM,data:PIj2wU3jQw==,iv:slPY4m4ae4VONyV2CE5o0qAdg4unVkPvm7rJZU1quzI=,tag:IrPgjYscJLJaTzS6o015Ig==,type:str]
+    - ENC[AES256_GCM,data:eRq5Py48DcB2gKp2UW7v33xd,iv:apfHuUWDcJFIkf6lAMsQSYdxtN4bZ2/glBWIvcuIgPI=,tag:XngY7wqehZoE+AA0sRo4lA==,type:str]
+    - ENC[AES256_GCM,data:Z6zp7t6Y,iv:YsJbZUDQBD9gCTdmD8sYEmdLIaR5a5okIWwUUwUrxaY=,tag:Qo5D406Gs0/6jLXqJfV/oQ==,type:str]
+    - ENC[AES256_GCM,data:RuqZt5Z+UfXTLHIkJYqgFtwyNg==,iv:SDNvmpGnToBTl+AHePlDP90qSAKV5Ad+CBsBdQK2rqw=,tag:0UpY3mb8F1juFfLZpxU9Ww==,type:str]
+    - ENC[AES256_GCM,data:ZP6TOznJ,iv:leiHpDN7pYYZATPshvi0DgLDQlHXE61clWr0qD5z1r8=,tag:CXGpOZylS/146sddw1HnFQ==,type:str]
+    - ENC[AES256_GCM,data:YXHIa4Ozr2gwVTBQPBLUeGsUTQ==,iv:aj0WFcYefpZfiPFtf04TZdoswBIkdXUFv5oDiJQAnFw=,tag:Qc7mD69hxyItedsz4+bAsw==,type:str]
+    - ENC[AES256_GCM,data:4Bb9iphEgQ==,iv:wZr6MUDvEGL5QOwISCaBHaNUVwCMWh5WSeYGvGcyfZc=,tag:ESxNVHHQ3tj/5Iqiw1P7sw==,type:str]
+    - ENC[AES256_GCM,data:s0uY4awbNhfdlg5pUzNRBpFI4w==,iv:EnLyTFTU3IfjNm2eIWUXkcz+SfuUbVygJ93n5Fu7fQw=,tag:dhZLxql0YTxBF/Zh6o0Z7Q==,type:str]
+    - ENC[AES256_GCM,data:yR6F53wxPBg=,iv:0X3HZNfy/o6ir2zlXUeamiyNw4bM+bgozjcG/CrKdaw=,tag:AiQ+SKRYjKxtrFNaLVzGXg==,type:str]
+    - ENC[AES256_GCM,data:hbwIe/ptLWk4jozC1jPNWRg/aw==,iv:wQHsvu031ABKJKNed4iRg7zYWQOwvHw/wvKJ0qqexCE=,tag:UrIIMwzzWVZkVNyfmeCzNg==,type:str]
+    - ENC[AES256_GCM,data:Fw9eVWbjbyU=,iv:JJUezvApVTpyz7D4Bo5+1hxBqrGXh6KhSXUliUEACD0=,tag:LXPfEY85kKunakp1tseSRw==,type:str]
+    - ENC[AES256_GCM,data:YJmNdfIr+dLCYtLDRrfw+zA=,iv:HJ1UiDjgMZZO0JEU8iDrlAoxhxIgWLRGc6kGY0pOIls=,tag:KqFmumXlh5tXKbQWAO6mxg==,type:str]
+    - ENC[AES256_GCM,data:PRbhLRI=,iv:j42vtRLmUHlKZR2/uASvE8ixvQ2iDe99wgSUnqlwmlY=,tag:Rm3wr47SNXZsrqJ/4GTDXQ==,type:str]
+    - ENC[AES256_GCM,data:u9z+kVFfJlWeR9K1IXLDfJm4BQ==,iv:y53EeMSCs5nDkp6P6O/UWM8YtqErLnCWDE515JTsius=,tag:IMsFsYjjyTKYzVDTlupFSA==,type:str]
+    - ENC[AES256_GCM,data:MUIOSi3F,iv:FHKYKeOk95LG3C6NLJUuBkm+9LCy+7d+HIHdH+sEN3E=,tag:w8cI/B5jaeZXtFl2n80gyQ==,type:str]
+    - ENC[AES256_GCM,data:MZ0vXM9xehPfTBy95N+6kfZ6,iv:n0WTjrESKLOQLwS50WCObBNVkHb38CC750Pg1QzQa+c=,tag:0bMTJfM4j4PEw1rP5aip1Q==,type:str]
+    - ENC[AES256_GCM,data:y4sMn8bW,iv:krhDoidx1xErhjkwas5RZxRt66QmEIwLqVYdd/JDA+Y=,tag:wI81kNUO5ihtUnrBulWzAg==,type:str]
+    - ENC[AES256_GCM,data:exh5FntAJBWvQqBHVzLeTCQWJw==,iv:f13MZzhvdVy44hnzZDc0OhxN/z6uTBujD1VDTiAV3x8=,tag:dL2n71IPYwbak61IHug9ug==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-08-16T17:35:33Z'
-    mac: ENC[AES256_GCM,data:+kFsDz1/GH6K8Tcbb99P8mtiealdTlna7tjtC5e/OHcOWHsdJxTe3bA3eBj1OLm1oMfMf2g9yUJ6hQOA4FX4BRO9TffJjAtQtbb0PyE5gr+MN+51Hpm2MfiQHjXj9BqYrld1mOdWt/rW7Pgq5Ygzj3XdIs/Gj4MDsiuhs3phnvM=,iv:JgAk/fE2kMw4v86ay6N7D6vqDob4dEIuCpKzowzuvSc=,tag:G3FdPlpj1c4dOgtbpOa6wA==,type:str]
+    age: []
+    lastmodified: "2021-08-17T16:16:36Z"
+    mac: ENC[AES256_GCM,data:/WArkcXFihq1qsdkYx5DXSqH4+MEpZNZ97O1Ma1tvXi41F2uxmHHLi/Xq378zvy4B4w5DBYJoOy4Mq5An8B7+3oImrFGcF5/F1fjvpwMQYv8xQ+/ZF25tP53O/4nJCXX37rWja2fuiygLt7TZ3z8cJmIAuiFQb2p+zWj9JGaVcM=,iv:vgTd4VmlqDOTeY04j55fqwe12ZhCbZRrY4eggo9SUxg=,tag:c7p22V7T3bwhyZHQJ7Zavw==,type:str]
     pgp:
-    -   created_at: '2021-05-17T19:07:37Z'
-        enc: |-
+        - created_at: "2021-05-17T19:07:37Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAgaNnf4tOgOdqZgoGl9GQRoenmA0MlZJqhgI+FbFKBPhF
@@ -45,9 +58,9 @@ sops:
             cooA
             =j6/n
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-05-17T19:07:37Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-05-17T19:07:37Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAgLc+aChS472Q4NjLuFwaeDV/K/nt9h3/R2cXmI/KoOGf
@@ -63,9 +76,9 @@ sops:
             lpgDShm7qe6/TeI7EVud4ayhAA==
             =oSYY
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-05-17T19:07:37Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-05-17T19:07:37Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAOON1R8BSivtzZrlZ3DGsrT2G3EAAXEIQ6QuWk6ChcK1e
@@ -84,9 +97,9 @@ sops:
             0wEA
             =Cg2u
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-05-17T19:07:37Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-05-17T19:07:37Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAvFFVSyzA+LSmFmQ8uCdYPVAc1rV20z/RDl0o9cPkRpeo
@@ -99,9 +112,9 @@ sops:
             a2o5WxUt8ODr5Ll0lyH4ABoZrIVGrTcJ8T7iOBQk5OEHeQA=
             =Loon
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
-    -   created_at: '2021-05-17T19:07:37Z'
-        enc: |
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+        - created_at: "2021-05-17T19:07:37Z"
+          enc: |
             -----BEGIN PGP MESSAGE-----
 
             hQEMA3vkazmcQuPLAQf+JSYoMlGAVYTzAbzJVLUbVmwV3eu2ZUu6oQ9VyPyRrGtx
@@ -114,6 +127,6 @@ sops:
             CQdKaQYcT+fFhmxRnrPxb6SVnedy0tpED2hZqmmB7Q==
             =0n3q
             -----END PGP MESSAGE-----
-        fp: 41E217886B24605316217B8F5AD1C1B1F3A28B6B
+          fp: 41E217886B24605316217B8F5AD1C1B1F3A28B6B
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/odh-admin.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/odh-admin.enc.yaml
@@ -5,128 +5,113 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-    - ENC[AES256_GCM,data:nrv3q0qUsEZOwCbD,iv:M56rpBmEVCGlwRo/Cdlw00Ql+one71QDslZI4bZacZ4=,tag:9bJe1d8SYxMx2EWUqzNUvA==,type:str]
-    - ENC[AES256_GCM,data:TvXjWeUaUNnfoFoIL3SY6mxzCg==,iv:Qs0vnvk76FkBy54MtxEoa7aw8q3Pk8FOPn4JOi5G8jo=,tag:tgjDe1SurJ23c88zcuJHIg==,type:str]
-    - ENC[AES256_GCM,data:nct9cOytX6s=,iv:sLkCnPuieMuqfRcm49mwFGGZ7mZKhVQZ6a6fsgnowSY=,tag:fkHn2G3pmavtl/v6Xp000w==,type:str]
-    - ENC[AES256_GCM,data:SvyuU2yg6AQTIQ72hz2pn2hO,iv:VxQS1Ci2ku1cv2hs4eO1e8jUooMXs0DcB0nqYyYuPJA=,tag:bKP2vq3Y+0zAaYilWvqKvg==,type:str]
-    - ENC[AES256_GCM,data:TcsupMnLIg8=,iv:1hOlUbX0yD/4xc4oZw6PrbdcFIhkfaVwwm5GXy55y5g=,tag:gblLr/S5rf8HtPY/f2o+CA==,type:str]
-    - ENC[AES256_GCM,data:WB9WMM5nHAtbzN3uS2Q/Rg==,iv:59Sa6v7i+OzOT7jrBnd9LyV5WeKpA+9etDWzLvXzwKA=,tag:Q6REcAyLkBTEMqWEFx/A+g==,type:str]
-    - ENC[AES256_GCM,data:PIj2wU3jQw==,iv:slPY4m4ae4VONyV2CE5o0qAdg4unVkPvm7rJZU1quzI=,tag:IrPgjYscJLJaTzS6o015Ig==,type:str]
-    - ENC[AES256_GCM,data:eRq5Py48DcB2gKp2UW7v33xd,iv:apfHuUWDcJFIkf6lAMsQSYdxtN4bZ2/glBWIvcuIgPI=,tag:XngY7wqehZoE+AA0sRo4lA==,type:str]
-    - ENC[AES256_GCM,data:Z6zp7t6Y,iv:YsJbZUDQBD9gCTdmD8sYEmdLIaR5a5okIWwUUwUrxaY=,tag:Qo5D406Gs0/6jLXqJfV/oQ==,type:str]
-    - ENC[AES256_GCM,data:RuqZt5Z+UfXTLHIkJYqgFtwyNg==,iv:SDNvmpGnToBTl+AHePlDP90qSAKV5Ad+CBsBdQK2rqw=,tag:0UpY3mb8F1juFfLZpxU9Ww==,type:str]
-    - ENC[AES256_GCM,data:ZP6TOznJ,iv:leiHpDN7pYYZATPshvi0DgLDQlHXE61clWr0qD5z1r8=,tag:CXGpOZylS/146sddw1HnFQ==,type:str]
-    - ENC[AES256_GCM,data:YXHIa4Ozr2gwVTBQPBLUeGsUTQ==,iv:aj0WFcYefpZfiPFtf04TZdoswBIkdXUFv5oDiJQAnFw=,tag:Qc7mD69hxyItedsz4+bAsw==,type:str]
-    - ENC[AES256_GCM,data:4Bb9iphEgQ==,iv:wZr6MUDvEGL5QOwISCaBHaNUVwCMWh5WSeYGvGcyfZc=,tag:ESxNVHHQ3tj/5Iqiw1P7sw==,type:str]
-    - ENC[AES256_GCM,data:s0uY4awbNhfdlg5pUzNRBpFI4w==,iv:EnLyTFTU3IfjNm2eIWUXkcz+SfuUbVygJ93n5Fu7fQw=,tag:dhZLxql0YTxBF/Zh6o0Z7Q==,type:str]
-    - ENC[AES256_GCM,data:yR6F53wxPBg=,iv:0X3HZNfy/o6ir2zlXUeamiyNw4bM+bgozjcG/CrKdaw=,tag:AiQ+SKRYjKxtrFNaLVzGXg==,type:str]
-    - ENC[AES256_GCM,data:hbwIe/ptLWk4jozC1jPNWRg/aw==,iv:wQHsvu031ABKJKNed4iRg7zYWQOwvHw/wvKJ0qqexCE=,tag:UrIIMwzzWVZkVNyfmeCzNg==,type:str]
-    - ENC[AES256_GCM,data:Fw9eVWbjbyU=,iv:JJUezvApVTpyz7D4Bo5+1hxBqrGXh6KhSXUliUEACD0=,tag:LXPfEY85kKunakp1tseSRw==,type:str]
-    - ENC[AES256_GCM,data:YJmNdfIr+dLCYtLDRrfw+zA=,iv:HJ1UiDjgMZZO0JEU8iDrlAoxhxIgWLRGc6kGY0pOIls=,tag:KqFmumXlh5tXKbQWAO6mxg==,type:str]
-    - ENC[AES256_GCM,data:PRbhLRI=,iv:j42vtRLmUHlKZR2/uASvE8ixvQ2iDe99wgSUnqlwmlY=,tag:Rm3wr47SNXZsrqJ/4GTDXQ==,type:str]
-    - ENC[AES256_GCM,data:u9z+kVFfJlWeR9K1IXLDfJm4BQ==,iv:y53EeMSCs5nDkp6P6O/UWM8YtqErLnCWDE515JTsius=,tag:IMsFsYjjyTKYzVDTlupFSA==,type:str]
-    - ENC[AES256_GCM,data:MUIOSi3F,iv:FHKYKeOk95LG3C6NLJUuBkm+9LCy+7d+HIHdH+sEN3E=,tag:w8cI/B5jaeZXtFl2n80gyQ==,type:str]
-    - ENC[AES256_GCM,data:MZ0vXM9xehPfTBy95N+6kfZ6,iv:n0WTjrESKLOQLwS50WCObBNVkHb38CC750Pg1QzQa+c=,tag:0bMTJfM4j4PEw1rP5aip1Q==,type:str]
-    - ENC[AES256_GCM,data:y4sMn8bW,iv:krhDoidx1xErhjkwas5RZxRt66QmEIwLqVYdd/JDA+Y=,tag:wI81kNUO5ihtUnrBulWzAg==,type:str]
-    - ENC[AES256_GCM,data:exh5FntAJBWvQqBHVzLeTCQWJw==,iv:f13MZzhvdVy44hnzZDc0OhxN/z6uTBujD1VDTiAV3x8=,tag:dL2n71IPYwbak61IHug9ug==,type:str]
+    - ENC[AES256_GCM,data:SX/s0+X1tKK2GAOL,iv:5I3xUnDO2xRdC5JPMS58SkTexmajH5SMoK8QxDPhCk0=,tag:84NBTJmYjJ5G6uhxiztALQ==,type:str]
+    - ENC[AES256_GCM,data:n/u1U44pcyY5YMs4et/0FJ8pKA==,iv:/0yUAdx2pa9dRdATa7a8Ah5/M7tVetOzsofarcGBAME=,tag:vT7pjRvB3n145i+1DlRXrQ==,type:str]
+    - ENC[AES256_GCM,data:DjLca1tFtEw=,iv:yNgXvY4UZRttjL6kQUlm3eCAXyFV1jFjYGaLtkgI98o=,tag:4+v9wxyeBEqI/IZUPV/ICA==,type:str]
+    - ENC[AES256_GCM,data:4tZWmgwli5p1L+DMiNmqt/Ha,iv:kzofKbjur3vjbrkhnmwJLQ23VzJaYMwYkuk9xBNUExc=,tag:pLMV3ECq9uqXULjKI+Hlbw==,type:str]
+    - ENC[AES256_GCM,data:Wm/bc+wDtGo=,iv:MBXP+EO7wBsSO/JRS0HO+M9D2AHdzo78i8RPoSeoA3Q=,tag:kIpzzXBk3YD4IlAM/bbs7A==,type:str]
+    - ENC[AES256_GCM,data:5k0jPMAlTpQOjtxj/mTI9w==,iv:4PHPKGvz/oMFyhvwycT+3AT34JXU2heqBLrZ4aUuEj0=,tag:PpjaEarY86dcGtYKh5oXlA==,type:str]
+    - ENC[AES256_GCM,data:35aZ/qlvBA==,iv:vpA2rGQgYWFfWbqea3rlJserIeTU2WOCZOguKv3ftNw=,tag:1TFToxcUcJL+YvFhg3eIiw==,type:str]
+    - ENC[AES256_GCM,data:jwQRQbRzMMq2vki6QIyNL231,iv:pCTc9dR8yIhhIiv2wDQanKQr6e4nus7VAz2z0Pyu5ns=,tag:kyLMBmZ0I30v7albNEnS3A==,type:str]
+    - ENC[AES256_GCM,data:7xZrfBBi,iv:7o4yWHbmEmoF0IkM5NjGgZYlTBli1GP5m/VyyqrJMzA=,tag:fzBJIS8qans/GSqiiu3BIA==,type:str]
+    - ENC[AES256_GCM,data:B94lDaMVdWIdYFPyhBlHIXh/Nw==,iv:WXhXScZ6wnMGrW1RNmwHvfHciXCDTmIMvM59rm/9VaQ=,tag:LbxqlL4Z20Bkfaefm6MrKQ==,type:str]
+    - ENC[AES256_GCM,data:fBSsCsP5,iv:iAsikM6xoahkNDXGV9+rpL54rIFNeotYJ/lFxuIM7Gs=,tag:SNRyteIpU0PW1E69UUZkyQ==,type:str]
+    - ENC[AES256_GCM,data:s3VIG4980vW5ZztNEEcaFJsD4w==,iv:EHPRcH8KnwF+ypAhqM1+YOzCbpocOjwZ2Bt9+ofXmMw=,tag:MqxdB3TExAmbTR0sV0WgsQ==,type:str]
+    - ENC[AES256_GCM,data:tFYzfJ8Akw==,iv:HezPpVRmwVaC6KMzOJYlTZtY00ELACdNJMx5+PNbHug=,tag:9Q6sf7H3fzgBeSF1O/boEw==,type:str]
+    - ENC[AES256_GCM,data:e8RxMJGNMwvVjo41UTjYX3JZVw==,iv:/HK3Xi8nUNCaEVxh/w9Z/KaAJMJLRmeMhkWrNlXSLcs=,tag:ycXCV9VGMxysTlZgvC5BBw==,type:str]
+    - ENC[AES256_GCM,data:FO/Rx5d/xXY=,iv:99pniT3FWCWz8Fz4GveNwfLdxz+VQTKhMI2BOZggqII=,tag:MSVA3gbzKEyjfU9WSF/O+w==,type:str]
+    - ENC[AES256_GCM,data:MJjGwHQsCmDn6zqPKtK0ySmYQw==,iv:ASM/aSg/tnHPQVEufmKkFZwgJNhwCsuHg6NqQe32KEk=,tag:+EOKQ3PZTsP5O2n9CpPdSw==,type:str]
+    - ENC[AES256_GCM,data:xxVRbg7xYvM=,iv:7iHBlnN/eBelnw1ifXQC0V5riNFzshH4x9iXu/xrwKA=,tag:29Qd01zn5NeQBSY+JKrgLA==,type:str]
+    - ENC[AES256_GCM,data:T5sjgrLSgyigxbiKb/HrkXM=,iv:JtHHb5+9dsRoQ2fVizdV0dvxHzBltjsxlT4NDjy0oac=,tag:wdnjxcg6r7CfPlUV8WoErA==,type:str]
+    - ENC[AES256_GCM,data:kYlYwZg=,iv:uiJkFD1qLx81aKpBIfBWI5PTTVqUZTHSxdkzqswnCP0=,tag:WBH99KG7QuzsjprhdRDCmw==,type:str]
+    - ENC[AES256_GCM,data:rnRu8MesInCBD9+MnbqzvF794Q==,iv:b/RDNGOpXaLi/Nfk4I3jH/F9KKmiBDmp5nrlUpJ+o6k=,tag:bSJGMUjrkP1VjZL1UGfmbg==,type:str]
+    - ENC[AES256_GCM,data:lD5Tbk0y,iv:ro+pKWfk1DRaaA6XhHNTtdoh+x1CNrJeCinqJCOj1Ts=,tag:2fRsgosJREOIMEx15nErjw==,type:str]
+    - ENC[AES256_GCM,data:ma8vG52l2l2TWihppdCzIQzS,iv:XmBvAl/rLbYDGEnd3NJjkjLjnIp0/ZjqYINURs+SMTY=,tag:fOLAYwN83huUMbPDCFWnLw==,type:str]
+    - ENC[AES256_GCM,data:CiXtYuZz,iv:xZ5ch2xzeWWVRQLboX8oaecc6Gfhm9eXWU09jugWi6U=,tag:ysX+y3+6yGmHnKZ6kefIyQ==,type:str]
+    - ENC[AES256_GCM,data:JSPieYuDyJrgj9BzBAHEPp38Sg==,iv:AcWTIyww5FbQi10fNwgiMpHTm8G9gYH9P+h2djjRl64=,tag:s7ZkJl5kktCUgyr9tKUi9Q==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-08-17T16:16:36Z"
-    mac: ENC[AES256_GCM,data:/WArkcXFihq1qsdkYx5DXSqH4+MEpZNZ97O1Ma1tvXi41F2uxmHHLi/Xq378zvy4B4w5DBYJoOy4Mq5An8B7+3oImrFGcF5/F1fjvpwMQYv8xQ+/ZF25tP53O/4nJCXX37rWja2fuiygLt7TZ3z8cJmIAuiFQb2p+zWj9JGaVcM=,iv:vgTd4VmlqDOTeY04j55fqwe12ZhCbZRrY4eggo9SUxg=,tag:c7p22V7T3bwhyZHQJ7Zavw==,type:str]
+    lastmodified: "2021-08-17T16:19:10Z"
+    mac: ENC[AES256_GCM,data:MbIyyVMPMvL7uUPRSvcbAeR4RkidXmOVWMcLv5a44gFazVxAIucWrvltzVRZE/l5ZyTlDncQSyyDbItMcRqtz8JrxrkyhAStR0N0XsPiJRLgFUZLe3Vev8ePJu7kXrbZAATmfxe5gUGXsOppXH7K1r6oRC6qA/n9RlZ2BQ8AO98=,iv:+eIOTYV+8RtJp/6DS/xKw7I4YGKQm7ie2AnQWJ+fQ3k=,tag:b2ehWByBLatvmHSgcNeCqQ==,type:str]
     pgp:
-        - created_at: "2021-05-17T19:07:37Z"
+        - created_at: "2021-01-12T17:24:03Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMA9aKBcudqifiARAAgaNnf4tOgOdqZgoGl9GQRoenmA0MlZJqhgI+FbFKBPhF
-            Xt38GjUWpjjgiMcfDQryVUYCQ7tVLAOoF//s42REXceFkO2I9v5iLRQ0aaVMchMH
-            PBVK0eZrhtcGnfwej37KGMNrDT4KYvMZ6r+pUeA/06SMnY6AiCBnEToUSaLUyNBr
-            VVDXy3EUIFnZJDAh53hjOkKWnLmM54q+aILIaxlSSLInYB0qluMb6wYRGhlb8FvC
-            gYoINcfj6DuOzaaXD3xGxPLREbJoWzscz83jQVvxRIj2Wt2oVm1qZPfX0iO11j0Z
-            qmsIplzR0FQ05N+cFaInAGTBvUsT5q0Wp0prXNC6HjUKgcRwJu2Fm8w0J51yC1Lh
-            yeF8u+2uNc2NSccVdVLI1IRJl7OAu2Ipo/5PU8W1j3C7a1bJBqZOAso3vN6rAJuj
-            CKbfXQI2DaNEqS38GvgVR447C0L8L+4PL9O3QlcAoEiUFIHxUhPU1vf4Con6QGkX
-            mpED78JWnyoyRao2HBk6vh8ocdyMta1pUOqGOPPm+72IcEwiZW6ZFAacoN4oRNZe
-            Mec0+JLHWalXb+H63suWdk9MDb6mzjANTu/Wdt9Cjg64FOv4djNm30nkBI3vB9qV
-            Vv+cWnXx18nLkZZUyGNRD7JvFMN4tXT473ySp3mqoUHAG7zF12WbzE1EYFsl9ibS
-            4AHkGi0ysq5PudcXpIAC9ywuaeH/b+A74Afh4o3g8+JzK1H94O7luaShxE8wmSVT
-            nuNktcJsPs7b19Y9RQQ+XeuTrsCcmyXgB+QQEHFDSmp975kQ67bf++yZ4hk9yZzh
-            cooA
-            =j6/n
+            wcFMA9aKBcudqifiARAAuuVOOTIM5OJBgBmOiyso7LxavqaEUGCHlQ4RSDkVONQk
+            P1oUYbHGxHjNSjj/hxVmhNlm52SNJKZpymgHo3ib8BKv3iT9AurqH2B4g3rt8Vi1
+            G+jWtNlmr6cjfCwaxAZ/4Qln9jxEFV70QnmS8LXnht+FQhDwdU59hOekjASkuT9R
+            3DHjs4Gi1QGrL1cvL+ZuRnyqM158ivwYbH2mWRaeTR6fBN4ChfpTPL9cVUl5StpI
+            IiPZbwx7jTGc+ZsoIV4bQLPkQ2+D6w4b8jFvGPxIj5Q9GCRmWljowaRuscLUehcZ
+            MRd8yN1lC0pcNuntu7IYi8hO8e6MDS93SSIPxBHppW7wX6ZGWzut4hr/4LXjfiI2
+            tpafzicq7LGrzUrodzZ2wNWfj8Cy970yNanJWQenQJcedf9DWlsQoqzwJWVc9P5Q
+            tLAoFq4v7TNtiHHHUVX8TYkwOPzhQemgvR2iyqPJ3tGlb850u4PD5eF2vqZ2Jl1I
+            QCBTcyqOSzcYup00Fw0GqpAwpYDzUJ4AJ3+69yGzfvWiz6Rrw+Rar8mmj+t+fUlF
+            2ED8hkhwqKGQVN6N+JwS95poxpE0k0Myr75+uOUrd60rkY4S+gL9FcwuGtxAIWo+
+            A1T5JE6BJYXAZuKHir/m6jb4iPWB2NdSKdhyNY9YqvVgUZF7JbIBb6T7Ee70fffS
+            4AHkW89d7xIRGoimJewngAyJpeGVeeCX4Ojh7KvggeIOuBud4G7lXvT0GnlJ9PCb
+            pwjasuOvhiDiPPAuacDp9JxwaJGw7LjgY+QyYgR4LoLyIrYFRQUKiGit4iNOq+zh
+            3NUA
+            =PWkO
             -----END PGP MESSAGE-----
           fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-        - created_at: "2021-05-17T19:07:37Z"
+        - created_at: "2021-03-11T14:06:19Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcDMA7rAHYSMKfAZAQwAgLc+aChS472Q4NjLuFwaeDV/K/nt9h3/R2cXmI/KoOGf
-            4QdGnvvZG8OLEfOtV8kLIiXFX+S543AUjMqXVzGf82TXJPjuVBHdHQWVlBJRPeit
-            MKvLdHbHAXfRZOm5+2cQRiEzSYO0AVypjzyjWD/+70qTmoo51gmFrnITV7TONsVG
-            dlzYZ9pZfshjeEUcf0vg7zhySeLOn8x8c0UeB4fLWZYftLHfYOpwsM4LHI6ESeoO
-            4kRZ20nTruYC2vWfZ4Jry1/sUZ/CQykj0XNe9z70/qmrsrzG5+wzUgIPkqrVhI5U
-            tKaJJZPldMgeXCxHfApjaQR6jue1rM8WSCFNBXlNcz2HFQ2zrrve3TvJgfnibTRv
-            PTfmlq/X6T9Gi/1XR97dlbZTezDQ/V4EGYM8VtjMeCJNVc5uIFf0gJSBrACoCdqN
-            mXfX1BPET39+j4cCV4Ceu8ySs48MjgHF3IG3Xl1GRL8aYuxzDas3HzkJvl98eCXt
-            ut2g8Cn3jkJchs/fEeNS0uAB5AY8IZallDRsQxm6nPQpUbzhw+7gqeAj4Skr4Izi
-            E5jZXuDt5a6J0biciZp8ysYVgZ1DKGyNavm+7c0T8osaiI2jtz0F4FPk8uB7nipO
-            lpgDShm7qe6/TeI7EVud4ayhAA==
-            =oSYY
+            wcDMA7rAHYSMKfAZAQwAKK8KAvMjIO/JcEEtRC29q507ilEktvnLwBCoUS+0xgdF
+            TdMGARzTvo39r2ZkouK5WLxZ9ViBIJzy1/tgq3fq/tDzuCz/mfHPdpja566mmwZL
+            EkM+qQj3xoRvFh7E9ZCBO2kZ0Gm1PTkdB5rD5ljk2bVc96p8mO5icy2cVMnoOVNA
+            Q2TbjUN09+uFY9055e2Avw62JeYN2PKcHlr8k3yHb+87tgg3uJsLfU3dLFZmSB2P
+            Ce1THZJHjj8VSruGQNL4GyfF6H1kWAVUBNWDCJCqc2a+elCwPdRPyXc6VeNx3Xkj
+            ybClBVMCGpcvBjS6trF3CEgiNDycD84n8qiyPfOxwyKZoS56bxhfRu4xJO5rrCB8
+            G9R5NVVK1nbXI5Q3jK6hE03XTvaZ46jQ7CbMcdud19ftkjGRc/aJK9sqR2lxz2uL
+            itbMCQ/ALfAbSi4Wrcs3GuUB0bxf7fVKuMXw8o1UFCYgy2vh2ynUjlQGf3RLEq/4
+            O+tOceeApuEYRMLYWL9w0uAB5AURVkAshNfJ9saD3ole467hOPHgAeD+4Vyl4Bvi
+            vCzo+uD75YN8EKuPj6UrLtfoYopJjdr9Uy4tj2l7TDETUFfxfXVW4JvkZoB+J066
+            sy8PEX4ikXvXquIZ3PZ24ZmoAA==
+            =StLa
             -----END PGP MESSAGE-----
           fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-        - created_at: "2021-05-17T19:07:37Z"
+        - created_at: "2021-03-11T14:06:19Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMAyzcsT8FUYakARAAOON1R8BSivtzZrlZ3DGsrT2G3EAAXEIQ6QuWk6ChcK1e
-            qQJ/m5lpO80zxa8dINcJAcj1O6LsrORfGKpo6g88nsuG2ekEDWrThnl8jpiaakdl
-            26XX5cx0ADJDjareqZ8z7YbtAhD5b+xEaNokEPxBAMNZfoD5aNx59xGi4atLOvVu
-            e/5ks7je1Sv4VzVt8DE1G2Arh+OzV1k4jaHYwAHRPPZIhpAMd30JmbSScaxd0UPh
-            hbAGFApU1cB+Waxa5iR/ouFHnuwH6FOskoVO5vDRyVBR+DsZCdPqaLIHIFkr42pd
-            SNO3ybyXtZEn5CEFXBq22COnv4+O2HuKcaW17kD8sEJfmthEjU0wLeRfd9p1c0Xo
-            HIlNoP/b3CRhU+MsN6DySm49JoQJgjrIz2VaoXYuq78WTR4hL9mhHv41PO+fnlPr
-            CJjfScFhDEbAnpLXWjiwxzXjp8/nsegAErcCUEjMLGhivtxLwEKaGm5rH4H/y212
-            LnhzHGMLxm34NHSJeWYyWCr18+YXfvGV45BlWtpWaYKHic/VxqK1EfnuH3yTHI/p
-            uYEUcbz62ZBzxsn6phF9RwuyNJaldSGz2cxaHrXgIszXGsgZHzyS4QczkdmVdapr
-            ucUtamuPV9KAtmghngVaJsXy92i1mWRqO5xXgdkudjDcbPFwh2yqcYxN4tvgpyjS
-            4AHkjRRwC0ByaHdBChXH3QY+/eF7/+A+4EnhThLgjOIV1cA44GjluQ2KP2Xhq+Nj
-            9l0SXYl2jpV00ZpLeMcdc2/DbyqJvvbgreQ+BOwmt+hLds/xnsRGy+wE4lzPs9nh
-            0wEA
-            =Cg2u
+            wcFMAyzcsT8FUYakARAAcY+bRBW78TAANKNorDjdlfvABpDNz6wjjnRuImSTdicy
+            /d67y4ydK7xPGEDA2/jzbPMQI7mm3Px6Tt7i3m00wRdHTx1gYSFkcVZQnC8Mb8Ra
+            F3+98ZbT5mGZy07GRb5CAkVUBlKTVeIudy3GoXrbJTYLzjIZbvgPY7Hf/FrSCb2H
+            U++7VliRhsUesUmKvCBBGJCkWRX0IE1pI0GDlvnXL/9TlFUjdqdp4kf7cowptjgB
+            8f7WBv0RtQHn6TzNZPssMpZLbHd646jUpnacWHlvtal64GOpFCaV1//76drURWFi
+            dJACwtwGPknEYqk7NY8yonv+e4MezBhjfw5XMVOtzjTel7LFKIh37wHi703TN/YQ
+            YMw+O/8eDXImrRKS9XV93pOewy1X/6MBAhEyVl9/eEuEZCyKeX5VhBBjIAgk9PR+
+            nQhEL8l6PGFtt9PWxylTuKzvP7JFTEzEKlDEFzmaqdW5VtOZFLvSvhCFZF/RMPXT
+            uPvHNSZklU+BLCKvxI5okc1ZZwHOfoR8/AkJ/7qfcysk5L5olqDDboshehQOD6+/
+            RKmC5R6BS7bKoAS7igX6kJh7ADlAiPP5+H39EVKu432YWuNoEp0L+lWh4dTnw2Pt
+            kjthb8nJl/Zw/nTWW4+aCyGDCQixbZndkiE7TxejLbU5ChdWiCWY5ScZHZpjW0jS
+            4AHkY1frg9QR0bpDY20TfPXWhOEjFeCZ4M7hWDLgLOK1xilp4Czlge6SxtaXk0bH
+            QSQ+oIP9bjoIMjT5Slx9gmoI1IjN3GHgbOQPatlFoi+IfzVQWm8eVRqV4hRtNa7h
+            V5EA
+            =/puT
             -----END PGP MESSAGE-----
           fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-        - created_at: "2021-05-17T19:07:37Z"
+        - created_at: "2021-03-11T14:06:19Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcBMA77Gn+FOVmJYAQgAvFFVSyzA+LSmFmQ8uCdYPVAc1rV20z/RDl0o9cPkRpeo
-            7AqAALcy3PWn4BBeHZz03REt3pdAGN0EUUK0RmGw6PR8EP0cQmNQWKKmR1nSYOB0
-            bK50F95IlAaqbRTUDdW4PpAwyDUdexHYX7w2u2iXfk7EvQOyDKxCIB2M/lB/7SDZ
-            AF0wuQ4pmT7T+Q2iJqLzNMMTwGHNFYwC2NXiPIitXvURJC3FgKEdlRxQ4eQdCZjx
-            B4yRM6jjxEw4+yGvNhUS+MYRMOx02VHItKtP+fTkpzhHo9MGxaJ6Y+lV8sIhZkfF
-            KBAS9tbzKNJybB9O40jpGtC987ZmA33o5uIchg3AfdLgAeTHo0WwEa+X5tuwNenT
-            lPJp4bsN4AXg4uGLqOBJ4jdyqYrgbuVdH69ZnZ63iW7TddoseUW/20gwAotkj8zU
-            a2o5WxUt8ODr5Ll0lyH4ABoZrIVGrTcJ8T7iOBQk5OEHeQA=
-            =Loon
+            wcBMA77Gn+FOVmJYAQgAGek54oTSkX1kHBkVvuFzxTgzQUGUjrLI8Kgk4jOzriVq
+            +ysmFFxnQ2mvVFukJZ9GmzETgJMMGCfkDldMROduK9y0xyW9e+VOs/4HY7oCH82A
+            Ju7LjxOCjssdq6bxQsJt8EHkovztj54N7EZ8JNGjnEpcVppE3K1xsxoXxHerQUsn
+            hOJdfwyDWy3RG5SuCRKYSVq1fBBt90+jmDiGPVOTWf8m6+PDkQRRCvW7T2glmKkT
+            vuwstcZpyUc0iLet5adnxeS+uGsNwClqieNhyhRMxAzl9kDF4g70RoVVJa9nGn/i
+            ECpA2rYu4/dB1XaR1bdx9gz1Tq1RTuwwuqW46osSTNLgAeR3H9w+DjhG1SK6jRoc
+            XDRE4Z0R4Ifg2+HKBuD64q12PMTggOX98Mw2IZNkTk6EdgdZoNDxwg5r1AWjXDCb
+            3I7YFzYY9uAr5PflwXmNxFTRAowRvZpYvqjiF9p1heHcMAA=
+            =EyK+
             -----END PGP MESSAGE-----
           fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
-        - created_at: "2021-05-17T19:07:37Z"
-          enc: |
-            -----BEGIN PGP MESSAGE-----
-
-            hQEMA3vkazmcQuPLAQf+JSYoMlGAVYTzAbzJVLUbVmwV3eu2ZUu6oQ9VyPyRrGtx
-            qfQ8YNjAW2S5DBhV8TaFvea0Id210fSLaTFiWaqhkntHempSAU+uQ0GvUzC9V+SU
-            oXOzZtfJ60ceLxgIgjCzi+8nJ/ckOBpWhhhtRTYGx47eBRcbCG0JPBDbZQttaf0W
-            JpVXxC4Bk2Uo6unwF8M0cz/eCwg1YOR1qalfUjucool5pVXZZJomSWu+CidNLKj2
-            4zi94hTwaSKztl7Ot3ucJxzkJRG9WUgDYoE+PSZeJu+nMuoN4FDIdZ95q8tZO429
-            UaN9PeIB/z4RXbUmAArDp2tvGVepon+cUR1DymRIB9JeATBP5dnOFZ5Du8+KnPAI
-            SuANUYu8ArJ1qobHJsTLK/T4aqwtNlzX/qDYaoYq2YzyqlEr6Px2k+qI5px9iHOO
-            CQdKaQYcT+fFhmxRnrPxb6SVnedy0tpED2hZqmmB7Q==
-            =0n3q
-            -----END PGP MESSAGE-----
-          fp: 41E217886B24605316217B8F5AD1C1B1F3A28B6B
     encrypted_regex: ^users$
     version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/open-aiops.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/open-aiops.enc.yaml
@@ -5,21 +5,27 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:L+2moaUenrJSYjfJRfI+XQrg,iv:lZ1OwbT6VYFkpzbT/Mpt7TKF+YQ5Z2DRiNIxYZidsY4=,tag:DJ5fDOsIiXrmHZQFUPUZlA==,type:str]
-- ENC[AES256_GCM,data:4E3Dro+hszBshJjXKQ3lUm4gRD4sUSkk,iv:Aj/jRJrRDu+3chBgx+iekNc3q9V6q+o8QnEdC0YRY5I=,tag:urDAyQYXkR+80F4NPl3RQQ==,type:str]
-- ENC[AES256_GCM,data:QIGg3f8AL/I9XsUM2TTfSPnfRhgeOi4=,iv:EJUOE2R6T7Gw3v4bR3oXbYpOcCpBErUlSFOQmr3D3yE=,tag:o9v1KxnIOxHcIbweobSIYw==,type:str]
-- ENC[AES256_GCM,data:djr6UToGS4Jcyg2yXfDQhlykO8a7RSe7DzM=,iv:TBxdx6kq+U+NDQikwiYVBCAmDnK/fbpJDe8FaGSgsDQ=,tag:wPyicUPEjeMIeMVs2EwqpA==,type:str]
-- ENC[AES256_GCM,data:E72OpG7lTP8y/JiMlyQYxr2jZELyZTivcw==,iv:vkXYgGsuAVtdl5mM5GrNNpdpde5KzMbkm0T8Obm4GPc=,tag:cEjE4ti2WYMrTjyFMY6ysg==,type:str]
+    - ENC[AES256_GCM,data:si9ZuXRno5PBjeaq8DcV4LGqwE+TcTk=,iv:IFhOjhFGy9/zzNBX2wP9hTjbxv/2rWHicDsn/xyDS2s=,tag:24koy7M4zegLdSilh9NlGw==,type:comment]
+    - ENC[AES256_GCM,data:L+2moaUenrJSYjfJRfI+XQrg,iv:lZ1OwbT6VYFkpzbT/Mpt7TKF+YQ5Z2DRiNIxYZidsY4=,tag:DJ5fDOsIiXrmHZQFUPUZlA==,type:str]
+    - ENC[AES256_GCM,data:Ec4XJ0w+0A==,iv:WBpkGRvl+P3XUTxmeKgQmWz6NDO4sa90speYdtWQyF8=,tag:LYcc2zzav8OLFBR5fz+pdA==,type:str]
+    - ENC[AES256_GCM,data:4E3Dro+hszBshJjXKQ3lUm4gRD4sUSkk,iv:Aj/jRJrRDu+3chBgx+iekNc3q9V6q+o8QnEdC0YRY5I=,tag:urDAyQYXkR+80F4NPl3RQQ==,type:str]
+    - ENC[AES256_GCM,data:QiZEfYKPBXSHlKCeS0oTWFpa83lAYn0=,iv:KW/joTJHcJHXwn+klb7AZyHc60RmTppmerhv5kTDGhU=,tag:tDdWxpLSJDUJhN890LlB7g==,type:comment]
+    - ENC[AES256_GCM,data:QIGg3f8AL/I9XsUM2TTfSPnfRhgeOi4=,iv:EJUOE2R6T7Gw3v4bR3oXbYpOcCpBErUlSFOQmr3D3yE=,tag:o9v1KxnIOxHcIbweobSIYw==,type:str]
+    - ENC[AES256_GCM,data:EhI0RKI=,iv:tTvy2YUH/WV3RCmRdtOhIDyQHTJZ1def/iWLGUex65s=,tag:s/rUuTq9qRJBcoQm/Bi8mA==,type:str]
+    - ENC[AES256_GCM,data:djr6UToGS4Jcyg2yXfDQhlykO8a7RSe7DzM=,iv:TBxdx6kq+U+NDQikwiYVBCAmDnK/fbpJDe8FaGSgsDQ=,tag:wPyicUPEjeMIeMVs2EwqpA==,type:str]
+    - ENC[AES256_GCM,data:5B2tSBGm,iv:S+aEousUGyqR78aQWQ8ubE9+pA3ds4uTcih8SFWefEw=,tag:Yc3HZE5rQmzB9G/X13ZCVQ==,type:str]
+    - ENC[AES256_GCM,data:E72OpG7lTP8y/JiMlyQYxr2jZELyZTivcw==,iv:vkXYgGsuAVtdl5mM5GrNNpdpde5KzMbkm0T8Obm4GPc=,tag:cEjE4ti2WYMrTjyFMY6ysg==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-03-11T14:06:22Z'
-    mac: ENC[AES256_GCM,data:ZY4smytbVPhLkZ6gj0emFfvt1LH3VURasKqTEjpknnepmCCy1vDRIFqxjocUVI71jRpEbHMCDcfcvrN7parwWIyOVSRQVXNozImMQPHu7Caob5f80s90GRjv2t55GBHHv5bt9uEEMuOneLEZd6ulG6eCmp1ka5YlHTPfgmc6mZE=,iv:u5f9XwGrIv0dGur5uNNBdbK4oRqfuM3i8WTPLTwYXes=,tag:gVVB//gwJboPXSh5ZGtVxQ==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:28:08Z"
+    mac: ENC[AES256_GCM,data:0JytsVT6VJI6H7R2JZFzFpjOLjZQBfV+89Hq4cSW5FlQd0MFXR33BPRWu/sQb8zYWi7DBQZyCH721zhlCdgkAfrOYjRRH+9FqUARgKez/FRMn3Djt0mAb2oqnk8TBUOK/4nJIpMKI65vXUEeG2I8y0FU7oN2Rwo7A+r3W1WnZHg=,iv:7Qoty7d8wG9+R4dCZy3yRoS1PeYWacyu/DSBAj+6Unc=,tag:F8fEv/ElJK+irzKNOvwN5Q==,type:str]
     pgp:
-    -   created_at: '2021-01-12T17:24:03Z'
-        enc: |-
+        - created_at: "2021-01-12T17:24:03Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAuuVOOTIM5OJBgBmOiyso7LxavqaEUGCHlQ4RSDkVONQk
@@ -38,9 +44,9 @@ sops:
             3NUA
             =PWkO
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-03-11T14:06:19Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-03-11T14:06:19Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAKK8KAvMjIO/JcEEtRC29q507ilEktvnLwBCoUS+0xgdF
@@ -56,9 +62,9 @@ sops:
             sy8PEX4ikXvXquIZ3PZ24ZmoAA==
             =StLa
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-03-11T14:06:19Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-03-11T14:06:19Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAcY+bRBW78TAANKNorDjdlfvABpDNz6wjjnRuImSTdicy
@@ -77,9 +83,9 @@ sops:
             V5EA
             =/puT
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-03-11T14:06:19Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-03-11T14:06:19Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAGek54oTSkX1kHBkVvuFzxTgzQUGUjrLI8Kgk4jOzriVq
@@ -92,6 +98,6 @@ sops:
             3I7YFzYY9uAr5PflwXmNxFTRAowRvZpYvqjiF9p1heHcMAA=
             =EyK+
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/operate-first.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/operate-first.enc.yaml
@@ -11,7 +11,7 @@ users:
     - ENC[AES256_GCM,data:JsUhCbDzdFzNsBm4polhCcql,iv:eG70e4ls1iCKdii8nUcxnZdOg9eiQEvF8akvvEd2MU8=,tag:s/tNKDcEZB7Y0KzyXDrL/w==,type:str]
     - ENC[AES256_GCM,data:owofylw=,iv:Y16BCagXOAm+LWaTHa7Svkq4Gm2XZ7T2tnBdyT4VpzY=,tag:5xOM6akVATHOhrJnuQXzyA==,type:str]
     - ENC[AES256_GCM,data:OFaJaubQwopw3sA4BPVeARh+oQ==,iv:P48AOQABhAC5m/KCRsjIwcLzYGmfa4ROEKU6XvGlEWM=,tag:87XjhswjbATMFsa+bMqAVg==,type:str]
-    - ENC[AES256_GCM,data:8T6wngam21k=,iv:Vpua6bMC/oeCuEYvXni3DdrlFSp5O4ZA3fPEp5H49Zc=,tag:D/rS4b5+MPjMgV1FfjD13w==,type:str]
+    - ENC[AES256_GCM,data:4pqeVBc/ywc=,iv:Haz02c3v8x1KaD00ABZj/iFHgfJVUeREXqoQmGjcnaQ=,tag:dWvBdcb8EheA6BoOnLaOXA==,type:str]
     - ENC[AES256_GCM,data:lgF/Jh6V3+/o+9AtTB80Z84=,iv:Jhj2v8WmkO9X9FkyKGsrmQGJzkM6Y4SMrwUpx/yiepk=,tag:Jo82gUHp5D7m5h2FdR+29w==,type:str]
     - ENC[AES256_GCM,data:mnmthMIC,iv:BparCh+X5D7IVP+4G/tZQGk5mrZg3h2RPdWb224qOjA=,tag:Ka3QPVtHRtDn4ZK8dk6xdg==,type:str]
     - ENC[AES256_GCM,data:EItuuPfnvv9WZNLpcDonMTXLZA==,iv:f+lgylGGqK5vIDTaYEuhcr3udDGvPwfRXFPEjAKm7tk=,tag:RxDaLOFx1EaGOQA53k/GVQ==,type:str]
@@ -39,8 +39,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-07-14T20:29:13Z"
-    mac: ENC[AES256_GCM,data:H+3h1Z80yFJ7Vb/uMOQE31mUCIBF2S7zXJDjynKaEhuWD3zIukkeDcibAaOzw96AYgDi+3befhm5njUpCcL3+LxYDoXwTtjOqTbaeaPoVd0qFZwXK2mMLKtsi1G3aUOIFfZH9HcUqbWfvCsT1J3GpVVnT9muV/ND4tYduHIajRM=,iv:DQI2vbr4vbjHsMVCzQy1TAbeJe0YvhQvU0vSbkfZxH8=,tag:G9wUOYp0f67C76Au5j3tCQ==,type:str]
+    lastmodified: "2021-08-12T12:52:53Z"
+    mac: ENC[AES256_GCM,data:hhhtvKcWBVNpTicvgItFz5HYecz9wv7rNcrO/b1YGgi4GoVkubRHO9WK4NzzZe3NGyj28lLz0vCEJwyfc/DWnZpzPFYW767PAD9jLMxH5Z3Oy7Y5znvqU24G6rC/Wly3G/CkD1HLm55lSjYZf2Q2PMdrFsKbto8FnO8ej08HsIA=,iv:VaG9ZiLVIMA0XHajSs3Xu87YbY6nT1TZrVm06SGZO/4=,tag:UvYzF6gSIgP3Lq1IY+HW0g==,type:str]
     pgp:
         - created_at: "2021-03-17T20:32:24Z"
           enc: |

--- a/cluster-scope/overlays/prod/common/groups/operate-first.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/operate-first.enc.yaml
@@ -5,30 +5,45 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:2bEbpAQsqVgr9JeIQVL+yAZygQ==,iv:5enq05157+GIPmwPoPznDZ7OZuB6xL2qQ2M+wMlYYmM=,tag:EUPKDnnXlcf/SMOf23sjnw==,type:str]
-- ENC[AES256_GCM,data:JsUhCbDzdFzNsBm4polhCcql,iv:eG70e4ls1iCKdii8nUcxnZdOg9eiQEvF8akvvEd2MU8=,tag:s/tNKDcEZB7Y0KzyXDrL/w==,type:str]
-- ENC[AES256_GCM,data:OFaJaubQwopw3sA4BPVeARh+oQ==,iv:P48AOQABhAC5m/KCRsjIwcLzYGmfa4ROEKU6XvGlEWM=,tag:87XjhswjbATMFsa+bMqAVg==,type:str]
-- ENC[AES256_GCM,data:lgF/Jh6V3+/o+9AtTB80Z84=,iv:Jhj2v8WmkO9X9FkyKGsrmQGJzkM6Y4SMrwUpx/yiepk=,tag:Jo82gUHp5D7m5h2FdR+29w==,type:str]
-- ENC[AES256_GCM,data:EItuuPfnvv9WZNLpcDonMTXLZA==,iv:f+lgylGGqK5vIDTaYEuhcr3udDGvPwfRXFPEjAKm7tk=,tag:RxDaLOFx1EaGOQA53k/GVQ==,type:str]
-- ENC[AES256_GCM,data:FVrtk0PEk1tiLHOuJQyhrA==,iv:jodskL3V0Y2wi+2U2PlG8CcBhNiWbdoddmfXSlrD68E=,tag:VDb1VFBmQEyFx7rr/BY4wg==,type:str]
-- ENC[AES256_GCM,data:DCheOUeUMegN4LpVGuVBPCWmng==,iv:94AcIm8vG5c3PCdx+WOLdYisDkSbhUnWa+82YlZPn7s=,tag:ySFydpuPqS+2WCcPYYrYTQ==,type:str]
-- ENC[AES256_GCM,data:8LW4eBMOBDUP/UmXi7UwR+aQ,iv:krRQfojHMbrprnl18yvU28E97sfYvuEALeU1U5FDFA8=,tag:cLgwi7xub1uLSldsahcvdA==,type:str]
-- ENC[AES256_GCM,data:l2idJ2+zHGj/+riJfHE+0OI=,iv:yWdiWu3t4pFNvMSbxG5Mtel6HU2T2jOUHkQPwLLJr+U=,tag:2r7eFSIfMDLlO8JArwcVtQ==,type:str]
-- ENC[AES256_GCM,data:P+OtoX1cPBOayd0+24TCWhE=,iv:MTJ8L18JAuGt5j2V2TbCBPgCutroBUQiKyIsc71Vahk=,tag:TSRMl3R4cCFvN/iNgiUaFA==,type:str]
-- ENC[AES256_GCM,data:2qApttP2DTleXRuTSte8I7A6pQ==,iv:cTIgcpBNuCoq5+PTrZ7i45/6h7MnJ3Uw+3BNhj5PBdM=,tag:9LmB2uB8mzbbE440KVF8Eg==,type:str]
-- ENC[AES256_GCM,data:JMvYsPew4+ZegSI0S/mjEJREhw==,iv:3Dgifl9wXqaKj276C2fzJ1BRBrOizgVERZE55F61iho=,tag:F2+O4KQ0p6LI7f8rziMhgA==,type:str]
-- ENC[AES256_GCM,data:fQCqZBypVfRoLI4L1jKoBQ==,iv:GZJFyOM7OCEs/gLK8s/ye2LuZuGA12/z8cTA2rL+t0k=,tag:+FuKw7KmPsRlKDLSmxiwqw==,type:str]
-- ENC[AES256_GCM,data:CZ+Z1U1FmIACWIhevvYR07ap,iv:wHtJBXLan/A7llYTX5aLebPleyBibpLhEn8XtnkzI0w=,tag:G8lPiiO62wf7O7/qYEhpqg==,type:str]
+    - ENC[AES256_GCM,data:+fFsa4KMf72ZM3P4,iv:RcBNA7ps1ZaSWEujfnhkHhuraVdphlZI2rCbzttaWXo=,tag:nDUPH1jVsXFxy2YRfzM5Gw==,type:str]
+    - ENC[AES256_GCM,data:2bEbpAQsqVgr9JeIQVL+yAZygQ==,iv:5enq05157+GIPmwPoPznDZ7OZuB6xL2qQ2M+wMlYYmM=,tag:EUPKDnnXlcf/SMOf23sjnw==,type:str]
+    - ENC[AES256_GCM,data:zCeFWyQ/DcE=,iv:GrBNd94tOXk8oEoeNCO+VEgKXeZg7LTNdkSKOTmNiRM=,tag:WQGKbY8nMCrNk8wQufGHdg==,type:str]
+    - ENC[AES256_GCM,data:JsUhCbDzdFzNsBm4polhCcql,iv:eG70e4ls1iCKdii8nUcxnZdOg9eiQEvF8akvvEd2MU8=,tag:s/tNKDcEZB7Y0KzyXDrL/w==,type:str]
+    - ENC[AES256_GCM,data:owofylw=,iv:Y16BCagXOAm+LWaTHa7Svkq4Gm2XZ7T2tnBdyT4VpzY=,tag:5xOM6akVATHOhrJnuQXzyA==,type:str]
+    - ENC[AES256_GCM,data:OFaJaubQwopw3sA4BPVeARh+oQ==,iv:P48AOQABhAC5m/KCRsjIwcLzYGmfa4ROEKU6XvGlEWM=,tag:87XjhswjbATMFsa+bMqAVg==,type:str]
+    - ENC[AES256_GCM,data:8T6wngam21k=,iv:Vpua6bMC/oeCuEYvXni3DdrlFSp5O4ZA3fPEp5H49Zc=,tag:D/rS4b5+MPjMgV1FfjD13w==,type:str]
+    - ENC[AES256_GCM,data:lgF/Jh6V3+/o+9AtTB80Z84=,iv:Jhj2v8WmkO9X9FkyKGsrmQGJzkM6Y4SMrwUpx/yiepk=,tag:Jo82gUHp5D7m5h2FdR+29w==,type:str]
+    - ENC[AES256_GCM,data:mnmthMIC,iv:BparCh+X5D7IVP+4G/tZQGk5mrZg3h2RPdWb224qOjA=,tag:Ka3QPVtHRtDn4ZK8dk6xdg==,type:str]
+    - ENC[AES256_GCM,data:EItuuPfnvv9WZNLpcDonMTXLZA==,iv:f+lgylGGqK5vIDTaYEuhcr3udDGvPwfRXFPEjAKm7tk=,tag:RxDaLOFx1EaGOQA53k/GVQ==,type:str]
+    - ENC[AES256_GCM,data:7duDPpzsLSQ=,iv:+4MSPynpoG7XQUiEEmK2269RijFLa8xziyOQziMeEyQ=,tag:xuqabUOkqPA7p1Ku2PuMxQ==,type:str]
+    - ENC[AES256_GCM,data:FVrtk0PEk1tiLHOuJQyhrA==,iv:jodskL3V0Y2wi+2U2PlG8CcBhNiWbdoddmfXSlrD68E=,tag:VDb1VFBmQEyFx7rr/BY4wg==,type:str]
+    - ENC[AES256_GCM,data:e0so2aiZudQalDUdIQ==,iv:rFpxEjNIdrZ25pFtKBUCPvq9MGMmUkusfKPY7crd5fE=,tag:URkM/hzF40x3U8IHrQMq7w==,type:str]
+    - ENC[AES256_GCM,data:DCheOUeUMegN4LpVGuVBPCWmng==,iv:94AcIm8vG5c3PCdx+WOLdYisDkSbhUnWa+82YlZPn7s=,tag:ySFydpuPqS+2WCcPYYrYTQ==,type:str]
+    - ENC[AES256_GCM,data:ijybKoN5,iv:PVhqKih8rQulE2nVMzqXQOoxR1vMteg00+pAFk/VoQI=,tag:OkFheXAyCN3H0RViO5aoQA==,type:str]
+    - ENC[AES256_GCM,data:8LW4eBMOBDUP/UmXi7UwR+aQ,iv:krRQfojHMbrprnl18yvU28E97sfYvuEALeU1U5FDFA8=,tag:cLgwi7xub1uLSldsahcvdA==,type:str]
+    - ENC[AES256_GCM,data:vZnAMh8=,iv:ZAFbp7g8k9FzO/4oh1diM4WwMxV0HFob88KfnGEhahw=,tag:wn9BQsA9G5ghgIu22eXlhg==,type:str]
+    - ENC[AES256_GCM,data:l2idJ2+zHGj/+riJfHE+0OI=,iv:yWdiWu3t4pFNvMSbxG5Mtel6HU2T2jOUHkQPwLLJr+U=,tag:2r7eFSIfMDLlO8JArwcVtQ==,type:str]
+    - ENC[AES256_GCM,data:wKf93nDgfNyT,iv:pmwTfKwXtvjbwhTYvzLrnPX7M7J0F+T24n3Jl70VUbQ=,tag:fJkWJa4U8s0kv22I6kVuwg==,type:str]
+    - ENC[AES256_GCM,data:P+OtoX1cPBOayd0+24TCWhE=,iv:MTJ8L18JAuGt5j2V2TbCBPgCutroBUQiKyIsc71Vahk=,tag:TSRMl3R4cCFvN/iNgiUaFA==,type:str]
+    - ENC[AES256_GCM,data:He2M7kEChpwX,iv:bchHC94fTvKVe2VsWUy3VTBVg67DR3UGnNgYCPjjwjw=,tag:zihXjGqclEJ07t7T59MtTw==,type:str]
+    - ENC[AES256_GCM,data:2qApttP2DTleXRuTSte8I7A6pQ==,iv:cTIgcpBNuCoq5+PTrZ7i45/6h7MnJ3Uw+3BNhj5PBdM=,tag:9LmB2uB8mzbbE440KVF8Eg==,type:str]
+    - ENC[AES256_GCM,data:TSpkqLyW5b8=,iv:7/skznkAp0zzqk+weS0Wc1vrUW5OzygZuO0w9TXHxeM=,tag:ZbGRQocHfwFp2ZgyzMilYQ==,type:str]
+    - ENC[AES256_GCM,data:JMvYsPew4+ZegSI0S/mjEJREhw==,iv:3Dgifl9wXqaKj276C2fzJ1BRBrOizgVERZE55F61iho=,tag:F2+O4KQ0p6LI7f8rziMhgA==,type:str]
+    - ENC[AES256_GCM,data:1QplCqPuAgk=,iv:MCkxJcb1I1RRdqOuGrCHYFET4zXU5AHhqgLLnaUMh1Y=,tag:4G+GFfRzawdnkj/YHxbWBQ==,type:str]
+    - ENC[AES256_GCM,data:fQCqZBypVfRoLI4L1jKoBQ==,iv:GZJFyOM7OCEs/gLK8s/ye2LuZuGA12/z8cTA2rL+t0k=,tag:+FuKw7KmPsRlKDLSmxiwqw==,type:str]
+    - ENC[AES256_GCM,data:nouvfC+wyQ==,iv:Q/c+0fMmq4tC+awxp3oS+dOdYhQJjhMZs6n3QsJCr84=,tag:TsPqkRwPgwTtLc8aRJu9UQ==,type:str]
+    - ENC[AES256_GCM,data:CZ+Z1U1FmIACWIhevvYR07ap,iv:wHtJBXLan/A7llYTX5aLebPleyBibpLhEn8XtnkzI0w=,tag:G8lPiiO62wf7O7/qYEhpqg==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-04-23T16:44:12Z'
-    mac: ENC[AES256_GCM,data:NKLo2r5H8EYd8txzYA0pFrsxOdcA6tnmfDoYuiTWtv285jvsgqPypCIa1KbF0UzsNXo4OA8F6Ukdis6hg83yYE1vQgUBKLsGzBk40GsA3KxdBn8ZopEAffj87ZSWrilRo3M/fwPOajrXCUIu/fZ3Mpw9GN18jINcv+SiMqSGB+Q=,iv:otPPZTxQWffgykT3E21GB2pEjlerLNqziMskbZ4oIQM=,tag:pcPwbbPtlIHiY0/3UwjorQ==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:29:13Z"
+    mac: ENC[AES256_GCM,data:H+3h1Z80yFJ7Vb/uMOQE31mUCIBF2S7zXJDjynKaEhuWD3zIukkeDcibAaOzw96AYgDi+3befhm5njUpCcL3+LxYDoXwTtjOqTbaeaPoVd0qFZwXK2mMLKtsi1G3aUOIFfZH9HcUqbWfvCsT1J3GpVVnT9muV/ND4tYduHIajRM=,iv:DQI2vbr4vbjHsMVCzQy1TAbeJe0YvhQvU0vSbkfZxH8=,tag:G9wUOYp0f67C76Au5j3tCQ==,type:str]
     pgp:
-    -   created_at: '2021-03-17T20:32:24Z'
-        enc: |
+        - created_at: "2021-03-17T20:32:24Z"
+          enc: |
             -----BEGIN PGP MESSAGE-----
 
             hQIMA9aKBcudqifiAQ/8CWHghz4Q1GtI8ufuQRtiD2SflhuoyvNp0A/fkF4QpQQS
@@ -46,9 +61,9 @@ sops:
             j4OoaWIVUVLw5yQoKYS8Gh3uvMiyDnxnC5pCb6k6Ix1rPvQYVAXKlmdS8dfcgO4=
             =bd1O
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-03-17T20:32:24Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-03-17T20:32:24Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAK30Ws8CjrndfPr/2HTmnlXNiH+CHjXV7BRJf5xN/316g
@@ -64,9 +79,9 @@ sops:
             jCI+00nhp1tvneJyVkO84dHdAA==
             =jw0T
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-03-17T20:32:24Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-03-17T20:32:24Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAGPsa+IYlW29HuMqGbBJlZ7YamhkHvmiJQpig9OG8eBKG
@@ -85,9 +100,9 @@ sops:
             I78A
             =+UgH
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-03-17T20:32:24Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-03-17T20:32:24Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAGarkVUp2u9Dvv8ZgJ1PDS+4N0eg//3N3+4Q4LgQrgNRS
@@ -100,6 +115,6 @@ sops:
             b5kKmfP0t+AR5O5t/iiPJcGcHOgTg500ovzip/BrOuGO3gA=
             =DPb8
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.7.0
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/osc.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/osc.enc.yaml
@@ -9,7 +9,7 @@ users:
     - ENC[AES256_GCM,data:MEF9MINI0YvCFj+KZCJ0CRbaYw==,iv:NZhOQoic/zh8/M34unsuXpaGG9roiREQJ7kwzT2Eg7A=,tag:Eo7vEF2pxSLmvcO6/QFvGg==,type:str]
     - ENC[AES256_GCM,data:Nl4bR48e,iv:3sWQg06dFkucanzjrehYR1AkwESLuE+R3JfKYHy809I=,tag:FuZKyIa4olfHaPre2FXBkg==,type:str]
     - ENC[AES256_GCM,data:MrGWtAUSNaFDCpxUcovFAg2UFg==,iv:5YilFckq/n2dcs1iIaw3KQ2ovM0+6Dg16bUnBG5w13k=,tag:ck0HrqernyQmPpFmES7vBA==,type:str]
-    - ENC[AES256_GCM,data:P1N9/KEu/C0=,iv:MvMQ09XFUjFb2IcAw+Nogv5MB+v4lyNdb58EYOy9w04=,tag:nhS9/djbos/aNa9so8H5xg==,type:str]
+    - ENC[AES256_GCM,data:gTZF8U4Axow=,iv:ifrdkTuVMklUCP2Gvbs0sO0NqGdAs7J0gQeYama07po=,tag:ffcWt5m8oQTBNOy/O3ybhg==,type:str]
     - ENC[AES256_GCM,data:Sf/Tq80sSoqEofMnqqJmMZA=,iv:WORBi2S3PPftAmbCYaZaChMFiXPg6OrdLMOPpum7RZ8=,tag:pBtIeXDuoiRKApZzVGBO9g==,type:str]
     - ENC[AES256_GCM,data:veOj7vE2C7b+,iv:FNcEHbA1uVLOwrK6cLLhR+1aXxVIDSDSS6S9n05X5P8=,tag:6hg5DxmTz/ZRiRsdw0s3OQ==,type:str]
     - ENC[AES256_GCM,data:byAPb7QTLgJ2Pbl1GKpH2Lol3w==,iv:NWoXkwMYz4CE+PYyeJN7kAXMMth3ii+inUQDFMNIyh4=,tag:WE+1FvHlyH9UMDnBZ7neKQ==,type:str]
@@ -19,8 +19,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-07-14T20:29:39Z"
-    mac: ENC[AES256_GCM,data:7izjnUtZd/h5GjWsWKmxsSYMXBI4DeHWu3MJaDaj7+fCL75CwJJRkHMEFo1YfiOKhU02XzO7lppMhY6baNd8S/kNjfRsvcJ9jBeKirPqRXZ/wSDM0HL6tPyDWSbXRcvV0SRZCJwojtmE1/eshduqW0HPAUwQ16CfyYZyOyJJtLs=,iv:gAK8NlFiokeebMGg4Q4lNj098GrxTCDOwNFuOzeDfa8=,tag:nor2G89jUuIOqQTBEyl0Pg==,type:str]
+    lastmodified: "2021-08-12T12:53:01Z"
+    mac: ENC[AES256_GCM,data:GybaYcUIdoqxo7EmxvqeYUberXsMeHEaCbtIKwmWeGWrXuD7mtphBztYw3KdgwVXBkjTnF2NB87nlPRilHuvb6OgwuIdtOJTp/l/Yt5NIXPTPY1oPaGodcSaNSc8/LNxDin6TzcHxtAcQmk1eZb+HO2bBEYTzBq/qi2qHQmAmL0=,iv:6cb074xVAQcq0XDa+bqERE7nlbNbRPz42xNJ533TrTw=,tag:BxECFiH4DDN9HmA7BKqdzQ==,type:str]
     pgp:
         - created_at: "2021-03-17T13:13:29Z"
           enc: |

--- a/cluster-scope/overlays/prod/common/groups/osc.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/osc.enc.yaml
@@ -5,20 +5,25 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:MEF9MINI0YvCFj+KZCJ0CRbaYw==,iv:NZhOQoic/zh8/M34unsuXpaGG9roiREQJ7kwzT2Eg7A=,tag:Eo7vEF2pxSLmvcO6/QFvGg==,type:str]
-- ENC[AES256_GCM,data:MrGWtAUSNaFDCpxUcovFAg2UFg==,iv:5YilFckq/n2dcs1iIaw3KQ2ovM0+6Dg16bUnBG5w13k=,tag:ck0HrqernyQmPpFmES7vBA==,type:str]
-- ENC[AES256_GCM,data:Sf/Tq80sSoqEofMnqqJmMZA=,iv:WORBi2S3PPftAmbCYaZaChMFiXPg6OrdLMOPpum7RZ8=,tag:pBtIeXDuoiRKApZzVGBO9g==,type:str]
-- ENC[AES256_GCM,data:byAPb7QTLgJ2Pbl1GKpH2Lol3w==,iv:NWoXkwMYz4CE+PYyeJN7kAXMMth3ii+inUQDFMNIyh4=,tag:WE+1FvHlyH9UMDnBZ7neKQ==,type:str]
+    - ENC[AES256_GCM,data:CTQqqu91tIhJ6zT2tA==,iv:2VQwXeWpDCQaGUXfTf3isAIxQDG8DF2eTvu7JY5pXYw=,tag:rGoNHuuIIb3ESxKJWuINig==,type:str]
+    - ENC[AES256_GCM,data:MEF9MINI0YvCFj+KZCJ0CRbaYw==,iv:NZhOQoic/zh8/M34unsuXpaGG9roiREQJ7kwzT2Eg7A=,tag:Eo7vEF2pxSLmvcO6/QFvGg==,type:str]
+    - ENC[AES256_GCM,data:Nl4bR48e,iv:3sWQg06dFkucanzjrehYR1AkwESLuE+R3JfKYHy809I=,tag:FuZKyIa4olfHaPre2FXBkg==,type:str]
+    - ENC[AES256_GCM,data:MrGWtAUSNaFDCpxUcovFAg2UFg==,iv:5YilFckq/n2dcs1iIaw3KQ2ovM0+6Dg16bUnBG5w13k=,tag:ck0HrqernyQmPpFmES7vBA==,type:str]
+    - ENC[AES256_GCM,data:P1N9/KEu/C0=,iv:MvMQ09XFUjFb2IcAw+Nogv5MB+v4lyNdb58EYOy9w04=,tag:nhS9/djbos/aNa9so8H5xg==,type:str]
+    - ENC[AES256_GCM,data:Sf/Tq80sSoqEofMnqqJmMZA=,iv:WORBi2S3PPftAmbCYaZaChMFiXPg6OrdLMOPpum7RZ8=,tag:pBtIeXDuoiRKApZzVGBO9g==,type:str]
+    - ENC[AES256_GCM,data:veOj7vE2C7b+,iv:FNcEHbA1uVLOwrK6cLLhR+1aXxVIDSDSS6S9n05X5P8=,tag:6hg5DxmTz/ZRiRsdw0s3OQ==,type:str]
+    - ENC[AES256_GCM,data:byAPb7QTLgJ2Pbl1GKpH2Lol3w==,iv:NWoXkwMYz4CE+PYyeJN7kAXMMth3ii+inUQDFMNIyh4=,tag:WE+1FvHlyH9UMDnBZ7neKQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-06-03T17:18:39Z'
-    mac: ENC[AES256_GCM,data:YPCeEENZN/walpGoOu7BVYNY/trK37Y1BCOU5l+3o3L14Ux24VbIvd7eczhVazHhh+OEKekRjkB6+WkOINOXMP3ZNwjGUXEEvqQLtioeVnIX/zkrOyjAJf7D+kPdJLjXM7Ps78yosXlhfwns+BidDG2aqUxxxH5LBCKOIhNHCbI=,iv:E65A1/Asxsvek0ZJiQcuby/RfzMG8lRtAXB+Qy2QDDY=,tag:orsLt5dg5WihKhfZX9zZxQ==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:29:39Z"
+    mac: ENC[AES256_GCM,data:7izjnUtZd/h5GjWsWKmxsSYMXBI4DeHWu3MJaDaj7+fCL75CwJJRkHMEFo1YfiOKhU02XzO7lppMhY6baNd8S/kNjfRsvcJ9jBeKirPqRXZ/wSDM0HL6tPyDWSbXRcvV0SRZCJwojtmE1/eshduqW0HPAUwQ16CfyYZyOyJJtLs=,iv:gAK8NlFiokeebMGg4Q4lNj098GrxTCDOwNFuOzeDfa8=,tag:nor2G89jUuIOqQTBEyl0Pg==,type:str]
     pgp:
-    -   created_at: '2021-03-17T13:13:29Z'
-        enc: |
+        - created_at: "2021-03-17T13:13:29Z"
+          enc: |
             -----BEGIN PGP MESSAGE-----
 
             hQIMA9aKBcudqifiAQ//bNAPPsCdKW42Cz9ewynP/oNt72pcG6zpTnceD3eaMMja
@@ -36,9 +41,9 @@ sops:
             3o3M1VCzFxee36Q1EkllRoTiUZ/f0Redcv1SSwas7mBj3YN14P6/aLSRBeyx
             =/kGa
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-03-17T13:13:29Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-03-17T13:13:29Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAm85yHfecZ0TLD1O37RakGWUZc1qCMbDoSsWzuiaQcXKT
@@ -57,9 +62,9 @@ sops:
             sSIA
             =ZENa
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-03-17T13:13:29Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-03-17T13:13:29Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgActgaputTve3Fbt4vwR5tRswYeSENSKh/dn20npCuJrea
@@ -72,9 +77,9 @@ sops:
             Hnum6wJ0Y+DS5CAujiihRRmIq+bg0I4UroHijsoXM+FTLwA=
             =Igbc
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
-    -   created_at: '2021-03-17T13:13:29Z'
-        enc: |-
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+        - created_at: "2021-03-17T13:13:29Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAKrDzJ3Uix8bYk2iXeOzTjJ0N9Fg7ouVugpHZe8AvKVv9
@@ -90,6 +95,6 @@ sops:
             +be105co4Dkbe+Lf1YeQ4RZaAA==
             =0HPd
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
     encrypted_regex: ^(users|data|stringData)
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/prometheus-anomaly-detector.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/prometheus-anomaly-detector.enc.yaml
@@ -5,19 +5,23 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:5DvRN6RzAAWcBfXsG5TunOVPsw==,iv:sgW/9bCyW8lkW8MHknNRVgsPhtO+bR34rSu7gvScL9c=,tag:2x0LVhTfKQh2JPo/H1ZFfA==,type:str]
-- ENC[AES256_GCM,data:iQd45u0iW1E8FH+d5IbWrqD3Ow==,iv:pNHrK3tMTJ7T08KCUpHKwIeqbVs9lx8R5ZK7RUoSl2Y=,tag:G/REuuuOlIULz8egF+gAuw==,type:str]
-- ENC[AES256_GCM,data:TweGO8jpNB+tI7qtMSDHnN7Y,iv:qzd7sVA9RGt8cJVMIbcDsybiyRV58MbyrjPUTAy1bZc=,tag:9Fg4MiyLDkm6vLypHmfqwQ==,type:str]
+    - ENC[AES256_GCM,data:8Vu5ttw=,iv:KAJXf0e/EMKN5LJ9yzYmsvACmFgmqBZUgcnV0Hu1SkU=,tag:d++DLkSmOSRAZO8B4S9+pA==,type:str]
+    - ENC[AES256_GCM,data:5DvRN6RzAAWcBfXsG5TunOVPsw==,iv:sgW/9bCyW8lkW8MHknNRVgsPhtO+bR34rSu7gvScL9c=,tag:2x0LVhTfKQh2JPo/H1ZFfA==,type:str]
+    - ENC[AES256_GCM,data:iJY0MhrB,iv:91yGc/R38ZDljBv9R93rU+YR/nlF5zFFQMBsoh77tJI=,tag:sd5wQAn7KO87G57RP2tKdA==,type:str]
+    - ENC[AES256_GCM,data:iQd45u0iW1E8FH+d5IbWrqD3Ow==,iv:pNHrK3tMTJ7T08KCUpHKwIeqbVs9lx8R5ZK7RUoSl2Y=,tag:G/REuuuOlIULz8egF+gAuw==,type:str]
+    - ENC[AES256_GCM,data:OBDri7UbwiyVLxd490EGb7aYyEv4+cQ=,iv:EEIwW6Ai/51CGEjNkPC6+7FMAnSOQ8hrYgh3C4dHXjA=,tag:6SMHErsyzTwDRoAWgtzHdQ==,type:comment]
+    - ENC[AES256_GCM,data:TweGO8jpNB+tI7qtMSDHnN7Y,iv:qzd7sVA9RGt8cJVMIbcDsybiyRV58MbyrjPUTAy1bZc=,tag:9Fg4MiyLDkm6vLypHmfqwQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-06-30T14:50:45Z'
-    mac: ENC[AES256_GCM,data:X8atlaUN6cxNn3ilMf51/UIhzvSre6jE0cmV7vKso6lWLJU2MaC2p78hATdTz6pAVbZsQyENHA5SiazlwLMQS/vNS9/Y8sYp9K5oQ/d03UTvUwXdKh2vgwq+uWOKbc83mKX2g8WxCXH0J3R/5wG6vWrWYSlij9+xpORHCmMzwZk=,iv:55USW+vySrbTbSSTdSVqjSdkQHwSvmGe64lFJ6D1cfs=,tag:gBFflm1sLgf8XAx5lEL2Vg==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:30:00Z"
+    mac: ENC[AES256_GCM,data:h3PL+MzFcEvxm/uzLvRs2Xz4ufRNaFTfxklLOuP7XnA52fuCeZ6qupUlbMnEICbgK2RuwxyFoZdJsn17sggpGLpZ/TK+5VkYGGlVVdYiYN6DLlByM/0bE34BZ871m+UGfgUVe5HNZWA7G7lq8A/prfNaN0pG/KYhVUEAnG/x694=,iv:DhumDt0/cnPt6jL7eALwNn2qJ80QgNp5lkfuFt2PeuU=,tag:ugaTBsBUqgy2LtqXIDisTg==,type:str]
     pgp:
-    -   created_at: '2021-04-15T15:51:09Z'
-        enc: |-
+        - created_at: "2021-04-15T15:51:09Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAee86qTv5MBzQpObVrVGmPQ6QCMncVAsFre3wOHfikh1A
@@ -36,9 +40,9 @@ sops:
             31YA
             =PLwY
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-04-15T15:51:09Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-04-15T15:51:09Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwApXoLX6q0ivrecxdqyri3FUJtYoroWLY0+R8OvmUw+u+B
@@ -54,9 +58,9 @@ sops:
             E3FSl6R5M6evIeKByk9u4XbaAA==
             =3LUi
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-04-15T15:51:09Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-04-15T15:51:09Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAeSlJkWigP6Zt9ShVmCmMofswZm0dAxtzzNUH2eNDOZKi
@@ -75,9 +79,9 @@ sops:
             I4QA
             =VqyP
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-04-15T15:51:09Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-04-15T15:51:09Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgATdaqh3m6gB32DpJVFcLhZDNgyJEIUHK46AZkeTKz5rur
@@ -90,6 +94,6 @@ sops:
             XTvU3tqdieC55HVx/iQlD0ZLZRi75xF9wdjiunO2w+EjeQA=
             =ckNJ
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/pulp.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/pulp.enc.yaml
@@ -5,10 +5,14 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
+    - ENC[AES256_GCM,data:/csJxjdr/B8PHw==,iv:E6QumaG6umlRb6A/3yEK+u8kja3KN2pM24MKLj2hqR0=,tag:L1rBXghAahAqQKGakgjpAg==,type:str]
     - ENC[AES256_GCM,data:didxTCR+0WTKkBF9fWvo0jfI8Q==,iv:dIXvDepsi6axJVc3piGf6lPRrCl1QHpmOoqumGQqSfY=,tag:qUhq+eVeOtbGHn0eNhJqwQ==,type:str]
     - ENC[AES256_GCM,data:Zd0DjmWveiYLq2z9wxWT6AoP3p+U,iv:yD4mTSqzWRCr30nra5JSBa7yQChuzF5A+YHvq3PPGnY=,tag:eeEPSkoL88BprBVUrKKy0Q==,type:str]
+    - ENC[AES256_GCM,data:uDhZZJc=,iv:nAae1QCwhbgI6MmJ7F8fyOQmMEamH0fxk/lEzk8BBfo=,tag:agIHXguI/fvVB98EU3G/sw==,type:str]
     - ENC[AES256_GCM,data:aJfl8HLJf5NnqXGNTxoFxeJtmA==,iv:ppW/3bIX3cBiC5TqI5IBXgo0FVmC1s/7ELFSHX7Pkp4=,tag:PAerSR7bvI082jXie3/0qA==,type:str]
+    - ENC[AES256_GCM,data:yzsRTMMAunzODA==,iv:yvtYb3o0W7C92aRmXYJ7yQcpXZSKSlC0AE0ircGZ/DE=,tag:nPkqVo337S/uYSO2z4XSIw==,type:str]
     - ENC[AES256_GCM,data:TYcNvMbhhQ3t1dUT8TMquQgdgQ==,iv:beBRwzw5OlI9H/nZMSYEyo/5zSYESUcZlTfWSdxxcr0=,tag:Ce7bw5GpLTR1Q1lyAnJsrw==,type:str]
+    - ENC[AES256_GCM,data:WAeNukD1RA==,iv:Vz70TUOYBm9po0avdIJ0tVTWoWhhXbuWnmix0QUGotE=,tag:3Y0sOfYKZPGdlvgZXbDJaw==,type:str]
     - ENC[AES256_GCM,data:gjLqAKM3yBfq5VRAm086ex0=,iv:hRH+kJnmkJH/i/U3ZxY7D2xaU3Yis8yTaGqQR9T2/bw=,tag:tsQpMU9hLDUaOvdbeJX+ZA==,type:str]
 sops:
     kms: []
@@ -16,8 +20,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-06-29T12:11:59Z"
-    mac: ENC[AES256_GCM,data:hYisGxqAYLX58VQTvdOjwzuQ2hLZQgVV60TBmzCiVUpWZg1vIiI6CSuhWv8O4TaTa+1qmb9yBZIdahMnLBm9vRjY4O2XAYd803FIOeMgydCdrMwgFIFWMCA7KE1L/ozZY8KVI2IGSDldg1b90sCbHEr9Qr+orasjiqnWodbr08k=,iv:4noD9S8oTo7eu6n90ow+UXipKGaygrWX+OWYy7cpi8Y=,tag:p90ju50JUR0+cn42euzhoQ==,type:str]
+    lastmodified: "2021-07-14T20:30:22Z"
+    mac: ENC[AES256_GCM,data:hCVvhBTl61SfUvKcIHwrnuqU345meeCpDfNQQt3Bo0qrnYsJwT+ApWWpJWXoAaTgUlv0neOhHp6CPdO1/6hNX4n3fpvPEPdZo/of68zMk3JngmsVh4Q3aK6gHWwqooAbPFlhUtbubpoAu1Q2ibb8gGatTHhBJKtl0Ay13yoE500=,iv:n38Pp6ytYrEqD5WAKp81wN+aXFR/m2GbwwbJCkIdMAw=,tag:FpixSeDnjj9RzvHatJW7Ag==,type:str]
     pgp:
         - created_at: "2021-04-07T15:06:53Z"
           enc: |

--- a/cluster-scope/overlays/prod/common/groups/quarkus.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/quarkus.enc.yaml
@@ -5,17 +5,19 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:mpS1acoape3h/OOU1eQ/wH5gMQ==,iv:TmOOPS1h16bL2cEhugU1/6C0NZKvpyRTi5r5Kz3/Lm4=,tag:lA9hkkBNxTOiSvc5T1oz1A==,type:str]
+    - ENC[AES256_GCM,data:tiB22idEga0=,iv:ipWJfq3Z0Sr7uMqHruKWqjRbthAkz2KlGjzop6EnjYI=,tag:wrjj3/D9PKIhdMjT+s2STQ==,type:str]
+    - ENC[AES256_GCM,data:mpS1acoape3h/OOU1eQ/wH5gMQ==,iv:TmOOPS1h16bL2cEhugU1/6C0NZKvpyRTi5r5Kz3/Lm4=,tag:lA9hkkBNxTOiSvc5T1oz1A==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-04-23T18:29:59Z'
-    mac: ENC[AES256_GCM,data:fNI1DY/PBgxVsD0zWWEZ+uaeoylVJezRy6q7Fa/EyWxNehyMvdYYl3cy9aBKxnkyPG7td/ce1vpQBCzZOw5xdNNsE4LPL5TpMVdEhINjs96VhQdVdLUm3NO+89sgBkxAueJCuC4kPSWHOArMOefrEWWNgNrlqgxK6e19uzKSmQ4=,iv:NfEaWdoVYtFphVCHZ+Nqh2lp/CowXEtDEghBDA6n4UI=,tag:QCUlm71V2xUfXsYmj3XIGA==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:30:33Z"
+    mac: ENC[AES256_GCM,data:l92CLGd4NebD5JeeAGRMWJotPVN3bHRVqtkNil18UPWqYarPECWf5Lmxt220a1EuCnT+RoqhCNy0ByMCoJi1ccPFRg4r2LUVGjuIO71hL/os4WQ9HZwjIQaQQJGqS+G66/eIMoyl78UP+57hqrsIlZimPRi+k/vnFdVlYJoVyls=,iv:AzUaONNIjs1CzxrbyHs8SueXotj9QfLekaJlxQah68U=,tag:UELaggfORjp+S2FHDq6tfg==,type:str]
     pgp:
-    -   created_at: '2021-04-23T18:29:58Z'
-        enc: |-
+        - created_at: "2021-04-23T18:29:58Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAvA6I1osfdZZzX33ovqTILVAwLZlWQCuluCqeHKm4C+nf
@@ -34,9 +36,9 @@ sops:
             UBAA
             =MlFG
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-04-23T18:29:58Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-04-23T18:29:58Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAa1st7z61Qe1DsymINJMf4V56oMMCIbft4amRf7xRiEJb
@@ -52,9 +54,9 @@ sops:
             YNX9zuz4kyXhmeL2tCFR4Sm2AA==
             =UE+r
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-04-23T18:29:58Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-04-23T18:29:58Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAKrwNLKP8YHDN5IKkTNASSsJc9eBXywr8TyWTTS9voyXo
@@ -73,9 +75,9 @@ sops:
             EIsA
             =49BZ
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-04-23T18:29:58Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-04-23T18:29:58Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAHplMubfZdDQVNr4VLi/GBR/rqypgi/bZIV7Y4sOMMJIV
@@ -88,6 +90,6 @@ sops:
             hUqu7j9uk+Cx5MdbkAA6f16P+kcLk8btFpjiVYSe6+ERCQA=
             =YXq/
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/ray.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/ray.enc.yaml
@@ -5,17 +5,19 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:ChKYHxk0uVj7wlOj9qbJirdDQg==,iv:Z8Qs/IHi1HSbaVxr5X2311bPNPP2Apm8Fdo9Cyu0aIw=,tag:Nhs0lnNvMooA40dcFIm2pg==,type:str]
+    - ENC[AES256_GCM,data:M4JbHsV9RQAxOaGtgA==,iv:bxWjZBDcM2q6QuqDSkdYD6u9TJnC975MY5YslkpMKFM=,tag:0fyOFGnE6H4qhBeyLhNTPA==,type:str]
+    - ENC[AES256_GCM,data:ChKYHxk0uVj7wlOj9qbJirdDQg==,iv:Z8Qs/IHi1HSbaVxr5X2311bPNPP2Apm8Fdo9Cyu0aIw=,tag:Nhs0lnNvMooA40dcFIm2pg==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-03-11T14:06:16Z'
-    mac: ENC[AES256_GCM,data:n7XW6j5KAqOrgCTbyMXpub4h4Dgo6TAcOO8GwKjDMjdo+8kE7Kl+h3vtIrtNYC5iCbpfLJk18xJ0AuvAl+rxEFwrgLWe6vuXkmKzpQrtipvl8MUBRozwBwhcTk8QkUE+Keak7i4Fttclf6hmuyylv5D/FyFGJNrrTZNa+1U6/rY=,iv:O7ODXerM4fglJQaG0/nKKCfe0nzVbD4SGc1vv246Pkw=,tag:KguaLeXRH7XViSCfPGKMWQ==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:30:42Z"
+    mac: ENC[AES256_GCM,data:hibOXBAq5UuXgE0B9Edmkte3WQGeKCNxMzLd3SIpphT/TojnpwOKAz3QJs3UvUEKLMKX8bFz/7Uz0mCa4GD4TUKZZm8InMJ1uHul5oF4t+QMYdSX3skV4tn5GB/w48B2VAB3xf4F9z1QTeEM9WpepFKKL3deQkmTNmMCQLnBwrM=,iv:RqmlDM7yGumewI2t8rVJTI8GOYjJcYanKerkSrgvLZQ=,tag:6tehycDSWq9+2RGgiyjZjA==,type:str]
     pgp:
-    -   created_at: '2021-01-12T17:24:03Z'
-        enc: |-
+        - created_at: "2021-01-12T17:24:03Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAxaxF7J7n8P0XUR0OAn8NkC2vPUyk+OEl3+q8RVlB9+Dx
@@ -34,9 +36,9 @@ sops:
             YbsA
             =F9dc
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-03-11T14:06:12Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-03-11T14:06:12Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwACyx9MqvfeDX9BuUSJMsBPKQn7fzEBR1Z3Cx1uB0Yf9eB
@@ -52,9 +54,9 @@ sops:
             RiQwu7KWn4dipOKS+4UI4XrCAA==
             =ZlfO
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-03-11T14:06:12Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-03-11T14:06:12Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAgluAOUzaz92M/Bz6L0FGRrONlSr/Agm2V3lrE2VkFHLZ
@@ -73,9 +75,9 @@ sops:
             eLoA
             =W/0s
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-03-11T14:06:12Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-03-11T14:06:12Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgACWRKtfGyrjdge2329oYoBhvM6uFJbrVkqCazu/4EnX1s
@@ -88,6 +90,6 @@ sops:
             8CB8P++QQeCa5FhnC84lRizuPOS8Lwno+87ipBpv3+EvkwA=
             =89kQ
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/redhat-cto-team.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/redhat-cto-team.enc.yaml
@@ -5,21 +5,27 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:5MQub5HiEET5hpYgJmALJx1Ppw==,iv:/PVMA2GlMBvd8qQrNJJACPbuhyiwCj2lV1s/yHaa1AU=,tag:7qo8R1Reh9mFfhA6QvPM8w==,type:str]
-- ENC[AES256_GCM,data:VCi9U6YWcmaTaSNjIeA+NxZ+Jg==,iv:odYCwGJcF69M0YV9/z344BX8DHscmgvvD19z/8XmQf8=,tag:iUxtIu4lbBDHwPmZ1LqjQQ==,type:str]
-- ENC[AES256_GCM,data:xHx01VMXG0LJal9Iz1niCnY=,iv:72YPMiqwgxT2dyo0OVsIrerfFOzYYiYXhIm66bqZPxE=,tag:zSkcXuNnXI22XC8+oxDDNg==,type:str]
-- ENC[AES256_GCM,data:mAhChr3JsuVKDSMRM8CwnRD4cw==,iv:XdkqodNaSyMI/4xbpxwDD7A5TbSz4yqx2IX8LeD0RrE=,tag:YB34FQ8qNJTaSb2hlFcaQQ==,type:str]
-- ENC[AES256_GCM,data:8wrxUUBu3bVxYEFQp5hisHCuLQ==,iv:AD7/OnzDMApLMY7DSogULnukSUyuCSWn0bgw4sifAcc=,tag:w2FCx6wVQVowyAuWsVrBxg==,type:str]
+    - ENC[AES256_GCM,data:VxzgqSQTKiDWlsZsTTxFTirqLw1K88I=,iv:b8c1hzy5WWog6haGaUl8j3s0cZcsSfyEoFqEeNpGGoU=,tag:La63FZx7jUHU4rKu+JniiA==,type:comment]
+    - ENC[AES256_GCM,data:5MQub5HiEET5hpYgJmALJx1Ppw==,iv:/PVMA2GlMBvd8qQrNJJACPbuhyiwCj2lV1s/yHaa1AU=,tag:7qo8R1Reh9mFfhA6QvPM8w==,type:str]
+    - ENC[AES256_GCM,data:k4oOMB5bNBw5+in7lB73Y9tj6uIZDP4=,iv:rariNKvaZRHisTymoK8AiI17+Z3zXaRvBkr/GJ1k+p0=,tag:48FtY885QxSjIkhRacG6Xg==,type:comment]
+    - ENC[AES256_GCM,data:VCi9U6YWcmaTaSNjIeA+NxZ+Jg==,iv:odYCwGJcF69M0YV9/z344BX8DHscmgvvD19z/8XmQf8=,tag:iUxtIu4lbBDHwPmZ1LqjQQ==,type:str]
+    - ENC[AES256_GCM,data:S9HuMuDDaTipcg+OfXEB8KNUJKi2Cjo=,iv:7FFBkVE+I53JODCENvNGzOzqGIXOeYyZAw9RKwT65t4=,tag:ja3AjvKxbRY4Ai9hsByaKA==,type:comment]
+    - ENC[AES256_GCM,data:xHx01VMXG0LJal9Iz1niCnY=,iv:72YPMiqwgxT2dyo0OVsIrerfFOzYYiYXhIm66bqZPxE=,tag:zSkcXuNnXI22XC8+oxDDNg==,type:str]
+    - ENC[AES256_GCM,data:bC5kM9Wy/s6M,iv:hNd/e04u3oZBF6OjPtJfM+FXla3ug/WVWq5bVTxBWPo=,tag:NNq8bp4NsLfxrDmqtZZUkA==,type:str]
+    - ENC[AES256_GCM,data:mAhChr3JsuVKDSMRM8CwnRD4cw==,iv:XdkqodNaSyMI/4xbpxwDD7A5TbSz4yqx2IX8LeD0RrE=,tag:YB34FQ8qNJTaSb2hlFcaQQ==,type:str]
+    - ENC[AES256_GCM,data:LugWpPKwKGOa,iv:uN9FE/CYSP1D+QhIkJlvjsGVAXU4efYr0AWmmhtwGZU=,tag:8Sx/KiePQilsHGyI+vrWYw==,type:str]
+    - ENC[AES256_GCM,data:8wrxUUBu3bVxYEFQp5hisHCuLQ==,iv:AD7/OnzDMApLMY7DSogULnukSUyuCSWn0bgw4sifAcc=,tag:w2FCx6wVQVowyAuWsVrBxg==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-06-08T18:22:31Z'
-    mac: ENC[AES256_GCM,data:BRWopW4wmQUfa8QDX6+06mX1lNh0vzZUSr7RzdC389PRd/vAG0zl1pXp/8Z5TmeF+FBb0XSonggT1CiWoL4tl9LZ0mWcvxiyCgM0im00GgJCeNCkQcxhspGHMMpasIkzLVQDkDutEBUfjCHM3m9Ud6qzOAt/sBBq03UkybtYEFg=,iv:P6VaLXTeWr7GTYal4zrdvsd65gXb7gm3MXC1U45W4MQ=,tag:LWJhpIMbK0R7uQqNazCt+w==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:31:24Z"
+    mac: ENC[AES256_GCM,data:VvAgfP3HIPWpuj0dIgzh9aTtx5Uca/GIJ/DrdaPVCUXpdxD4YRewUnnv+TZVb9zE2YKxBs5zwOCXMbMXL/sZajEhtVRpN7yp83UXAw0jwNVZIIGD8uo9i4db8o3uTG0MPlDKADne99TptG6urzXptRcjlju++7PWXt1CTnbzPPw=,iv:wjLQR/PLNVsBIxpr4nEtw7I2RcmXOwG2uCbc9B9fyW0=,tag:b0KmhYbcrO2j6v2zXt77GQ==,type:str]
     pgp:
-    -   created_at: '2021-06-08T18:22:29Z'
-        enc: |-
+        - created_at: "2021-06-08T18:22:29Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAopQLi0DUSJui8IlgPRGCLTAir6lil7oGVTSV+OMvM261
@@ -38,9 +44,9 @@ sops:
             9bsA
             =EGSV
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-06-08T18:22:29Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-06-08T18:22:29Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAkSAXkA8+42BO8e4yayE4hrXjlxQxNVjFuPjvpInwd2NW
@@ -56,9 +62,9 @@ sops:
             jd37fiR7lWPXwOJXKEER4efPAA==
             =pFqa
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-06-08T18:22:29Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-06-08T18:22:29Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAffaveZdHU98LMtb1TEe/lOEdI7v3x4ZL/2BzkgAMfbF9
@@ -77,9 +83,9 @@ sops:
             50UA
             =Ru1W
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-06-08T18:22:29Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-06-08T18:22:29Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAFZ7Zsa9s+J/RHh5ck+ZstbIFMTnzic4qjQs1/Q3uarxj
@@ -92,6 +98,6 @@ sops:
             A3o2EMuOWuDI5Iho5QoXLtCSUlE2o3HasEfi9ZVnS+HCVgA=
             =/xtY
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/rekor.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/rekor.enc.yaml
@@ -5,19 +5,23 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:uswtyAH5tZtNi4kPTsrEgB9GOQ==,iv:ukBozXMKkDUZ7C2tbv2e0Ri5TgGcpUScgKt2GVlC4e4=,tag:WF3oKSxcGmHCDuZqeNuJLg==,type:str]
-- ENC[AES256_GCM,data:GTeb3baaaME1HkjCQY++/A==,iv:mdlIW+B1yBIftIstJhWPwOQBvR3/LKzpFthpfSZUpU0=,tag:C+XBdefZvVtAOMn1O5RRYQ==,type:str]
-- ENC[AES256_GCM,data:sbxKly1P+WS92b+C8eySmK8=,iv:2Jz/Z4zniygVQGAP4uHEoAA0xriE9Ruyxl5jr0BIQjE=,tag:boz/H4yNNE35HxbIyK+URg==,type:str]
+    - ENC[AES256_GCM,data:jlQZLqoH87I0fFg=,iv:NPpOjV/EnDBH2pADcnP5kfp17HkzZ0zRcoiuFtpj4hw=,tag:+5jypB7A49Qm8peFvFlh/Q==,type:str]
+    - ENC[AES256_GCM,data:uswtyAH5tZtNi4kPTsrEgB9GOQ==,iv:ukBozXMKkDUZ7C2tbv2e0Ri5TgGcpUScgKt2GVlC4e4=,tag:WF3oKSxcGmHCDuZqeNuJLg==,type:str]
+    - ENC[AES256_GCM,data:ddueKg==,iv:56FJGEdzHEVNs0KcDKui0u7h1TOy4XZpIR8ybj5NBHE=,tag:mNmZiXC3vndiv2S3Oiyyxw==,type:str]
+    - ENC[AES256_GCM,data:GTeb3baaaME1HkjCQY++/A==,iv:mdlIW+B1yBIftIstJhWPwOQBvR3/LKzpFthpfSZUpU0=,tag:C+XBdefZvVtAOMn1O5RRYQ==,type:str]
+    - ENC[AES256_GCM,data:dEvwPeHpcnK4,iv:lXduZLdsZ3QRcVWCoErpNj2KAJImlOes6P2JUOZyCtI=,tag:TQuuS2AgxKb2vLE6xg1siQ==,type:str]
+    - ENC[AES256_GCM,data:sbxKly1P+WS92b+C8eySmK8=,iv:2Jz/Z4zniygVQGAP4uHEoAA0xriE9Ruyxl5jr0BIQjE=,tag:boz/H4yNNE35HxbIyK+URg==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-03-11T14:06:29Z'
-    mac: ENC[AES256_GCM,data:alI9nBKIrIWKM5EvOp2VlbpRGQRTMoK4M+btBcswBL44uK8F16goIdqQlYJmkqJcY0h/teErN0t/Umpc9IymLSrwusxZc2L5wq6ZfQbJ0gmQWei9EsGROgdxwrD8R5ZSjwijdzzz94HpqBEcvBvtcHMLhAJUkheMkbRvSKRXQYY=,iv:kOJE/JR1cDyMdRir2K0+iKHf0QXc1wVoqUhvHATzCpE=,tag:WCwhEaGZyfaq7cUulnf4DA==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:31:53Z"
+    mac: ENC[AES256_GCM,data:5fgqSg1tk638+SFZpTVE4UbHdp7OloKhARWQc8U5OjslNSN8Ws187ksDm9KCpuZvdoRSLIkvbYF0EzMR+Z4EdpeegPgVuCbMCojSv729VqKgXQfPd2i8DWCnt9R+JivVh2mZCF0lXYrElDU/kWsViC736uFtOICkTOkDFC7GR5Y=,iv:SkJ3GHA94doNvNH2PJlMBkiqYbtWPc8r5YE9sDWTE1M=,tag:6QR52Eg5Y9HMedV1SJ3w8Q==,type:str]
     pgp:
-    -   created_at: '2021-01-12T17:24:03Z'
-        enc: |-
+        - created_at: "2021-01-12T17:24:03Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAb7Y2cY/KSoLioHHqILgZGYzwWldJ8otqj/JFZ4jmRlS6
@@ -36,9 +40,9 @@ sops:
             ndoA
             =kXmm
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-03-11T14:06:25Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-03-11T14:06:25Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAL8uQZ2kvvOqhAeeKBStF2cKjbWC/0ONCAfVPblx677Tw
@@ -54,9 +58,9 @@ sops:
             bkD+q5Lv9zu3I+JElIOb4fvMAA==
             =zcZP
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-03-11T14:06:25Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-03-11T14:06:25Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAKwe+QpcGp5b6mVrpA92yxoGG/dp7QTQoJhipICLfClMP
@@ -75,9 +79,9 @@ sops:
             RBYA
             =e+8J
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-03-11T14:06:25Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-03-11T14:06:25Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAZ4RNsf2QLABCil9bUIy9WrQG9Sl6tvU0pd7SuVBcq28u
@@ -90,6 +94,6 @@ sops:
             Xqekjao0MOBX5HlwdtJ7cG64/WmTUTc+fk7ivfKu0uFu6QA=
             =AWMl
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/sa-dach.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/sa-dach.enc.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
+    - ENC[AES256_GCM,data:00uI,iv:Yn1h1Jq9xZ3UOwGqTOTQWBynlGywhDrmj1ABTb82OW0=,tag:waMlF65bf/GlyZZHpGgYFg==,type:str]
     - ENC[AES256_GCM,data:QnhP44WnK/sev1rCvW4DqtM=,iv:TRLaVVbp0JRi10TgqZgPfThJCAhj09zN3uXN6SQzPBE=,tag:FljUYncatSNQL4cqK1h5ng==,type:str]
 sops:
     kms: []
@@ -12,8 +13,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-03-31T09:57:16Z"
-    mac: ENC[AES256_GCM,data:zCvgCHPVdhc66UDRz5kf0IsYYwdabnU6hMEKZ0tcL0ojHIfDTVPotn2JvrA8mLV60voN0iOIMmFAj/wLLoGv3T5Am/fa3iw9NENeXgl5Rpw/XjH0SmWNEDaiRjgkv5wPreuMyQFgtIgA7m+SxayW932g8ujW4e+z01t2DFfNwgc=,iv:7PJCWAf/9bhNwFRiQ0iIA76bodXHZRNz0FaIgt7fxsc=,tag:A+VsnTAWyZB7KthzwYK+ZQ==,type:str]
+    lastmodified: "2021-07-14T20:32:04Z"
+    mac: ENC[AES256_GCM,data:FJ8n7V+WCmDiIhHG0Y5ZtyqguLWr41KwyuBP/3Dmt2/l7QUbNxIFI6sqxFFvXL6FwjWWgk9w8D7lbkkLa2llhr9t4pMdupjrHySmM0FfLH6rsQmb6ka9z7IFbGYUuiGw1ixN98IeWOswwCX5pp2BQ6O3yP5h7zlXflL2gAs583w=,iv:5TMiCoapdBx5rED1HFcu7kjrGx6gkUm9a2GuJeCAhfI=,tag:j7/O8rlBaxFeYaI07Y1Yqw==,type:str]
     pgp:
         - created_at: "2021-03-02T07:30:35Z"
           enc: |-
@@ -91,4 +92,4 @@ sops:
             -----END PGP MESSAGE-----
           fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^(users|data|stringData)$
-    version: 3.7.0
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/sdap-mslsp.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/sdap-mslsp.enc.yaml
@@ -5,19 +5,23 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:+ecRD0JCQNEIVjpiQEWZxsTaJ+Gw64xy,iv:HWqn/TXOcrfCKbB6piIQnwD9flFX/sqEJGDDsjFNLiw=,tag:vzTdGV5uWzszk76K3N9POg==,type:str]
-- ENC[AES256_GCM,data:JTDXNBD40HZPq91BSB7xPwjUAsF4Iw==,iv:n2RCE6LM93CxHZQR0RHsPUq98RJlyimJ7JmvQ/awmnY=,tag:JVdXrG6EcIQ+4V71wct2Cg==,type:str]
-- ENC[AES256_GCM,data:WRb0ylANuCLfdBGK+5He0V2s5Qjs,iv:1XqTrryX3Z4EABwNPNe8OIdJDkZOfDpU3tqzPr1/YAo=,tag:AbQ2ezT0cuhGAfhJHYr5Vg==,type:str]
+    - ENC[AES256_GCM,data:UiE59QgEu2cSlZjrUQ==,iv:ivUUYwwX/HxP0yUr1Se0iOM1hyKHIz8MSPbDGl/4FVA=,tag:eP4AdUo4RoD4Tpv21aXD/Q==,type:str]
+    - ENC[AES256_GCM,data:+ecRD0JCQNEIVjpiQEWZxsTaJ+Gw64xy,iv:HWqn/TXOcrfCKbB6piIQnwD9flFX/sqEJGDDsjFNLiw=,tag:vzTdGV5uWzszk76K3N9POg==,type:str]
+    - ENC[AES256_GCM,data:vA8yqdhjifw=,iv:xCzUh4K19jnaUTF0rsXpysjIN19HSJmpmJmP+BR2OeI=,tag:DIH4Y0TZNX3Mi1xvHpPgNw==,type:str]
+    - ENC[AES256_GCM,data:JTDXNBD40HZPq91BSB7xPwjUAsF4Iw==,iv:n2RCE6LM93CxHZQR0RHsPUq98RJlyimJ7JmvQ/awmnY=,tag:JVdXrG6EcIQ+4V71wct2Cg==,type:str]
+    - ENC[AES256_GCM,data:+SLuho2EpO8=,iv:4CjVOoJ+F9zq/se+QGlJ0NwiXMk9eV/o5/9FvMbVKs0=,tag:PBWRSamQ0EDepP7HIZRiVQ==,type:str]
+    - ENC[AES256_GCM,data:WRb0ylANuCLfdBGK+5He0V2s5Qjs,iv:1XqTrryX3Z4EABwNPNe8OIdJDkZOfDpU3tqzPr1/YAo=,tag:AbQ2ezT0cuhGAfhJHYr5Vg==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-03-26T19:13:51Z'
-    mac: ENC[AES256_GCM,data:1HnPI7YdLxbGdXxqHT2ir93bqX3UDNI80OztxbIVrk1VzFJZf2/e78c8y2TtfP3wsgHWtSuyYbJH5mQx5mQiJaS5g09tGDFQHhebcikwLlOlLZCgSVKrZmdIcDv9mVtT5ksM7wFh4ibJzOpGh6LFCyn817buZZt17WzTMejYB4Q=,iv:Kh+YembVdYDqfX1Jl8M9ETGCE66L/6PIz75L57KeawM=,tag:QxVXrFoVTOZXhvDOW3Fe1Q==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:32:20Z"
+    mac: ENC[AES256_GCM,data:qbcP805nc1fXuFxQ6Zy9W3khWjVKUj2wHfeiSHOkj1ButqqKK0Tk1uCies6kzTMB7IocM3ZAI2d2JHqkYZ7tzqUUlVWSgx7fsAwoNigrB9WEcZoU1DCki6lTCMjyv2vUKgUphDnQtn17iju2NJBrhuXTtX53WVa5Y6zM0Pqn8q4=,iv:IvJZvV4NBIXoiWPc29WMvFgYQpKVk9ILJAjV8z5S+18=,tag:yMJAl/uFmY/RoouIGOyPxw==,type:str]
     pgp:
-    -   created_at: '2021-03-26T19:13:49Z'
-        enc: |
+        - created_at: "2021-03-26T19:13:49Z"
+          enc: |
             -----BEGIN PGP MESSAGE-----
 
             hQIMA9aKBcudqifiAQ//bSQjdiw6j2YpusKcpGfyPbTMq+DgTtV+vW1B1wQCsm3B
@@ -35,9 +39,9 @@ sops:
             BUutf/mq3c/yptqKe243bsTShR/Z99kUuTtHo+0Cr7DQJaNZKnaMuKZaCds1
             =KQD+
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-03-26T19:13:49Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-03-26T19:13:49Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAZz56b5ydbWLWcfAnv/qdi7ZREVtOi8GKLstIOOjd6ong
@@ -53,9 +57,9 @@ sops:
             eWuQgP7AAzUqzeJgAGRi4WSEAA==
             =/i4f
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-03-26T19:13:49Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-03-26T19:13:49Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAMgDjnWeT4L4v3drOGljFpQZK7iL0Go0Jy04FMo1o9zds
@@ -74,9 +78,9 @@ sops:
             WqkA
             =dDc3
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-03-26T19:13:49Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-03-26T19:13:49Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAOkvNi1fjHY9rl9djRSOMjGvNqRa+/2jAcd8Euq/CHZUc
@@ -89,6 +93,6 @@ sops:
             n5tXTmzZSOBS5Jx9UC7iJXbwgXSniHh2pLvipaCBseEGXwA=
             =nKIV
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/sigstore.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/sigstore.enc.yaml
@@ -5,18 +5,21 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:xnxWcoMj4do1Q1vDI6faS/rhJA==,iv:IsgC11eXQLSZxHbxGEC68S2f1cWG7BLmPegLnZcVXsI=,tag:euORejZ/XtETqbMoMOtFOw==,type:str]
-- ENC[AES256_GCM,data:aQtHtTAUDZarzPIHJcPQD1g=,iv:xM45KpUOrnzE4NgoFm9qRMKZC38UZIqh/TfI128hEIE=,tag:hrhCE7/2n/6tdMtHYLOXzA==,type:str]
+    - ENC[AES256_GCM,data:JZ+SS0SzL8tScw==,iv:jE6N6VLModBZlhFUZSOd/gNfQBCDFr+sRFOr6PUilg4=,tag:QE0Bt8wn9NM0gEG1m026VA==,type:str]
+    - ENC[AES256_GCM,data:xnxWcoMj4do1Q1vDI6faS/rhJA==,iv:IsgC11eXQLSZxHbxGEC68S2f1cWG7BLmPegLnZcVXsI=,tag:euORejZ/XtETqbMoMOtFOw==,type:str]
+    - ENC[AES256_GCM,data:nlHdAFpro4NB,iv:o0h5WkbRdgWd6WbaEO06QqFBFRqsbdBnAMAx6G1bkdA=,tag:vO+Kuo4gn7PJAjbYqMo3ow==,type:str]
+    - ENC[AES256_GCM,data:aQtHtTAUDZarzPIHJcPQD1g=,iv:xM45KpUOrnzE4NgoFm9qRMKZC38UZIqh/TfI128hEIE=,tag:hrhCE7/2n/6tdMtHYLOXzA==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-05-18T11:59:54Z'
-    mac: ENC[AES256_GCM,data:Kj5ONF2LAzRZ41dUwGsYLannmS1sX+i/QXCS12qgotw7hc/pJQfNFDYFAm6rSP01SrsW/tDZdCsUMi+WBDNMKLdsVYZNXeP0EvMC8D/WKZWIuwPDabF3mi77cgiBs0rheKlpz60W5IHz3+iQij4dar+ZaCSzovFoUmc9/Fx/AQs=,iv:CP/FzL7+LK/qE8DUL8dywWNF1gEOk0EAJEMhzh8qQSk=,tag:O0+wYAsQf6lIqOcSmKX13g==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:32:31Z"
+    mac: ENC[AES256_GCM,data:q8Wkv9iO35ovreGSkY97oA3QUCXZRvx4G7iYCyvGp3lLsLFTCi7Slaf8ZFw8mQk08ELbMwvp8hlVr6P2X79YOO+wR9rAcwhpNGAKQZz8ahuI+HfkTNTpFL+ka6dFrMsfqarEQVfjd99aqY+ywOOAj4r/ASm5cKhaoeCgxqYDICk=,iv:T1faN2eE0lvyc5vWRMMhF510PsNg+4wk71NKS0iPgfQ=,tag:EC8w/bBGWspntdC46HOtzQ==,type:str]
     pgp:
-    -   created_at: '2021-05-17T18:21:24Z'
-        enc: |-
+        - created_at: "2021-05-17T18:21:24Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAI9RF3RV6SKA3LkpHXi2QHDQCsMTiTOo31zucFlhDhNhN
@@ -35,9 +38,9 @@ sops:
             jDIA
             =hGTw
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-05-17T18:21:24Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-05-17T18:21:24Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAg1AVkCiq/0Can8GckyEklD0I9OTUhcjWBneLMgFwJu4W
@@ -53,9 +56,9 @@ sops:
             h/SMHvD7Vt64AOKKhJx54cDbAA==
             =vEx6
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-05-17T18:21:24Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-05-17T18:21:24Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAH9fVVMsRTpiHv0C4CLpq0THVj9EFL8tCfbgblD5/380g
@@ -74,9 +77,9 @@ sops:
             DrEA
             =9CQ1
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-05-17T18:21:24Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-05-17T18:21:24Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAp1lVGJLAHS/aKyIOHyqV8ek8hS6wfU7q6IBLAeMqB4V9
@@ -89,6 +92,6 @@ sops:
             wwl15wYXNeBv5Ma+44uUdurproQw2EB92SviTvlqZuGuDgA=
             =HSRs
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/sre.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/sre.enc.yaml
@@ -5,11 +5,19 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
+    - ENC[AES256_GCM,data:BIKWbAU=,iv:MLOrAvyYAkm5p6g2RoZB2AHfK3E3xy/8L3soF3rcom4=,tag:W9+F9P+MpnMHpHSdqX7OKg==,type:str]
     - ENC[AES256_GCM,data:uDgWZDZACJiSMkgB+5DZ34Iycg==,iv:vyzVqP/O6iMfQS3mOjundlfsXvv4crjdL7XTH/CxDW4=,tag:5dwslZtsXqj/8euJayKV3Q==,type:str]
+    - ENC[AES256_GCM,data:TMEJct1w,iv:ilvQ6hOKvbBvKUpoHnOj/JKg/IbqrPOhnfIn5BXjZkU=,tag:a1W0GPLzlk3hX+jMRGHS0Q==,type:str]
+    - ENC[AES256_GCM,data:Zc4EAxmoxL62gh904aAGjrrGxw==,iv:v/Xv8OCqCp38kUYpDGT3/ciPKstj8GNexlYRwuXRL1U=,tag:pEO3VQl64pnS5lmPLPuWMA==,type:str]
+    - ENC[AES256_GCM,data:t2Jog0qHxCvVZGLjshBa,iv:CwjXX5HpSf/kVH+BLuh3r+oqOBg5YuHmKGaaE1TcAck=,tag:FAPLtMzN1cr8Bx+Wtcl4jA==,type:str]
     - ENC[AES256_GCM,data:hJwlc9vuAjCoPqwHUfNJdWdbTA==,iv:wJ4dQ3wkP79oRXpLN65dQkRzMOLWtMc8ucIn669sxDI=,tag:hC+CZUJCt3FPFT+1xpeIRw==,type:str]
+    - ENC[AES256_GCM,data:abFOOMj0C60x,iv:xCoyq+nuTw+gS6T8Zfr8aeaR2mZh8IJhCFkBuylHJ7I=,tag:+QxhdsCVAghbM1QEDxYUEA==,type:str]
     - ENC[AES256_GCM,data:tUkGkaIrZiitBT0RRXPUJ9g=,iv:FbuL3X6rO5iLv16d8/Gc17tSO3UXn7YU3o262kd47fI=,tag:kY5DmpU4S30rmozwuXDc5A==,type:str]
+    - ENC[AES256_GCM,data:kTWItDDP8+M=,iv:tLihdnWJugaWkCk0KqHkYqF0+Aen6bMI0xLElvOZ3FU=,tag:lWuBb/LOJonY/SLw16p00A==,type:str]
     - ENC[AES256_GCM,data:2Vp0fnjuSsGpf0LpvblG8os=,iv:113/6VNZ7PI5sgDY8sOLacwQHgrflkWzu+ySjrFpo3w=,tag:roStGyabnqNf4hKwjGGkSA==,type:str]
+    - ENC[AES256_GCM,data:+HGHx34quw==,iv:oRN5JkwF9SWPck+l81MVgZdpWdmOXigeEqAHgeZ7IaM=,tag:eIpeFaQkn768lmnnSoNVwg==,type:str]
     - ENC[AES256_GCM,data:Wp3ABajqYaaKqNy2TYSacg==,iv:5ZeC7zKlGMCMHdOLTl9ZAVTfvboKjkK8/Ed8zlJN17o=,tag:+O/hqwdbtR8aLRkbE89vUg==,type:str]
+    - ENC[AES256_GCM,data:44N7oawI,iv:JJNnousETMHsTCjATtGhXGgaokohmeyBuwQSUjheDI8=,tag:YtDLLHB2JgyvonsDPaJtcw==,type:str]
     - ENC[AES256_GCM,data:k7rBVMMnd/q4FXH2gJd22q1w,iv:afQ/arERkywspOaV5L9+814t3A9W8m2WsoHmsfuLDqE=,tag:Jj3KD+Pv61QZvNVkbb29Yw==,type:str]
 sops:
     kms: []
@@ -17,8 +25,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-08-04T13:42:56Z"
-    mac: ENC[AES256_GCM,data:RaL60QYGBVKH0w+p0EvEYzZU8+4+f6o5W+E6Fhzn7so0NMbYkQmvQJCHbheVIlNF2jpzc7E3GIJiJp8SFaP/+bTg0gHtsoV+IIB3XU+sVrKk4dvK09Lta2jbgRxkJY7aqP9mfVOnitrW3Oi0qsmkNxP+TZtMWD4bMk+FQo2tudk=,iv:wp7ehavCNZKRKztDK3178anuoZHZnkyoLk5aE3o2WIQ=,tag:ePzls1uZvk0QUWIkwaMCEg==,type:str]
+    lastmodified: "2021-08-12T13:00:42Z"
+    mac: ENC[AES256_GCM,data:z00MnNGQBidEo/RdCibj6pyO2lKU/Kfvjh4EWJHVZELfNYReTk8lPpx7XwS56Sun9EvS4Bnfss8yqG018Gtkd5qdw7kfPLUTWHLEJyrSJzadOIYbhiqnNlTGxXZZGkk8uOhaNW7uOlJSSXClMkzVgCYg2EryRKKKCOFLBUQOIo0=,iv:i+Tte2PdlLTKyxoSUqyMVs/Ik0uMK/qYSB5piSzQMgc=,tag:6sv33gwqkQJ1Lju8KQEIDA==,type:str]
     pgp:
         - created_at: "2021-07-27T07:09:40Z"
           enc: |-

--- a/cluster-scope/overlays/prod/common/groups/team-pixel.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/team-pixel.enc.yaml
@@ -5,7 +5,7 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-    - ENC[AES256_GCM,data:YdBI+3KI+BjY+g==,iv:zc5ruSp1uxoDT53uokA5g+jT2cHVcqVwfGju4eaVXLU=,tag:43AwvVxrEMfZM/j4fhW60Q==,type:str]
+    - ENC[AES256_GCM,data:+gmm4XOjYItd3Q==,iv:YOLK4PeLncbk/L4us3KjeJcze4UAUIFJlkDOlTsUYhg=,tag:WVAv+9nW/OZAWyCA3x4qmQ==,type:str]
     - ENC[AES256_GCM,data:FGwZNAXAze7FT1k/GuKAvQ==,iv:xp2fQO+gPO5/KuqQIsyZ7hGsOdx7BR1cN5l+mq1nHjw=,tag:nkdc/pLT+nJDtp3C5CwY7g==,type:str]
 sops:
     kms: []
@@ -13,8 +13,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-07-14T20:33:21Z"
-    mac: ENC[AES256_GCM,data:xhkiVs5PBZF3xHgUm5hdUuxHAJGSpafbvHKMp675RrFoPO5BV7tfWGYc2sgm6ylKmU4F1ei9QmxdyKYAaY3Fm4SvYM5Lc+FN/g76teO3yZATA3Rr5lTpzvwHLklWd5hj+x1eh1K3Bj5m2lmqsECg3ugbWGFeK1oWvnbc2nLz3Uk=,iv:bNdZvNgMyyP0GOOqPIIGpvKzDAWAXuGbLxr44iZDvcw=,tag:BYPR+1bN4RWM2caKowaANA==,type:str]
+    lastmodified: "2021-08-12T12:54:16Z"
+    mac: ENC[AES256_GCM,data:ZSBj+KM2Dmvq+ChAoQ/g3xWf/df048iVI6she1PnkyvElByDwOwQ4VaLx3f0lMqGGHRkMTlr8IYVaW3Jc3lg265BxgoBljnMYow9bDvxfVJiHDDPyEUc0eWr/bXvgt0+VN0MP/E3NaPpbufXy1ZQut+qUqhCqC1BwHEysoj3Zlw=,iv:UZW/qKBD8zKHc/fJXXiywHt+LeSxXOb++2k39F535OI=,tag:oJ0RYWsJSy++ard5J6DJyQ==,type:str]
     pgp:
         - created_at: "2021-05-04T02:17:39Z"
           enc: |-

--- a/cluster-scope/overlays/prod/common/groups/team-pixel.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/team-pixel.enc.yaml
@@ -5,17 +5,19 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:FGwZNAXAze7FT1k/GuKAvQ==,iv:xp2fQO+gPO5/KuqQIsyZ7hGsOdx7BR1cN5l+mq1nHjw=,tag:nkdc/pLT+nJDtp3C5CwY7g==,type:str]
+    - ENC[AES256_GCM,data:YdBI+3KI+BjY+g==,iv:zc5ruSp1uxoDT53uokA5g+jT2cHVcqVwfGju4eaVXLU=,tag:43AwvVxrEMfZM/j4fhW60Q==,type:str]
+    - ENC[AES256_GCM,data:FGwZNAXAze7FT1k/GuKAvQ==,iv:xp2fQO+gPO5/KuqQIsyZ7hGsOdx7BR1cN5l+mq1nHjw=,tag:nkdc/pLT+nJDtp3C5CwY7g==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-05-04T02:17:40Z'
-    mac: ENC[AES256_GCM,data:ECyDZiLwOs5dikc3Libxl/z0DUWB2DpljxQT4qk+MbhnimV66wa2UP1hAozdbJrATgCNeGEwqUJkmSE8yEO6mp/esRqah4DOo2mmA0DdaspW2jFgw8Ryx8TcvCsuRyRSzi37mxD3UYp7Km6850Ru58ZrEZoeQs1joGT37J07dic=,iv:gaOX/3CrvK9dM4pnIlS3bIMo7YH/K2U0meTRQW07lXo=,tag:xTXWANXg6cdXYaI9QAlUrw==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:33:21Z"
+    mac: ENC[AES256_GCM,data:xhkiVs5PBZF3xHgUm5hdUuxHAJGSpafbvHKMp675RrFoPO5BV7tfWGYc2sgm6ylKmU4F1ei9QmxdyKYAaY3Fm4SvYM5Lc+FN/g76teO3yZATA3Rr5lTpzvwHLklWd5hj+x1eh1K3Bj5m2lmqsECg3ugbWGFeK1oWvnbc2nLz3Uk=,iv:bNdZvNgMyyP0GOOqPIIGpvKzDAWAXuGbLxr44iZDvcw=,tag:BYPR+1bN4RWM2caKowaANA==,type:str]
     pgp:
-    -   created_at: '2021-05-04T02:17:39Z'
-        enc: |-
+        - created_at: "2021-05-04T02:17:39Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAxaPFQQ6YFuOjQqBSD/g/p62FVT9T6IzRDcxHYkn0aPem
@@ -34,9 +36,9 @@ sops:
             evMA
             =TlOD
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-05-04T02:17:39Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-05-04T02:17:39Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwARZEteJx3GI3dOoP0tmHROPks4HAWfdQUpkKRE+l0Kb+4
@@ -52,9 +54,9 @@ sops:
             +AjMID91RfzmSeIf4OD94QBbAA==
             =sFxy
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-05-04T02:17:39Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-05-04T02:17:39Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAK1V8SdJn1pdhc2XnZUD2/nC74XzvEHg5+Vh1pZXzZyJR
@@ -73,9 +75,9 @@ sops:
             nb8A
             =lMOb
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-05-04T02:17:39Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-05-04T02:17:39Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAK7EvVxCzZZMr7K6ZKAZhPETU62kxrWQEwoTwKgNOaJos
@@ -88,9 +90,9 @@ sops:
             1VUUdy8RgODb5H0UDZS5v2MIaZwbnfvlC9ziJYrbAeGSxgA=
             =fRVW
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
-    -   created_at: '2021-05-04T02:17:39Z'
-        enc: |-
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+        - created_at: "2021-05-04T02:17:39Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA06VcBSMalACAQwAQAAOMI/ajXXBH0ytuopZqZ3USDp7PketAar+8aP9hNXQ
@@ -106,6 +108,6 @@ sops:
             BqfHyEUoxLNH7uIWyuJd4f+LAA==
             =cSys
             -----END PGP MESSAGE-----
-        fp: 16787415FA4A18A006599425A5D655E1C8499F03
+          fp: 16787415FA4A18A006599425A5D655E1C8499F03
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/thoth-devops.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/thoth-devops.enc.yaml
@@ -5,19 +5,25 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:FDzD2ecEEpSksUJJEpGR9vY=,iv:ZH/9w3GbHzaCc49xZ705n4MK6aKp6IsuU2xwBFDYcHY=,tag:mPGIUZwYaSP+U/05PcMKjA==,type:str]
-- ENC[AES256_GCM,data:QUqEr1kVUZMoYPuFhHTUI7fmAA==,iv:yklTgdnp33WzT6WprU5CmhdRiafjxDMLxTcTfUSOwQg=,tag:5IiBWA/tmI2aumpKZBoRSQ==,type:str]
-- ENC[AES256_GCM,data:KpR2q3H05B2veTb2weeeLYkORg==,iv:72NKIIgdiG1x/0B6EryqiKLvJM4B7HL5YiU+GmBHh20=,tag:vp40f25hoIo3KLG8WnUoww==,type:str]
-- ENC[AES256_GCM,data:DNaYkJ+2m+fz/BmPE9WWf0I=,iv:ZVYo3qrcgFDn99tA6KwV7z6rdt3EzPokc42MdF0uWxA=,tag:PW+sieZwlfEV1O4AJvlzjQ==,type:str]
+    - ENC[AES256_GCM,data:bdru8Gs=,iv:/SyVinfqHO5EdDS1qJAFnaxU9gbT7pynZlnqc1TvyXQ=,tag:t3LIms3EKzsQjWNjwpKgoA==,type:str]
+    - ENC[AES256_GCM,data:FDzD2ecEEpSksUJJEpGR9vY=,iv:ZH/9w3GbHzaCc49xZ705n4MK6aKp6IsuU2xwBFDYcHY=,tag:mPGIUZwYaSP+U/05PcMKjA==,type:str]
+    - ENC[AES256_GCM,data:8KzV2gec/uSd,iv:EtGs/aWGuym/5R3hfsGBLnpBnmIjl+fnYQDPbi1zhlA=,tag:eqliCPqYDR34P0Xgf3D01w==,type:str]
+    - ENC[AES256_GCM,data:QUqEr1kVUZMoYPuFhHTUI7fmAA==,iv:yklTgdnp33WzT6WprU5CmhdRiafjxDMLxTcTfUSOwQg=,tag:5IiBWA/tmI2aumpKZBoRSQ==,type:str]
+    - ENC[AES256_GCM,data:InhVSEa3,iv:VZGZAXAkQyHMZZ3Jj/j9IlnhVOgO1UsL8z59Zks5cks=,tag:KqRioL7PyrC0/RZc05Ll2A==,type:str]
+    - ENC[AES256_GCM,data:KpR2q3H05B2veTb2weeeLYkORg==,iv:72NKIIgdiG1x/0B6EryqiKLvJM4B7HL5YiU+GmBHh20=,tag:vp40f25hoIo3KLG8WnUoww==,type:str]
+    - ENC[AES256_GCM,data:n+S6hhUE+vIe,iv:EkkmajJ09lVh37w0RBgqQtdRNTHH2+uC/DwqDQr6jzg=,tag:CNSoT2EiwLEDKRypfikReg==,type:str]
+    - ENC[AES256_GCM,data:DNaYkJ+2m+fz/BmPE9WWf0I=,iv:ZVYo3qrcgFDn99tA6KwV7z6rdt3EzPokc42MdF0uWxA=,tag:PW+sieZwlfEV1O4AJvlzjQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
-    lastmodified: '2021-04-07T15:07:03Z'
-    mac: ENC[AES256_GCM,data:X+3AJysD9VFUz1WmgWFwFNpIyVG5+j37xi8ebiR4A0z9xCOxlP5yWNTYDtvMTZ92+Ml0k+jPwaF0ZbjtCRF/4gwuPFUIQ0por8jwZddyEiXiCn4lpbyKOX5YJHPgC+Vrca0UBTEyglQluYdoOlpj0I/JKY5jzSITN8drpObITGM=,iv:31ou+6ARHTVu+fX8YNt+tQ94TMpzVpmgrr6um2HVN24=,tag:UYyJyOvZ3ZhorHCziyn+vA==,type:str]
+    hc_vault: []
+    age: []
+    lastmodified: "2021-07-14T20:33:35Z"
+    mac: ENC[AES256_GCM,data:fZu5o9aA1UbFkF/NpNBXtNrW5gUo69XJH/fdpoAZdT6Sa5ho8mgoBWiEHu0jH/KeqDZWDsf/UoEnOxnKZv4GK8mCym44qZYURMx+As2BjtmRuKg+20JlwfXubgzhTx/uwa/tBCmn1YxyGX20C5JgGIM2FlMkIJ9PKu1z3FDGMgk=,iv:BCZ8wgVHQRluKAJrpB3rDJfUxSigzrf/CDnwZtQEcdc=,tag:vVCn38/8vIIUNQqFzoodvA==,type:str]
     pgp:
-    -   created_at: '2021-04-07T15:07:03Z'
-        enc: |
+        - created_at: "2021-04-07T15:07:03Z"
+          enc: |
             -----BEGIN PGP MESSAGE-----
 
             hQIMA9aKBcudqifiAQ//SDj5aMGoOS9rh5ozSkDt47YQdNOsUuRmJorUO475lYao
@@ -35,6 +41,6 @@ sops:
             +03aIPr8/EdWOsJdUKdahywcJ1WdqILhFUPyeZMvnBFUNiW6+epYXPzZxVYNneo=
             =G8x1
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
     encrypted_regex: ^(users|data|stringData)$
-    version: 3.5.0
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/thoth.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/thoth.enc.yaml
@@ -5,23 +5,31 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:UudExMPhizTj7GJAlLiFQEk=,iv:l5DKt6mFOKzqVMqS5CWquMFS+yXPIsrar6IhxsUUcek=,tag:SxojJRdc2bRpbX6xmi+R1g==,type:str]
-- ENC[AES256_GCM,data:y+UvB7FDY3L0OR0BmGTeFHyZrw==,iv:syl/vrTf3+YsHPJv+HR5VnWxJLl7pemMgLGv880u3Bc=,tag:0epOmdQC4q9JiLb5cvFBlw==,type:str]
-- ENC[AES256_GCM,data:KMXV1OWh0e6rgR8oOV3nYSQ/Mg==,iv:GymdcoPCjeDt57+ljSjyLHq2eBxjsDqhzn4ywL3Esgg=,tag:kBMLJGBOXwRewCXQE7ijOg==,type:str]
-- ENC[AES256_GCM,data:czLs3ssPdwXfuf/90x5j087YWg==,iv:XdbnfzU7sqcwAbi7XKGpqKOiqeCQzfriWBMWF6rG8M0=,tag:CqeXgfj1sjDiXMEFI3fb4Q==,type:str]
-- ENC[AES256_GCM,data:kOn0043wv7t0T6H4Q4fctLM=,iv:sNAhmck3gQRWT+rp/9hzNTZ3FPaPV3OVczMAfiFKl+U=,tag:JxUvt0KAv2dd0NbtDEQPXA==,type:str]
-- ENC[AES256_GCM,data:0MAyr2KLl4sF110aaAhxaVfVeg==,iv:LyRzvHShChKUzXOAZNYWgxs7Xu9RHIB7NHEHw0Mkk58=,tag:QGMEB8U7HLHVGqIOgdkVDQ==,type:str]
-- ENC[AES256_GCM,data:rxfbzymWx/aO56Tt0Kh2QJt/mA==,iv:lLbLUgI8Yh73RPQGmTvxKW4fuSFDIdwjdxrM+pgiD4I=,tag:qUNc6q2QnNhUkbd7sDQRTg==,type:str]
+    - ENC[AES256_GCM,data:IYkKMEM=,iv:nl8Ty/gE6pfl+ge8b8LCNPS0AEVTm62GcdOC/nRYILI=,tag:+7qGWx3nbo0nj5ssG+LfIw==,type:str]
+    - ENC[AES256_GCM,data:UudExMPhizTj7GJAlLiFQEk=,iv:l5DKt6mFOKzqVMqS5CWquMFS+yXPIsrar6IhxsUUcek=,tag:SxojJRdc2bRpbX6xmi+R1g==,type:str]
+    - ENC[AES256_GCM,data:jG+dYp9AETso,iv:yojaPoY2bEi5KHDDEV/iDi26135Hc1g64jcz6NMQCS4=,tag:ElhPEOeqM5yLPU5O3NitFg==,type:str]
+    - ENC[AES256_GCM,data:y+UvB7FDY3L0OR0BmGTeFHyZrw==,iv:syl/vrTf3+YsHPJv+HR5VnWxJLl7pemMgLGv880u3Bc=,tag:0epOmdQC4q9JiLb5cvFBlw==,type:str]
+    - ENC[AES256_GCM,data:ZvpJpyhL,iv:0kMr9ApQvCBlYHQqMISC90o73H9qgInEGazHrWEDTvQ=,tag:1UDWnnUs6+wUoaC5hAmpbw==,type:str]
+    - ENC[AES256_GCM,data:KMXV1OWh0e6rgR8oOV3nYSQ/Mg==,iv:GymdcoPCjeDt57+ljSjyLHq2eBxjsDqhzn4ywL3Esgg=,tag:kBMLJGBOXwRewCXQE7ijOg==,type:str]
+    - ENC[AES256_GCM,data:wYd9j9q2UQw4SoAwFe4/,iv:iUZJbU4GaNC+w6cVC7hiJ2B3mPD8udor68v6oAL63t4=,tag:RQdfsBC2D2Nh5qEukEZacw==,type:str]
+    - ENC[AES256_GCM,data:czLs3ssPdwXfuf/90x5j087YWg==,iv:XdbnfzU7sqcwAbi7XKGpqKOiqeCQzfriWBMWF6rG8M0=,tag:CqeXgfj1sjDiXMEFI3fb4Q==,type:str]
+    - ENC[AES256_GCM,data:QyDEX9s8v0RR,iv:XaSbQLO4qBb+i9Ke4ezkMzj9d541M1/SfJ2j9Iam5Rw=,tag:1AFJ4EM1UhQ8Wmm22aM6XA==,type:str]
+    - ENC[AES256_GCM,data:kOn0043wv7t0T6H4Q4fctLM=,iv:sNAhmck3gQRWT+rp/9hzNTZ3FPaPV3OVczMAfiFKl+U=,tag:JxUvt0KAv2dd0NbtDEQPXA==,type:str]
+    - ENC[AES256_GCM,data:16SaEwuX/sLWOIA=,iv:rCdRfb21rMr9gNr78giVE9umPOe3SF0lYhTgZ2al2VY=,tag:txjyFZglrmBdOvlFencCTQ==,type:str]
+    - ENC[AES256_GCM,data:0MAyr2KLl4sF110aaAhxaVfVeg==,iv:LyRzvHShChKUzXOAZNYWgxs7Xu9RHIB7NHEHw0Mkk58=,tag:QGMEB8U7HLHVGqIOgdkVDQ==,type:str]
+    - ENC[AES256_GCM,data:aHCX/qYWkOw=,iv:XnJYFKeesQeaUdfoukzbRZVohq7AJR86D5Gpoti25yw=,tag:K3fVvOzyhN8mhtHSAHjvBg==,type:str]
+    - ENC[AES256_GCM,data:rxfbzymWx/aO56Tt0Kh2QJt/mA==,iv:lLbLUgI8Yh73RPQGmTvxKW4fuSFDIdwjdxrM+pgiD4I=,tag:qUNc6q2QnNhUkbd7sDQRTg==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-06-17T14:06:50Z'
-    mac: ENC[AES256_GCM,data:PQDprz5YxmN5puITEPYAbKgchl0dfFOLKeCUpnguVquFjNpE7L/38JT1cnP9dL+OyhVr0HXT2MLQRuGWzpsdyUIXWTw5ydAUpnP7ODWDLeTlBo4Y0AOkaEDoIK0gyC8CozCSHYjVAv2dOlVZ/waaGeh70lMRHze9u5pAnN71afM=,iv:XqWt1SV1xUjkjVLkp8QsLHTrvWNdsd6PKQxq2MhttXw=,tag:own6hafN0BaYjbVT3pS4Xg==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:33:08Z"
+    mac: ENC[AES256_GCM,data:Go8+ihVquY11SrDOaNJpXVe+HImy4RKbYVPTlfC2noNN6teKDBWezKR8NLzwHHbxa3hUNMfJuGamL9CamHqSgV78Tu7bg0SiHOpPj/zIbWk/oTGK5B00PntATMzO1aFTEkJEKjkYLOcmaAUkzsc30c5l8WS93UWHk1PSrTplWlw=,iv:uXvLaJiZRe0vXsFMLxTxnlf00zvSxNcB5zCVqEVyZtw=,tag:c2PKk6UloTN2ItI+qXx7ig==,type:str]
     pgp:
-    -   created_at: '2021-04-07T15:06:53Z'
-        enc: |
+        - created_at: "2021-04-07T15:06:53Z"
+          enc: |
             -----BEGIN PGP MESSAGE-----
 
             hQIMA9aKBcudqifiAQ//WgTiWGPBSFkxyy776h9v1T3lEvWY87PGDPEsP1DzkvpP
@@ -39,6 +47,6 @@ sops:
             1EGkPq3253tI+Kt5pUH4KurqQDggEa6q5PU5uXEkJU+3bOufi51ic9YEGszm4Ug=
             =On28
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
     encrypted_regex: ^(users|data|stringData)$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/thoth.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/thoth.enc.yaml
@@ -11,11 +11,11 @@ users:
     - ENC[AES256_GCM,data:y+UvB7FDY3L0OR0BmGTeFHyZrw==,iv:syl/vrTf3+YsHPJv+HR5VnWxJLl7pemMgLGv880u3Bc=,tag:0epOmdQC4q9JiLb5cvFBlw==,type:str]
     - ENC[AES256_GCM,data:ZvpJpyhL,iv:0kMr9ApQvCBlYHQqMISC90o73H9qgInEGazHrWEDTvQ=,tag:1UDWnnUs6+wUoaC5hAmpbw==,type:str]
     - ENC[AES256_GCM,data:KMXV1OWh0e6rgR8oOV3nYSQ/Mg==,iv:GymdcoPCjeDt57+ljSjyLHq2eBxjsDqhzn4ywL3Esgg=,tag:kBMLJGBOXwRewCXQE7ijOg==,type:str]
-    - ENC[AES256_GCM,data:wYd9j9q2UQw4SoAwFe4/,iv:iUZJbU4GaNC+w6cVC7hiJ2B3mPD8udor68v6oAL63t4=,tag:RQdfsBC2D2Nh5qEukEZacw==,type:str]
+    - ENC[AES256_GCM,data:JLrAkhoQUlDDtARAjC22,iv:y5QxiHb6CCauVTUfCx0t2N8qGHCZpqOazV45iMXr8UM=,tag:Sbea8IIUgybLJvbIQBvBfw==,type:str]
     - ENC[AES256_GCM,data:czLs3ssPdwXfuf/90x5j087YWg==,iv:XdbnfzU7sqcwAbi7XKGpqKOiqeCQzfriWBMWF6rG8M0=,tag:CqeXgfj1sjDiXMEFI3fb4Q==,type:str]
     - ENC[AES256_GCM,data:QyDEX9s8v0RR,iv:XaSbQLO4qBb+i9Ke4ezkMzj9d541M1/SfJ2j9Iam5Rw=,tag:1AFJ4EM1UhQ8Wmm22aM6XA==,type:str]
     - ENC[AES256_GCM,data:kOn0043wv7t0T6H4Q4fctLM=,iv:sNAhmck3gQRWT+rp/9hzNTZ3FPaPV3OVczMAfiFKl+U=,tag:JxUvt0KAv2dd0NbtDEQPXA==,type:str]
-    - ENC[AES256_GCM,data:16SaEwuX/sLWOIA=,iv:rCdRfb21rMr9gNr78giVE9umPOe3SF0lYhTgZ2al2VY=,tag:txjyFZglrmBdOvlFencCTQ==,type:str]
+    - ENC[AES256_GCM,data:SR88qXrGVJibSVo=,iv:AH2cB6rH27AmyUSBn1wghrwO5hyLtWrvNkjJ6dCYx6o=,tag:Ju1qp5bKOHWRWUrvk64yGQ==,type:str]
     - ENC[AES256_GCM,data:0MAyr2KLl4sF110aaAhxaVfVeg==,iv:LyRzvHShChKUzXOAZNYWgxs7Xu9RHIB7NHEHw0Mkk58=,tag:QGMEB8U7HLHVGqIOgdkVDQ==,type:str]
     - ENC[AES256_GCM,data:aHCX/qYWkOw=,iv:XnJYFKeesQeaUdfoukzbRZVohq7AJR86D5Gpoti25yw=,tag:K3fVvOzyhN8mhtHSAHjvBg==,type:str]
     - ENC[AES256_GCM,data:rxfbzymWx/aO56Tt0Kh2QJt/mA==,iv:lLbLUgI8Yh73RPQGmTvxKW4fuSFDIdwjdxrM+pgiD4I=,tag:qUNc6q2QnNhUkbd7sDQRTg==,type:str]
@@ -25,8 +25,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-07-14T20:33:08Z"
-    mac: ENC[AES256_GCM,data:Go8+ihVquY11SrDOaNJpXVe+HImy4RKbYVPTlfC2noNN6teKDBWezKR8NLzwHHbxa3hUNMfJuGamL9CamHqSgV78Tu7bg0SiHOpPj/zIbWk/oTGK5B00PntATMzO1aFTEkJEKjkYLOcmaAUkzsc30c5l8WS93UWHk1PSrTplWlw=,iv:uXvLaJiZRe0vXsFMLxTxnlf00zvSxNcB5zCVqEVyZtw=,tag:c2PKk6UloTN2ItI+qXx7ig==,type:str]
+    lastmodified: "2021-08-12T12:54:37Z"
+    mac: ENC[AES256_GCM,data:NO1d+IOkKt23tUFhd51/59d/mU6TNbfyMdydmwcDlqVFWIW+7/cWNA6vDLaqE1SS9LKH6KHrRaLz4jpv+ocsjSywHH9d0SWqrG4yFyKtzS5T6rhGj6OzneOidFOJqCgkcv8CWrGrKlzi1Te+LdHr0SFMvpxdz2QpbfCaLJY3ZaE=,iv:B++Gy4NlY3xJAmLoIrmfndAt9x3g8U5RVIcIcGPTcj4=,tag:CkxCnPlfV8I/82WSwlYqAA==,type:str]
     pgp:
         - created_at: "2021-04-07T15:06:53Z"
           enc: |

--- a/cluster-scope/overlays/prod/common/groups/uky-redhat.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/uky-redhat.enc.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
+    - ENC[AES256_GCM,data:pIBQPJ/aZT8=,iv:WRLdZXOFfP29Rf4UC3iwgGrgsdNe7Hx4BQgMfkergUg=,tag:4/1HBH/1bzC3ZwpAcPfYQg==,type:str]
     - ENC[AES256_GCM,data:X4KpHoCQZG1hCfgQwN+dDlgVyqI6Cw==,iv:flCCwDdYKb8YcTbhYU5rGcVeVZMmfmKAIrVGB4d+WVY=,tag:qr41Rab9dlFDct0uw6bm6w==,type:str]
 sops:
     kms: []
@@ -12,8 +13,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-04-06T15:07:35Z"
-    mac: ENC[AES256_GCM,data:2gP/5sVeaKV2kpzhxTFrdcLj+62KBfA4HAFiV81YBCnc7ETENfPbVmPJhRzz4I2H4KYaIvjIQQUOQnjijIEf5FOH1OBfdCVygeiesF2NDuI1+2ytuhVBG0cTqNs9VOqQ7BFVflbsSVH7YKCFJhm0kOHH8ArQ40ZOx+3kIGwn/AA=,iv:qWKwfV2D3W7Ib5WlTYEkndUtBbt3mkdrgcuTXLRCXuM=,tag:3kn53UoGXPZHxy01F1yfgQ==,type:str]
+    lastmodified: "2021-07-14T20:33:53Z"
+    mac: ENC[AES256_GCM,data:9Y3/HO0Im4cjXbCznIrF5oY8d2IKo8B48JCbj3+1ZbY+N9tGb+YT10GDxGaJrtDjA/j2FMAQCIDGWTShXzn0n9hVfhLWyZayG7NtCo1tTpUeHXijaWBhzrzMPil5pp6Lx7fpM7ztNVKkbSJf7vq497+q+sQ/8gmf22QziHf89Dg=,iv:+zm/uMc5EHMDe/e3RTuRmzaveL4sV1XVODL1ETY2oU8=,tag:BggUluXnR6PqTZ238sC5fw==,type:str]
     pgp:
         - created_at: "2021-04-05T18:14:51Z"
           enc: |
@@ -90,4 +91,4 @@ sops:
             -----END PGP MESSAGE-----
           fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.7.0
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/common/groups/uky-redhat.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/uky-redhat.enc.yaml
@@ -5,7 +5,7 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-    - ENC[AES256_GCM,data:pIBQPJ/aZT8=,iv:WRLdZXOFfP29Rf4UC3iwgGrgsdNe7Hx4BQgMfkergUg=,tag:4/1HBH/1bzC3ZwpAcPfYQg==,type:str]
+    - ENC[AES256_GCM,data:KzeN0yPmJIU=,iv:oHklMUBoKsnHPbzVGPBenaOSGkub2QLM0zxYjYv40Jk=,tag:Y971OAE9MLfaH7wvSz0eFw==,type:str]
     - ENC[AES256_GCM,data:X4KpHoCQZG1hCfgQwN+dDlgVyqI6Cw==,iv:flCCwDdYKb8YcTbhYU5rGcVeVZMmfmKAIrVGB4d+WVY=,tag:qr41Rab9dlFDct0uw6bm6w==,type:str]
 sops:
     kms: []
@@ -13,8 +13,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-07-14T20:33:53Z"
-    mac: ENC[AES256_GCM,data:9Y3/HO0Im4cjXbCznIrF5oY8d2IKo8B48JCbj3+1ZbY+N9tGb+YT10GDxGaJrtDjA/j2FMAQCIDGWTShXzn0n9hVfhLWyZayG7NtCo1tTpUeHXijaWBhzrzMPil5pp6Lx7fpM7ztNVKkbSJf7vq497+q+sQ/8gmf22QziHf89Dg=,iv:+zm/uMc5EHMDe/e3RTuRmzaveL4sV1XVODL1ETY2oU8=,tag:BggUluXnR6PqTZ238sC5fw==,type:str]
+    lastmodified: "2021-08-12T12:54:45Z"
+    mac: ENC[AES256_GCM,data:UyF5ZZM6UUW+z3RNBdeOWIRfas4/3cEQ1Nj/xIOT6wIULuMenHnGgNytfS1NI8oT3uRQzJxAMGOqXAZleUfGmYUNOkIPO6jr+dkNQKcboPy9KGS+cTVQDd6Mi99DQrleub0usXYMu0Ms1KiIlTpGsMP8LyWwx0pd8hoL6L0JY8A=,iv:QbCoCweHx0zDndjPWlQi/xvnRqpBzSlqTYP3TnWdX10=,tag:8DPpuhM5sHZfQTXpt3QXiw==,type:str]
     pgp:
         - created_at: "2021-04-05T18:14:51Z"
           enc: |

--- a/cluster-scope/overlays/prod/common/groups/workshops.enc.yaml
+++ b/cluster-scope/overlays/prod/common/groups/workshops.enc.yaml
@@ -5,21 +5,27 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:dpbZ2Cl9CgueKWiIXcS6g2Q=,iv:imwVXbxjRH1ryKCYS/FQu6leK10JMnLUSjqvhmfHFI8=,tag:l7H1te2OKQP+/Uy3u35HOg==,type:str]
-- ENC[AES256_GCM,data:N3far3bICTssFlzXwy/McevPOQ==,iv:cBUAcHOeNSutbJXCaA/hnDSfycIF7U04V35Bl0qu3qc=,tag:Mlz6J8+VmlDSkJXLo+484Q==,type:str]
-- ENC[AES256_GCM,data:n3br7c7uwBd3+Evh0a3PXOSmbPxplQk=,iv:a5y1wm0ea1vmowqETnMexR9OMTz88g4Kyra8ukDGBUo=,tag:gJ1F2QVWgB2sXRwSIgWEzA==,type:str]
-- ENC[AES256_GCM,data:WhUQ39RZG+P/PYbnp34Nn88X,iv:VI/5jPt7iTJNhvlbJVK4AZbfxPitXjG0LZc+0y7pfgs=,tag:Tt55dI7Yunrm1h7PSETzBw==,type:str]
-- ENC[AES256_GCM,data:73jQEk1XSNPZXIzRtu+PPEWzYA==,iv:xrDkeoyhfxWq8tNAz2IplvSE3SzXt3lgvcQ8GQexHu4=,tag:87F5+/OI4Om9+V48m3LDeg==,type:str]
+    - ENC[AES256_GCM,data:orLpisezOI9Z,iv:a7EtWNRn93ajBNGUh8g+VsQNEITfxKiB9HpkhNrKUgU=,tag:bBunJAxwaUiACRyJWf9qlA==,type:str]
+    - ENC[AES256_GCM,data:dpbZ2Cl9CgueKWiIXcS6g2Q=,iv:imwVXbxjRH1ryKCYS/FQu6leK10JMnLUSjqvhmfHFI8=,tag:l7H1te2OKQP+/Uy3u35HOg==,type:str]
+    - ENC[AES256_GCM,data:Z+3H2jDozJQo,iv:qvoKS6KQ9RY1Qd+rLV3Bhp6SiI+/4XFgW/U96hCLwAI=,tag:XDgbc+mR7QtxzkPx1Ia/tw==,type:str]
+    - ENC[AES256_GCM,data:N3far3bICTssFlzXwy/McevPOQ==,iv:cBUAcHOeNSutbJXCaA/hnDSfycIF7U04V35Bl0qu3qc=,tag:Mlz6J8+VmlDSkJXLo+484Q==,type:str]
+    - ENC[AES256_GCM,data:lUbyerDADg==,iv:Z6BiIedAtohpvbVtz50OyM6gOAgByipXRxd3nzqGJCI=,tag:qjOrJ2QUlqteFpgBfYM/wQ==,type:str]
+    - ENC[AES256_GCM,data:n3br7c7uwBd3+Evh0a3PXOSmbPxplQk=,iv:a5y1wm0ea1vmowqETnMexR9OMTz88g4Kyra8ukDGBUo=,tag:gJ1F2QVWgB2sXRwSIgWEzA==,type:str]
+    - ENC[AES256_GCM,data:sIXujw47,iv:iZkkOiHijPXszskkuqyLJ6uSYWahad2EMHj45fAhKCE=,tag:FeedXrLBkio+s0RcA7b69g==,type:str]
+    - ENC[AES256_GCM,data:WhUQ39RZG+P/PYbnp34Nn88X,iv:VI/5jPt7iTJNhvlbJVK4AZbfxPitXjG0LZc+0y7pfgs=,tag:Tt55dI7Yunrm1h7PSETzBw==,type:str]
+    - ENC[AES256_GCM,data:8vfYeLyFBRJbf7gGaw==,iv:NNsWcD2g/xQRV4JX46ETQfzWcfTFIRKdpPj0AUMlXj0=,tag:jy0tzREBP0yImKaeaIlwHA==,type:str]
+    - ENC[AES256_GCM,data:73jQEk1XSNPZXIzRtu+PPEWzYA==,iv:xrDkeoyhfxWq8tNAz2IplvSE3SzXt3lgvcQ8GQexHu4=,tag:87F5+/OI4Om9+V48m3LDeg==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-03-11T14:06:19Z'
-    mac: ENC[AES256_GCM,data:12zI0x7hyYW1BzSdauDl88GrU/XHinD3Kl/8Hc7hgUKp4q2UKaneXz0teZJFD9ewPWrdWjMikE6DRasaUWKIGVK3kPeQ9a8pS7RWJ8mEmoK6mapMsuAK840Tlf3ixRWzcYHJle1itvJmDdon+Fcht39JCUj6xshAoj4vrFhUqng=,iv:bT5ihVREotUnQExNAJJYT9mkW4CfMLYj3JGtseBGFkQ=,tag:kOp+HZLCEC/DvXrrlH8RmQ==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:34:11Z"
+    mac: ENC[AES256_GCM,data:Sl2e+DlD+SE4+22Z1s7iduC07e0UsDuyGXGSRIMSxAGFFf0QxTD3cFesodfWAj5sCh0CtPARRwdlPsWIXVB/FYw8uaXzUgT3veJUrCFvjaI2jOFntH5X9fjcbXDG3TzPSX/DAeM0iJv8HndoYiarRKcvxEhiMBpqD0XB7MmAHTU=,iv:1jr98qeQWxWFifLrB4TNdn3U1gjrf/wgbU0xod08/NA=,tag:l9CIzTX/VbWB5cfMM/t7Dw==,type:str]
     pgp:
-    -   created_at: '2021-01-12T17:24:03Z'
-        enc: |-
+        - created_at: "2021-01-12T17:24:03Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAo20CwQ7xESP4ErDCsd2V008XpT6sUTOjaUUPbi2MuvlG
@@ -38,9 +44,9 @@ sops:
             7zcA
             =g2f2
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-03-11T14:06:16Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-03-11T14:06:16Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAkVUU21ABrJ2UmOK8SkTFqcyC/U1gju0tPxI5pKEseP6d
@@ -56,9 +62,9 @@ sops:
             bp5KiE/Zhwa4puJdjs1G4bG9AA==
             =gI02
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-03-11T14:06:16Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-03-11T14:06:16Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAd6kbOnJ7ZynZRYPApT8P/CaF9WMurQC0cjvz7vSB3NLr
@@ -77,9 +83,9 @@ sops:
             pAQA
             =uMB1
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-03-11T14:06:16Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-03-11T14:06:16Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAZDiahWmP6Wty9ISjarKVdfM6Zqccop4uqx4nSSasGlLy
@@ -92,6 +98,6 @@ sops:
             qabR+9tTJeDe5ItZuGk3UHVIOKgzQvSay9viE9rL1+FVggA=
             =x4C1
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/moc/curator/groups/cluster-admins.enc.yaml
+++ b/cluster-scope/overlays/prod/moc/curator/groups/cluster-admins.enc.yaml
@@ -5,21 +5,27 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:qSSc2HKcZ49zG3s=,iv:CP1f5xp28+k2AbwdYPtLLCTYQPHoS+GU5SxxdhenSYk=,tag:Tw8qn556zfhCQlQsgS1X9g==,type:str]
-- ENC[AES256_GCM,data:hGDY7FaJLhUMm5ZuWY9z,iv:SDzAVj4Z/1xurYk2L6T46X+unYDjsVPR4RKy7GXqWt0=,tag:uzBKr72sQ29JS6VkMqdACQ==,type:str]
-- ENC[AES256_GCM,data:agXEe6Oy/JGdYhvZGwSK,iv:Rrk3zMQRRSYr5tcTmzEzI/Sj3rOMMLncIPYF8EvQkEM=,tag:QGKMHrvUzRNAUx40siZDsA==,type:str]
-- ENC[AES256_GCM,data:a95smgMabERDPuGs7Y5LexqXHA==,iv:r78WNgC+3aPk8TP8hiOl+t7DcJjLhbTvwu5Hvwx4bAo=,tag:EIx9sX4puvJe65afd4q9Pg==,type:str]
-- ENC[AES256_GCM,data:2Kq2E2syk0dI9vqefks56uJIXg==,iv:c2AfR7afJr4uT7hIe1eBRJAl45vmZ46xYC8PV2Ry2Y4=,tag:RdqpYRRLKyiZq1hzKyNxhA==,type:str]
+    - ENC[AES256_GCM,data:YDU2JXJM,iv:lDrSGepzDisJ+lj4NfcvBJpiIYFlhdeb5f1AANvHQq4=,tag:oQZzpAOHI6kYkZ92Wm5uPg==,type:str]
+    - ENC[AES256_GCM,data:qSSc2HKcZ49zG3s=,iv:CP1f5xp28+k2AbwdYPtLLCTYQPHoS+GU5SxxdhenSYk=,tag:Tw8qn556zfhCQlQsgS1X9g==,type:str]
+    - ENC[AES256_GCM,data:DUoVUszDJPa1,iv:VNPfo4fz8TI1ndEK9bd/A1MHniP4AUCo+zEzERw5Jow=,tag:Bfls4lSRkPBZ18dS2dpNhg==,type:str]
+    - ENC[AES256_GCM,data:hGDY7FaJLhUMm5ZuWY9z,iv:SDzAVj4Z/1xurYk2L6T46X+unYDjsVPR4RKy7GXqWt0=,tag:uzBKr72sQ29JS6VkMqdACQ==,type:str]
+    - ENC[AES256_GCM,data:kaZRx9MRD9w=,iv:2fAULF1AaaNwcMliPxeWYkFkLdsecldXEMgGeazyd/E=,tag:YbV7x57EQMFUt3+y8fLbcA==,type:str]
+    - ENC[AES256_GCM,data:agXEe6Oy/JGdYhvZGwSK,iv:Rrk3zMQRRSYr5tcTmzEzI/Sj3rOMMLncIPYF8EvQkEM=,tag:QGKMHrvUzRNAUx40siZDsA==,type:str]
+    - ENC[AES256_GCM,data:tM/mDJ4Aa0A=,iv:m37NDKMenCrl3xAg3mNGrucCIT13AmR//fnyE6l3das=,tag:CeHUZThL1fhtWfcXDM8XsQ==,type:str]
+    - ENC[AES256_GCM,data:a95smgMabERDPuGs7Y5LexqXHA==,iv:r78WNgC+3aPk8TP8hiOl+t7DcJjLhbTvwu5Hvwx4bAo=,tag:EIx9sX4puvJe65afd4q9Pg==,type:str]
+    - ENC[AES256_GCM,data:XSodjj6h7IA=,iv:UkRAFLSy1c1VUGXh9jKmZ38HHMS5RRzYHw1sW3sfOeg=,tag:pw05epeXFFz2GbN0p3k2hA==,type:str]
+    - ENC[AES256_GCM,data:2Kq2E2syk0dI9vqefks56uJIXg==,iv:c2AfR7afJr4uT7hIe1eBRJAl45vmZ46xYC8PV2Ry2Y4=,tag:RdqpYRRLKyiZq1hzKyNxhA==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-03-22T18:59:31Z'
-    mac: ENC[AES256_GCM,data:7RZ4PpJq9nJKfDv42GLe0ccRCSo5kIpXhrWU8q3GKbowJUJuicPsM28QAavAhfLuxyXjehx3gFsD331li0w6y+nIUvEsjVOJOnkSLLWiyelrGNN+5CefiPj+ooyeHFGucvn6/s7UmBN+apWEXW81aPZBubnx1BHpNI03GBBI2sI=,iv:CvuV622kWMCfPd/iYZcT/a63083IuLgpGf0EjJdm/8U=,tag:pTAmCai09zlWAZDU1HytYw==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:59:51Z"
+    mac: ENC[AES256_GCM,data:WB5K3YIgv7rU8TNJ8FVM0BK5ORWTzozgSAmwqqALLFXh/0gZKPpwUznIdNm6g8qxTwrpGW5lopMkwbHDB+0BJC17xDQwF1Z3BPsKofACaWS6SiBDqA2u6swV61m9oMS2BVLwq2CDLJl6/7zi1iMGbXu30MrSCgRQRbxbmz9Jklo=,iv:GDnawRco+boQyL9d9B09mDhAJawICP1/HKqEY3Vs01A=,tag:icu+vy6ujpXnfI8WzCs/5g==,type:str]
     pgp:
-    -   created_at: '2021-01-12T17:24:03Z'
-        enc: |-
+        - created_at: "2021-01-12T17:24:03Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAPa+BVbfI284XVFHGnNXMX9+O1JhiSnNP6dHYox1PZUSm
@@ -38,9 +44,9 @@ sops:
             zpYA
             =LEjZ
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-03-11T14:06:41Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-03-11T14:06:41Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAuAld50yRBH+Bm4cq0tfJkTiRMbTFNDLVYq18xsL1tZ+j
@@ -56,9 +62,9 @@ sops:
             60UrSB7sPznRHeJe6yLe4fTXAA==
             =SlR1
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-03-11T14:06:41Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-03-11T14:06:41Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAvR92uY+uC3Emm9s33FhYTGDmpCDOIan6JE4mM1CmS6Sy
@@ -77,9 +83,9 @@ sops:
             VCYA
             =vTg+
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-03-11T14:06:41Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-03-11T14:06:41Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAFqplQqeJKsVPODWgb+XEcqEyxeBWZEevVQotKQ3HWeBU
@@ -92,6 +98,6 @@ sops:
             9xFuOwtLnuCM5MSqKVD0X+i8AQBLCj8qLKHiMsw8POFmwQA=
             =xyhO
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/moc/infra/groups/cluster-admins.enc.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/groups/cluster-admins.enc.yaml
@@ -5,25 +5,35 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:jFP/7OqNV9kxdfbJZh5hAsf0Vw==,iv:iur4nw0AKS+mDho/sS1O7uf8RN0jVdjXaEebG3dxbFs=,tag:xImpPVYFMQAX3SX0iTVggg==,type:str]
-- ENC[AES256_GCM,data:20ZSzh0u3K/mFZGlJsePHw==,iv:lGmTAfC4H7tghQPx6VrzouzzIDeaEQgDPJ2Rim77vDE=,tag:aIxi2kdp5Xu2Li+DcHxcXA==,type:str]
-- ENC[AES256_GCM,data:VKXH/iR/AMxz4lj/57Lc9N4=,iv:5W3Ch63dAzpSlNBzpIvMmlpKMKP15jbH6P+Bp3AiFzg=,tag:Xo3FZT4sL8pn9JHdt5ej8Q==,type:str]
-- ENC[AES256_GCM,data:VtedBp1rXZ2rQG61bgsXIezdVQ==,iv:QdBd4vUtcBRIK5P9RhVhtlSJUgrT/+NTqfXP2UqDF9A=,tag:Xc6UfxERIocCkk9j2FXjFA==,type:str]
-- ENC[AES256_GCM,data:TOE6B8u0JtlaA+Q=,iv:CP1f5xp28+k2AbwdYPtLLCTYQPHoS+GU5SxxdhenSYk=,tag:DPNyEKBEYGnskXywBSgK/w==,type:str]
-- ENC[AES256_GCM,data:G9eWuVxNv6qBW6O64B8H1A==,iv:BwImOt73k2SwRTN57fZPahgS8koRqyILtw0LrX43paY=,tag:lmdF/bgagMplV+k7YAxGOg==,type:str]
-- ENC[AES256_GCM,data:C1FzjjUBcQ4hltBwawAs,iv:Rrk3zMQRRSYr5tcTmzEzI/Sj3rOMMLncIPYF8EvQkEM=,tag:J89DGocC3IU6gexr2/E2bg==,type:str]
-- ENC[AES256_GCM,data:dNMEhoVzwpYfifruAk1c,iv:SDzAVj4Z/1xurYk2L6T46X+unYDjsVPR4RKy7GXqWt0=,tag:Hm/eQrGaj58EzmlBUcZ0vA==,type:str]
-- ENC[AES256_GCM,data:KGGg9ispMfT1v7xJaFuGM391,iv:A1GHS8oPVFxhYN2E1C5Mt6ibah5mpTFVL1eL3rLHrXc=,tag:lmCWY8pVNQoMDfdqk+8GBA==,type:str]
+    - ENC[AES256_GCM,data:j+xSeDs=,iv:QWZXv7YySP+p/H6ObxCYXkq2/dq4kIFiQ+RmM/v0UcA=,tag:JSZdgDyRXj2sv/bG7wTewQ==,type:str]
+    - ENC[AES256_GCM,data:jFP/7OqNV9kxdfbJZh5hAsf0Vw==,iv:iur4nw0AKS+mDho/sS1O7uf8RN0jVdjXaEebG3dxbFs=,tag:xImpPVYFMQAX3SX0iTVggg==,type:str]
+    - ENC[AES256_GCM,data:YIIlQcUW,iv:Sw5vbwl/VzwFnIwzYMVc7+fyWSC/Y1le9pHHkykQxWE=,tag:M20WqBxfeK/cEheyPLXLfw==,type:str]
+    - ENC[AES256_GCM,data:20ZSzh0u3K/mFZGlJsePHw==,iv:lGmTAfC4H7tghQPx6VrzouzzIDeaEQgDPJ2Rim77vDE=,tag:aIxi2kdp5Xu2Li+DcHxcXA==,type:str]
+    - ENC[AES256_GCM,data:UMZ/Gtg0ozI=,iv:JMrgZQSRAMngOMclEsIL5NDk4LGTjaP114jPokyAoeI=,tag:A6epaWbsoiWx2eM3UZ+6Vw==,type:str]
+    - ENC[AES256_GCM,data:VKXH/iR/AMxz4lj/57Lc9N4=,iv:5W3Ch63dAzpSlNBzpIvMmlpKMKP15jbH6P+Bp3AiFzg=,tag:Xo3FZT4sL8pn9JHdt5ej8Q==,type:str]
+    - ENC[AES256_GCM,data:5iyxqYv6Vnv7PPN6FA==,iv:T/aztbCuHWm2dq9C73QeV7K7ZHvLxO0IjFL4+eOGxZI=,tag:5OWFX0YsUUvK67HiW5GD+g==,type:str]
+    - ENC[AES256_GCM,data:VtedBp1rXZ2rQG61bgsXIezdVQ==,iv:QdBd4vUtcBRIK5P9RhVhtlSJUgrT/+NTqfXP2UqDF9A=,tag:Xc6UfxERIocCkk9j2FXjFA==,type:str]
+    - ENC[AES256_GCM,data:ZzKrXNch,iv:XtqonpANKWWW2szX8hAAHZsp/ukr4dN9YhQAv5UrmQE=,tag:ELPFfvELK97D7ca7Htrv7Q==,type:str]
+    - ENC[AES256_GCM,data:TOE6B8u0JtlaA+Q=,iv:CP1f5xp28+k2AbwdYPtLLCTYQPHoS+GU5SxxdhenSYk=,tag:DPNyEKBEYGnskXywBSgK/w==,type:str]
+    - ENC[AES256_GCM,data:BJlYkgg+BEM=,iv:O0U/yFIcDP4aXBlctrNCVUP13RWXybaI7sMvTqgRXN4=,tag:OogVsPGIU0IWQnIpxZwmJg==,type:str]
+    - ENC[AES256_GCM,data:G9eWuVxNv6qBW6O64B8H1A==,iv:BwImOt73k2SwRTN57fZPahgS8koRqyILtw0LrX43paY=,tag:lmdF/bgagMplV+k7YAxGOg==,type:str]
+    - ENC[AES256_GCM,data:gOU7pgsD9og=,iv:wZxJf1S4Ec1KuGTyV96icg6FKjdisEDopYHK9x8lDhY=,tag:SZq+vix73JF4D8ic/YweDA==,type:str]
+    - ENC[AES256_GCM,data:C1FzjjUBcQ4hltBwawAs,iv:Rrk3zMQRRSYr5tcTmzEzI/Sj3rOMMLncIPYF8EvQkEM=,tag:J89DGocC3IU6gexr2/E2bg==,type:str]
+    - ENC[AES256_GCM,data:aRaM3i0jujUD,iv:S7kPgQX6Giv/YPmRvusfPvHdPbGdICbl1LhVvVYnzlE=,tag:Afm1NipEEIPgFd79P9ZHXQ==,type:str]
+    - ENC[AES256_GCM,data:dNMEhoVzwpYfifruAk1c,iv:SDzAVj4Z/1xurYk2L6T46X+unYDjsVPR4RKy7GXqWt0=,tag:Hm/eQrGaj58EzmlBUcZ0vA==,type:str]
+    - ENC[AES256_GCM,data:LzXSJArs,iv:0aCN+BH7k4n+oWLtj8v9exZldTe9fgJViLfdRyWfwzM=,tag:KZDeFjG8P5Eka11GN0Y4xw==,type:str]
+    - ENC[AES256_GCM,data:KGGg9ispMfT1v7xJaFuGM391,iv:A1GHS8oPVFxhYN2E1C5Mt6ibah5mpTFVL1eL3rLHrXc=,tag:lmCWY8pVNQoMDfdqk+8GBA==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-06-17T13:47:02Z'
-    mac: ENC[AES256_GCM,data:7tLVCFxDJ2T4Wk0k/H6OZdClEvn8yIjBuDDR0O4uw1sRI1+SxQNIzX1bZ4U2XbKEImyN98ypoeiG9Oih5I+NrokY3ZvDvTakFhBlb9Qu0e7O/JEJp7yof8o84bWw1h9GaBM7yPdUjx3Fs1Ah8r7X1tXqOJfSPtVkJRNcspPjy4U=,iv:JJoMGTZOs+auhuUTlZh3o8N254gi/aTPd3tup/2WEb8=,tag:QbgQGmm4JvmuVDfMn69qBw==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:38:18Z"
+    mac: ENC[AES256_GCM,data:hwYEICah8yZbNTzQ4UxMlQ8tmT229jRt2sdCijnCuyGu0+RrmScvdbkoZla8I1yzvGrFdkeYEwfwlKpEfNdkJM2WYSHWfrxRi9Oq5cWLSzOIuxDlOEDHYxaCXdt9IOtGD0GDSGJO6fML9hOJpxRY2sfi3kHMAumLkc6mbdFLDHE=,iv:ixwPPdbiOqB71HcxqElwonAt4dFZT7fwqB3yM59KDtI=,tag:+ZXXVlF/ppCYq2RGSiC5Dw==,type:str]
     pgp:
-    -   created_at: '2021-01-12T17:24:03Z'
-        enc: |-
+        - created_at: "2021-01-12T17:24:03Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAATDzySUo52IwfBnmfGVvfKy/EuenK0YLgkf6JNZ/t7pr3
@@ -42,9 +52,9 @@ sops:
             MMUA
             =QSN3
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-03-11T14:06:50Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-03-11T14:06:50Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAvK4kmChXK2YT7z9gCNUnG+dsx7AC+UXUFAGhRpqRg0oH
@@ -60,9 +70,9 @@ sops:
             mgRPeCoSOMsuJeL19uWc4ZJqAA==
             =vQo7
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-03-11T14:06:50Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-03-11T14:06:50Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAPrUmL2fHCeFpk5XSz1gt/wcMbrP8xEYBrddzhU/8tu2o
@@ -81,9 +91,9 @@ sops:
             MYkA
             =cJ8G
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-03-11T14:06:50Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-03-11T14:06:50Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAcnmXEzV0Tm3aZRkKE+7tyROPLn2q/zll3J7QW1FCxat+
@@ -96,6 +106,6 @@ sops:
             6I4pq8raJOCl5H6gM9CttYd840j6ZYALLefikzvG2+GHMgA=
             =aWv+
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/moc/infra/groups/cluster-admins.enc.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/groups/cluster-admins.enc.yaml
@@ -9,9 +9,9 @@ users:
     - ENC[AES256_GCM,data:jFP/7OqNV9kxdfbJZh5hAsf0Vw==,iv:iur4nw0AKS+mDho/sS1O7uf8RN0jVdjXaEebG3dxbFs=,tag:xImpPVYFMQAX3SX0iTVggg==,type:str]
     - ENC[AES256_GCM,data:YIIlQcUW,iv:Sw5vbwl/VzwFnIwzYMVc7+fyWSC/Y1le9pHHkykQxWE=,tag:M20WqBxfeK/cEheyPLXLfw==,type:str]
     - ENC[AES256_GCM,data:20ZSzh0u3K/mFZGlJsePHw==,iv:lGmTAfC4H7tghQPx6VrzouzzIDeaEQgDPJ2Rim77vDE=,tag:aIxi2kdp5Xu2Li+DcHxcXA==,type:str]
-    - ENC[AES256_GCM,data:UMZ/Gtg0ozI=,iv:JMrgZQSRAMngOMclEsIL5NDk4LGTjaP114jPokyAoeI=,tag:A6epaWbsoiWx2eM3UZ+6Vw==,type:str]
+    - ENC[AES256_GCM,data:Zvj3znJZmd0=,iv:GmD3dx5/majHhZoeX1OSytpyYDWz+Q1qeTfpxZ8bBWw=,tag:9mNIaZHPJwVAeJgvI7hFog==,type:str]
     - ENC[AES256_GCM,data:VKXH/iR/AMxz4lj/57Lc9N4=,iv:5W3Ch63dAzpSlNBzpIvMmlpKMKP15jbH6P+Bp3AiFzg=,tag:Xo3FZT4sL8pn9JHdt5ej8Q==,type:str]
-    - ENC[AES256_GCM,data:5iyxqYv6Vnv7PPN6FA==,iv:T/aztbCuHWm2dq9C73QeV7K7ZHvLxO0IjFL4+eOGxZI=,tag:5OWFX0YsUUvK67HiW5GD+g==,type:str]
+    - ENC[AES256_GCM,data:bxclE9fORtQsuj5K4g==,iv:uoWABb+Izgn3wqSt702IzRWHWzo9HGg/yDaEaKUPfko=,tag:Q1FoLBE3ppAdaGEXoQpw7g==,type:str]
     - ENC[AES256_GCM,data:VtedBp1rXZ2rQG61bgsXIezdVQ==,iv:QdBd4vUtcBRIK5P9RhVhtlSJUgrT/+NTqfXP2UqDF9A=,tag:Xc6UfxERIocCkk9j2FXjFA==,type:str]
     - ENC[AES256_GCM,data:ZzKrXNch,iv:XtqonpANKWWW2szX8hAAHZsp/ukr4dN9YhQAv5UrmQE=,tag:ELPFfvELK97D7ca7Htrv7Q==,type:str]
     - ENC[AES256_GCM,data:TOE6B8u0JtlaA+Q=,iv:CP1f5xp28+k2AbwdYPtLLCTYQPHoS+GU5SxxdhenSYk=,tag:DPNyEKBEYGnskXywBSgK/w==,type:str]
@@ -29,8 +29,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-07-14T20:38:18Z"
-    mac: ENC[AES256_GCM,data:hwYEICah8yZbNTzQ4UxMlQ8tmT229jRt2sdCijnCuyGu0+RrmScvdbkoZla8I1yzvGrFdkeYEwfwlKpEfNdkJM2WYSHWfrxRi9Oq5cWLSzOIuxDlOEDHYxaCXdt9IOtGD0GDSGJO6fML9hOJpxRY2sfi3kHMAumLkc6mbdFLDHE=,iv:ixwPPdbiOqB71HcxqElwonAt4dFZT7fwqB3yM59KDtI=,tag:+ZXXVlF/ppCYq2RGSiC5Dw==,type:str]
+    lastmodified: "2021-08-12T12:55:27Z"
+    mac: ENC[AES256_GCM,data:ufRjJyRXw9J9Y8wUEDb7oB6cu9EBpl6Yefzrwjt2nsAZY4npkIEXoGdLeqCRS4u6rX7k+tROnByLRaVKEBB5GrHBJqe14mEVwb7x7Jsyqgc017IkzWeP/BGBzNgkjbQZbvAwGd/zwW54iklaQWi+IU2uS2gvB7YgxD5p781DBIA=,iv:rbj4wbuPVLu24X6cPiQ7+0E9rlygnaRwwRhNBTJ08/g=,tag:tObbWANnTDXSkcalhXN3EQ==,type:str]
     pgp:
         - created_at: "2021-01-12T17:24:03Z"
           enc: |-

--- a/cluster-scope/overlays/prod/moc/zero/groups/cluster-admins.enc.yaml
+++ b/cluster-scope/overlays/prod/moc/zero/groups/cluster-admins.enc.yaml
@@ -13,7 +13,7 @@ users:
     - ENC[AES256_GCM,data:agXEe6Oy/JGdYhvZGwSK,iv:Rrk3zMQRRSYr5tcTmzEzI/Sj3rOMMLncIPYF8EvQkEM=,tag:QGKMHrvUzRNAUx40siZDsA==,type:str]
     - ENC[AES256_GCM,data:yG3PVRzI,iv:OhRYq5cje8k8O6UNwsXXT1sCBqDH4yaAQWTj1UfQkxQ=,tag:QZjWvg9nKo11aCT76KvtCA==,type:str]
     - ENC[AES256_GCM,data:NedbJLOSkDmI6cAsNKwyfdLU,iv:A1GHS8oPVFxhYN2E1C5Mt6ibah5mpTFVL1eL3rLHrXc=,tag:iHTTnm0O1VyIzQQwaPkZLw==,type:str]
-    - ENC[AES256_GCM,data:TtYWoBqHIYE=,iv:/qlDTbkWGLDVmUD436hPqYhbG9GGtBfJnLcRDv0TL/4=,tag:zgcSh0TQUR20qQJQo7Rd5A==,type:str]
+    - ENC[AES256_GCM,data:3kECAhPECmc=,iv:4PnDknBhQZLs+ZcUhpr2EdsG34ATes2S+dMVbI9RmPE=,tag:nnLTQW81hOv4uTJo87KIqw==,type:str]
     - ENC[AES256_GCM,data:Fdo9s47JoU3a6KiWWJ7YjUA=,iv:5W3Ch63dAzpSlNBzpIvMmlpKMKP15jbH6P+Bp3AiFzg=,tag:xnXBf9+hB90uULYRBNcLqA==,type:str]
     - ENC[AES256_GCM,data:iEEA7nA=,iv:qOp7pGQqdSWdM10JUnSXW4XpYY7pDVHjSfQBnLWDyTM=,tag:oAwu52EOU8F7/yBksPZRDQ==,type:str]
     - ENC[AES256_GCM,data:ZACTQyjFMwD1gXKu571N11RVhg==,iv:qaAQMIDiA/SJ3YTABJZQ6W5tjlhw0K63oh3FsfuNNY8=,tag:B7MihbC5rVQ/YIsrV8NT3Q==,type:str]
@@ -23,8 +23,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-07-14T20:38:56Z"
-    mac: ENC[AES256_GCM,data:wa4HlmCkCwXUgGqRiHLSOtH1W/NeENQ3j9Emtdklh8JT+e5qfD/Q6ZACH30WpPT7VF4+d0uOeV47gZEOLo3yzOaZe24fjc7FS14oMF4SLN8ceZNjtuBnyrdSptL7qODxj2i7x5PvWInQmVnhu7QM4aF2GBpzRbk9PJXcRl+LMqc=,iv:6LARPmjHqdlH7RCy9CFDyspcI5PuIrpsF+fy/uP1gU4=,tag:r1jRkktsL2i/s1GhdRdXqQ==,type:str]
+    lastmodified: "2021-08-12T12:55:35Z"
+    mac: ENC[AES256_GCM,data:AFY7vhzISRQpOvtBtqNhL0kHZzFHRgoQC65EPSENPaNayqKPWepnJx1vDRDCWi/ZLYm5aXrV0hS559YV9eSye+Sf5jQKtwOtksEEbIDJg8CRfjatHD68968NwJfClmJ7VRO9k+P+Xfix++6V5VD0btLgcPWNQzaiiYOE4ubOoSA=,iv:ot9rSh7Wd85Kb5eqHeH4kW5m+NKkMzG1NSDvk5gEB4E=,tag:5LkBIGEDqFhmB3Yo9i5LKA==,type:str]
     pgp:
         - created_at: "2021-01-12T17:24:03Z"
           enc: |-

--- a/cluster-scope/overlays/prod/moc/zero/groups/cluster-admins.enc.yaml
+++ b/cluster-scope/overlays/prod/moc/zero/groups/cluster-admins.enc.yaml
@@ -5,22 +5,29 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 users:
-- ENC[AES256_GCM,data:qSSc2HKcZ49zG3s=,iv:CP1f5xp28+k2AbwdYPtLLCTYQPHoS+GU5SxxdhenSYk=,tag:Tw8qn556zfhCQlQsgS1X9g==,type:str]
-- ENC[AES256_GCM,data:hGDY7FaJLhUMm5ZuWY9z,iv:SDzAVj4Z/1xurYk2L6T46X+unYDjsVPR4RKy7GXqWt0=,tag:uzBKr72sQ29JS6VkMqdACQ==,type:str]
-- ENC[AES256_GCM,data:agXEe6Oy/JGdYhvZGwSK,iv:Rrk3zMQRRSYr5tcTmzEzI/Sj3rOMMLncIPYF8EvQkEM=,tag:QGKMHrvUzRNAUx40siZDsA==,type:str]
-- ENC[AES256_GCM,data:NedbJLOSkDmI6cAsNKwyfdLU,iv:A1GHS8oPVFxhYN2E1C5Mt6ibah5mpTFVL1eL3rLHrXc=,tag:iHTTnm0O1VyIzQQwaPkZLw==,type:str]
-- ENC[AES256_GCM,data:Fdo9s47JoU3a6KiWWJ7YjUA=,iv:5W3Ch63dAzpSlNBzpIvMmlpKMKP15jbH6P+Bp3AiFzg=,tag:xnXBf9+hB90uULYRBNcLqA==,type:str]
-- ENC[AES256_GCM,data:ZACTQyjFMwD1gXKu571N11RVhg==,iv:qaAQMIDiA/SJ3YTABJZQ6W5tjlhw0K63oh3FsfuNNY8=,tag:B7MihbC5rVQ/YIsrV8NT3Q==,type:str]
+    - ENC[AES256_GCM,data:l8hqSn2U,iv:TwTkaa1ynUV4IeT8N5tM4g1dlB9pKHXSyzqzleRoB3Q=,tag:CeeugLQq2+KWEn6oPeNJAA==,type:str]
+    - ENC[AES256_GCM,data:qSSc2HKcZ49zG3s=,iv:CP1f5xp28+k2AbwdYPtLLCTYQPHoS+GU5SxxdhenSYk=,tag:Tw8qn556zfhCQlQsgS1X9g==,type:str]
+    - ENC[AES256_GCM,data:zoFQt7vZzZ/Y,iv:e85LQhBdq4VnRXQvXQiwyCHW7w3ZPkplo0SxpDAmbuc=,tag:khdrMAqinip2H/8NbXyorg==,type:str]
+    - ENC[AES256_GCM,data:hGDY7FaJLhUMm5ZuWY9z,iv:SDzAVj4Z/1xurYk2L6T46X+unYDjsVPR4RKy7GXqWt0=,tag:uzBKr72sQ29JS6VkMqdACQ==,type:str]
+    - ENC[AES256_GCM,data:x4JEUDV/4kI=,iv:0jL9T/ClgIIXqrOPCF/Y3cdfa4nQYz4X/tFro3eyX6I=,tag:itTWpl0ZTGkmNT4PBH/2XQ==,type:str]
+    - ENC[AES256_GCM,data:agXEe6Oy/JGdYhvZGwSK,iv:Rrk3zMQRRSYr5tcTmzEzI/Sj3rOMMLncIPYF8EvQkEM=,tag:QGKMHrvUzRNAUx40siZDsA==,type:str]
+    - ENC[AES256_GCM,data:yG3PVRzI,iv:OhRYq5cje8k8O6UNwsXXT1sCBqDH4yaAQWTj1UfQkxQ=,tag:QZjWvg9nKo11aCT76KvtCA==,type:str]
+    - ENC[AES256_GCM,data:NedbJLOSkDmI6cAsNKwyfdLU,iv:A1GHS8oPVFxhYN2E1C5Mt6ibah5mpTFVL1eL3rLHrXc=,tag:iHTTnm0O1VyIzQQwaPkZLw==,type:str]
+    - ENC[AES256_GCM,data:TtYWoBqHIYE=,iv:/qlDTbkWGLDVmUD436hPqYhbG9GGtBfJnLcRDv0TL/4=,tag:zgcSh0TQUR20qQJQo7Rd5A==,type:str]
+    - ENC[AES256_GCM,data:Fdo9s47JoU3a6KiWWJ7YjUA=,iv:5W3Ch63dAzpSlNBzpIvMmlpKMKP15jbH6P+Bp3AiFzg=,tag:xnXBf9+hB90uULYRBNcLqA==,type:str]
+    - ENC[AES256_GCM,data:iEEA7nA=,iv:qOp7pGQqdSWdM10JUnSXW4XpYY7pDVHjSfQBnLWDyTM=,tag:oAwu52EOU8F7/yBksPZRDQ==,type:str]
+    - ENC[AES256_GCM,data:ZACTQyjFMwD1gXKu571N11RVhg==,iv:qaAQMIDiA/SJ3YTABJZQ6W5tjlhw0K63oh3FsfuNNY8=,tag:B7MihbC5rVQ/YIsrV8NT3Q==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-03-12T17:02:31Z'
-    mac: ENC[AES256_GCM,data:XJfWfPfIa8hunJ7M8ZZe8JnyFRUcXY2Rgmj1sLT5EA+8al+u20P1KsSDDxK1kUcA62WTEQpRKzmAXhccQIA5nNMwZBbIINCWFfbAHV2cg26PhdoFfSB0w+m2aO1O21JvhxDjF+AnLxJwAmSVdc81q6SMpjnFLO3yoC45XZIAbKE=,iv:lHKX5etajHnCCh7eV+ugJbxmk0Jbhh6Km4oyfcQOZ4s=,tag:w0zElinPX/f6nzd7Iju6lA==,type:str]
+    age: []
+    lastmodified: "2021-07-14T20:38:56Z"
+    mac: ENC[AES256_GCM,data:wa4HlmCkCwXUgGqRiHLSOtH1W/NeENQ3j9Emtdklh8JT+e5qfD/Q6ZACH30WpPT7VF4+d0uOeV47gZEOLo3yzOaZe24fjc7FS14oMF4SLN8ceZNjtuBnyrdSptL7qODxj2i7x5PvWInQmVnhu7QM4aF2GBpzRbk9PJXcRl+LMqc=,iv:6LARPmjHqdlH7RCy9CFDyspcI5PuIrpsF+fy/uP1gU4=,tag:r1jRkktsL2i/s1GhdRdXqQ==,type:str]
     pgp:
-    -   created_at: '2021-01-12T17:24:03Z'
-        enc: |-
+        - created_at: "2021-01-12T17:24:03Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMA9aKBcudqifiARAAPa+BVbfI284XVFHGnNXMX9+O1JhiSnNP6dHYox1PZUSm
@@ -39,9 +46,9 @@ sops:
             zpYA
             =LEjZ
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
-    -   created_at: '2021-03-11T14:06:41Z'
-        enc: |-
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2021-03-11T14:06:41Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcDMA7rAHYSMKfAZAQwAuAld50yRBH+Bm4cq0tfJkTiRMbTFNDLVYq18xsL1tZ+j
@@ -57,9 +64,9 @@ sops:
             60UrSB7sPznRHeJe6yLe4fTXAA==
             =SlR1
             -----END PGP MESSAGE-----
-        fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
-    -   created_at: '2021-03-11T14:06:41Z'
-        enc: |-
+          fp: B27ED6FAF92F28FA805451F33F5CA0E2A1824018
+        - created_at: "2021-03-11T14:06:41Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcFMAyzcsT8FUYakARAAvR92uY+uC3Emm9s33FhYTGDmpCDOIan6JE4mM1CmS6Sy
@@ -78,9 +85,9 @@ sops:
             VCYA
             =vTg+
             -----END PGP MESSAGE-----
-        fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
-    -   created_at: '2021-03-11T14:06:41Z'
-        enc: |-
+          fp: 5B2E9490ED4F7BB379EC93C17BF065CD97112F06
+        - created_at: "2021-03-11T14:06:41Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
             wcBMA77Gn+FOVmJYAQgAFqplQqeJKsVPODWgb+XEcqEyxeBWZEevVQotKQ3HWeBU
@@ -93,6 +100,6 @@ sops:
             9xFuOwtLnuCM5MSqKVD0X+i8AQBLCj8qLKHiMsw8POFmwQA=
             =xyhO
             -----END PGP MESSAGE-----
-        fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
+          fp: 3625572E2E3C694CB19911FFB727FBE237CEADAC
     encrypted_regex: ^users$
-    version: 3.6.1
+    version: 3.7.1


### PR DESCRIPTION
Part 1 of 2 for: https://github.com/operate-first/apps/issues/791

Migrate each user group to allow auth via both MOC SSO and OperateFirst SSO, in other words: include both email and github usernames.

(The reason why I'm extending the encrypted resources and not creating a plaintext base that is merged with the encrypted is that kustomize with ksops can't merge lists in resources)

Please check every group for missing entries. This PR aims to provide 1to1 mapping of emails and github usernames. In case multiple emails were used for the same user, they were merged into single github user name entry.

This PR is just a transition phase before https://github.com/operate-first/apps/pull/842 There you can observe GitHub usernames in plaintext already.

**All Operate First Keycloak usernames must be lowercase**

Groups with known missing github usernames:
- `esi-project`: 1 missing
- `lab-cicd`: 1 missing
- `open-aiops`: 2 missing
- `prometheus-anomaly-detector`: 1 missing
- `redhat-cto-team`: 3 missing
- `enterprise-neurosystem`: 4 missing

Please mark if a group was verified:
- [x] `adoptium`
- [x] `ai-services`
- [x] `apicurio`
- [x] `argocd-admins`
- [x] `argocd-readonly`
- [x] `b4mad`
- [x] `ccx`
- [x] `chi-rhug`
- [x] `cnv-testing`
- [x] `codait-advo`
- [x] `curator`
- [x] `data-science`
- [x] `esi-project`
- [ ] `enterprise-neurosystem`
- [x] `fde`
- [ ] `lab-cicd`
- [x] `mesh-for-data`
- [x] `mwperf`
- [ ] `odh-admin`
- [x] `open-aiops`
- [x] `operate-first`
- [x] `osc`
- [ ] `prometheus-anomaly-detector`
- [x] `pulp`
- [x] `quarkus`
- [x] `ray`
- [ ] `redhat-cto-team`
- [x] `rekor`
- [x] `sa-dach`
- [x] `sdap-mslsp`
- [x] `sigstore`
- [x] `sre`
- [x] `team-pixel`
- [x] `thoth`
- [x] `thoth-devops`
- [x] `uky-redhat`
- [x] `workshops`
- [x] `cluster-admins` on MOC Zero
- [x] `cluster-admins` on MOC Infra
- [x] `cluster-admins` on MOC Curator