### PR TITLE
added group authorization for kafka user

### DIFF
--- a/odh-manifests/kafka/overlays/users/audio-decoder.yaml
+++ b/odh-manifests/kafka/overlays/users/audio-decoder.yaml
@@ -7,12 +7,19 @@ spec:
     type: tls
   authorization:
     acls:
-      - host: '*'
+      - host: "*"
         operation: All
         resource:
           # this user has access to all topics with "audio-decoder." prefix
           name: audio-decoder.
           patternType: prefix
           type: topic
+        type: allow
+      - host: "*"
+        operation: All
+        resource:
+          name: audio-decoder-consumer
+          patternType: literal
+          type: group
         type: allow
     type: simple


### PR DESCRIPTION
I am using KafkaJS which requires kafka consumers to have a consumer group (compared to something like kafka-python). Therefore I am getting an error: `Not authorized to access group: Group authorization failed` when i try to connect a consumer.

So this pull request is adding that group to my user yaml.