### PR TITLE
Added a stream for BU Computer Science online Juypter-book course mat…

### DIFF
--- a/kfdefs/base/jupyterhub/notebook-images/bu-cs-jupyterbook.yaml
+++ b/kfdefs/base/jupyterhub/notebook-images/bu-cs-jupyterbook.yaml
@@ -1,0 +1,30 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: bu-cs-jupyter-book
+  labels:
+    component.opendatahub.io/name: jupyterhub
+    opendatahub.io/component: 'true'
+    opendatahub.io/notebook-image: 'true'
+  annotations:
+    opendatahub.io/notebook-image-name:
+      "BU CS Jupyter Book"
+    opendatahub.io/notebook-image-url:
+      "https://github.com/jappavoo/bu-cs-book-dev"
+    opendatahub.io/notebook-image-desc:
+      "Image for using and developing Boston University Course Materials"
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        openshift.io/imported-from: docker.io/jappavoo/bu-cs-book-dev
+      name: latest
+      from:
+        kind: DockerImage
+        name: 'docker.io/jappavoo/bu-cs-book-dev:latest'
+      importPolicy:
+        scheduled: true
+      referencePolicy:
+        type: Local

--- a/kfdefs/base/jupyterhub/notebook-images/kustomization.yaml
+++ b/kfdefs/base/jupyterhub/notebook-images/kustomization.yaml
@@ -19,3 +19,4 @@ resources:
   - s2i-spark3.0.1-minimal-notebook.yaml
   - time-series.yaml
   - s2i-pytorch-py38-notebook.yaml
+  - bu-cs-jupyterbook.yaml


### PR DESCRIPTION
…erial

The associated Dockerfile can be found here:
https://github.com/jappavoo/bu-cs-book-dev

The public container image is here:
https://hub.docker.com/repository/docker/jappavoo/bu-cs-book-dev

And this is being developed in context of this material:
https://github.com/jappavoo/UndertheCovers