### PR TITLE
Disable sending logs Elasticsearch and send logs to Loki

### DIFF
--- a/cluster-logging/base/clusterlogging.yaml
+++ b/cluster-logging/base/clusterlogging.yaml
@@ -5,37 +5,6 @@ metadata:
   name: "instance"
 spec:
   managementState: "Managed"
-  logStore:
-    type: "elasticsearch"
-    retentionPolicy:
-      application:
-        maxAge: 1d
-      infra:
-        maxAge: 7d
-      audit:
-        maxAge: 7d
-    elasticsearch:
-      resources:
-        requests:
-          cpu: 800m
-          memory: 10Gi
-        limits:
-          cpu: 2
-          memory: 16Gi
-      # it's better to keep nodeCount to a odd number for leader election issues
-      nodeCount: 5
-      storage:
-        storageClassName: "moc-nfs-csi"
-        size: 80Gi
-      redundancyPolicy: "ZeroRedundancy"
-  visualization:
-    type: "kibana"
-    kibana:
-      replicas: 1
-  curation:
-    type: "curator"
-    curator:
-      schedule: "30 3 * * *"
   collection:
     logs:
       type: "fluentd"

--- a/cluster-logging/overlays/moc/zero/clusterlogforwarders/clusterlogforwarder.yaml
+++ b/cluster-logging/overlays/moc/zero/clusterlogforwarders/clusterlogforwarder.yaml
@@ -8,7 +8,17 @@ spec:
   outputs:
     - name: app-logs
       type: kafka
-      url: tls://odh-message-bus-kafka-bootstrap-opf-kafka.apps.zero.massopen.cloud:443/zero-prod.cluster-logs.application
+      url: tls://odh-message-bus-kafka-bootstrap.opf-kafka.svc:9093/zero-prod.cluster-logs.application
+      secret:
+        name: clo-kafka
+    - name: infra-logs
+      type: kafka
+      url: tls://odh-message-bus-kafka-bootstrap.opf-kafka.svc:9093/zero-prod.cluster-logs.infrastructure
+      secret:
+        name: clo-kafka
+    - name: audit-logs
+      type: kafka
+      url: tls://odh-message-bus-kafka-bootstrap.opf-kafka.svc:9093/zero-prod.cluster-logs.audit
       secret:
         name: clo-kafka
   pipelines:
@@ -18,14 +28,14 @@ spec:
       outputRefs:
         - app-logs
         # default outputref sends logs to the default CLO ES
-        - default
+        # - default
     - name: forward-infra-logs
       inputRefs:
         - infrastructure
       outputRefs:
-        - default
+        - infra-logs
     - name: forward-audit-logs
       inputRefs:
         - audit
       outputRefs:
-        - default
+        - audit-logs

--- a/observatorium/base/instance/grafana.yaml
+++ b/observatorium/base/instance/grafana.yaml
@@ -4,7 +4,7 @@ kind: Grafana
 metadata:
     name: grafana
 spec:
-    baseImage: quay.io/operate-first/grafana:7.1.1
+    baseImage: quay.io/operate-first/grafana:8.0.6
     config:
         users:
             viewers_can_edit: true
@@ -25,5 +25,46 @@ spec:
             operator: In
             values:
             - grafana
+    containers:
+    -   args:
+        - -provider=openshift
+        - -pass-basic-auth=false
+        - -https-address=:9091
+        - -http-address=
+        - -email-domain=*
+        - -upstream=http://localhost:3000
+        - '-openshift-sar={"resource": "namespaces", "verb": "get"}'
+        - -openshift-service-account=grafana-serviceaccount
+        - -openshift-ca=/etc/pki/tls/cert.pem
+        - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        - -tls-cert=/etc/tls/private/tls.crt
+        - -tls-key=/etc/tls/private/tls.key
+        - -cookie-secret=SECRET
+        - -skip-auth-regex=^/metrics,/api/datasources,/api/dashboards
+        - '-openshift-sar={"resource": "namespaces", "verb": "get", "resourceName":
+            "openshift-logging", "namespace": "openshift-logging"}'
+        image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.7
+        name: oauth-proxy
+        ports:
+        -   containerPort: 9091
+            name: oauth-proxy
+        resources: {}
+        volumeMounts:
+        -   mountPath: /etc/tls/private
+            name: secret-grafana-tls
+            readOnly: false
     ingress:
-        enabled: true
+        enabled: false
+    secrets:
+    - grafana-tls
+    service:
+        annotations:
+            service.alpha.openshift.io/serving-cert-secret-name: grafana-tls
+        ports:
+        -   name: oauth-proxy
+            port: 9091
+            protocol: TCP
+            targetPort: oauth-proxy
+    serviceAccount:
+        annotations:
+            serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana"}}'

--- a/observatorium/overlays/moc/zero/grafana-data-sources/kustomization.yaml
+++ b/observatorium/overlays/moc/zero/grafana-data-sources/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - opf-test-loki-source.yaml
+  - opf-moc-zero-loki-source.yaml

--- a/observatorium/overlays/moc/zero/grafana-data-sources/opf-moc-zero-loki-source.yaml
+++ b/observatorium/overlays/moc/zero/grafana-data-sources/opf-moc-zero-loki-source.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDataSource
+metadata:
+    name: cluster-zero-logs
+spec:
+    name: cluster-zero-logs
+    datasources:
+        - name: cluster-zero-app-logs
+          type: loki
+          access: proxy
+          url: http://opf-observatorium-loki-query-frontend-http.opf-observatorium.svc.cluster.local:3100
+          version: 1
+          editable: false
+          jsonData:
+              httpHeaderName1: 'X-Scope-OrgID'
+          secureJsonData:
+              httpHeaderValue1: 'cluster-app-logs'
+        - name: cluster-zero-infra-logs
+          type: loki
+          access: proxy
+          url: http://opf-observatorium-loki-query-frontend-http.opf-observatorium.svc.cluster.local:3100
+          version: 1
+          editable: false
+          jsonData:
+              httpHeaderName1: 'X-Scope-OrgID'
+          secureJsonData:
+              httpHeaderValue1: 'cluster-infra-logs'
+        - name: cluster-zero-audit-logs
+          type: loki
+          access: proxy
+          url: http://opf-observatorium-loki-query-frontend-http.opf-observatorium.svc.cluster.local:3100
+          version: 1
+          editable: false
+          jsonData:
+              httpHeaderName1: 'X-Scope-OrgID'
+          secureJsonData:
+              httpHeaderValue1: 'cluster-audit-logs'

--- a/observatorium/overlays/moc/zero/routes/grafana-oauth-proxy.yaml
+++ b/observatorium/overlays/moc/zero/routes/grafana-oauth-proxy.yaml
@@ -1,0 +1,14 @@
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: grafana
+spec:
+  to:
+    kind: Service
+    name: grafana-service
+  port:
+    targetPort: oauth-proxy
+  tls:
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect

--- a/observatorium/overlays/moc/zero/routes/kustomization.yaml
+++ b/observatorium/overlays/moc/zero/routes/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - grafana-oauth-proxy.yaml
   - loki-distributor.yaml
   - loki-query-frontend-oauth-proxy.yaml
   - thanos-query-frontend-oauth-proxy.yaml

--- a/vector/overlays/moc/zero/opf-observatorium/configmap.yaml
+++ b/vector/overlays/moc/zero/opf-observatorium/configmap.yaml
@@ -80,11 +80,7 @@ data:
         type: remap
         inputs:
         - zero-audit-logs-kafka
-        source: "
-          message = parse_json!(.message) \n
-          .message = message.message \n
-          .docker = message.docker \n
-          .kubernetes = message.kubernetes \n "
+        source: ". = parse_json!(.message)"
 
     sinks:
       loki_sink_app:
@@ -142,7 +138,7 @@ data:
         labels:
           openshift_cluster: moc/zero
           cluster_log_level: audit-logs
-          k8s_namespace_name: "{{ kubernetes.namespace_name }}"
+          k8s_namespace_name: "{{ objectRef.namespace }}"
 
       vector_metrics_prom_exporter:
         type: prometheus_exporter

--- a/vector/overlays/moc/zero/opf-observatorium/configmap.yaml
+++ b/vector/overlays/moc/zero/opf-observatorium/configmap.yaml
@@ -12,7 +12,7 @@ data:
       playground: false
 
     sources:
-      opf_kafka_source:
+      zero-app-logs-kafka:
         type: kafka
         bootstrap_servers: odh-message-bus-kafka-bootstrap.opf-kafka.svc:9093
         group_id: cluster-logs-consumer
@@ -25,15 +25,61 @@ data:
           crt_file: "/mnt/tls.crt"
           key_file: "/mnt/tls.key"
 
+      zero-infra-logs-kafka:
+        type: kafka
+        bootstrap_servers: odh-message-bus-kafka-bootstrap.opf-kafka.svc:9093
+        group_id: cluster-logs-consumer
+        key_field: message_key
+        topics:
+        - zero-prod.cluster-logs.infrastructure
+        tls:
+          enabled: true
+          ca_file: "/mnt/ca-bundle.crt"
+          crt_file: "/mnt/tls.crt"
+          key_file: "/mnt/tls.key"
+
+      zero-audit-logs-kafka:
+        type: kafka
+        bootstrap_servers: odh-message-bus-kafka-bootstrap.opf-kafka.svc:9093
+        group_id: cluster-logs-consumer
+        key_field: message_key
+        topics:
+        - zero-prod.cluster-logs.audit
+        tls:
+          enabled: true
+          ca_file: "/mnt/ca-bundle.crt"
+          crt_file: "/mnt/tls.crt"
+          key_file: "/mnt/tls.key"
+
       vector_metrics_source:
         type: internal_metrics
         scrape_interval_secs: 60
 
     transforms:
-      loki_parser:
+      loki_parser_app:
         type: remap
         inputs:
-        - opf_kafka_source
+        - zero-app-logs-kafka
+        source: "
+          message = parse_json!(.message) \n
+          .message = message.message \n
+          .docker = message.docker \n
+          .kubernetes = message.kubernetes \n "
+
+      loki_parser_infra:
+        type: remap
+        inputs:
+        - zero-infra-logs-kafka
+        source: "
+          message = parse_json!(.message) \n
+          .message = message.message \n
+          .docker = message.docker \n
+          .kubernetes = message.kubernetes \n "
+
+      loki_parser_audit:
+        type: remap
+        inputs:
+        - zero-audit-logs-kafka
         source: "
           message = parse_json!(.message) \n
           .message = message.message \n
@@ -41,13 +87,16 @@ data:
           .kubernetes = message.kubernetes \n "
 
     sinks:
-      opf_loki_sink:
+      loki_sink_app:
         type: loki
         inputs:
-        - loki_parser
+        - loki_parser_app
         endpoint: http://opf-observatorium-loki-distributor-http.opf-observatorium.svc:3100
         out_of_order_action: rewrite_timestamp
         tenant_id: cluster-app-logs
+        batch:
+          max_bytes: 1024000 # 1MB
+          max_events: 1000000
         encoding:
           codec: json
         healthcheck:
@@ -55,6 +104,44 @@ data:
         labels:
           openshift_cluster: moc/zero
           cluster_log_level: app-logs
+          k8s_namespace_name: "{{ kubernetes.namespace_name }}"
+
+      loki_sink_infra:
+        type: loki
+        inputs:
+        - loki_parser_infra
+        endpoint: http://opf-observatorium-loki-distributor-http.opf-observatorium.svc:3100
+        out_of_order_action: rewrite_timestamp
+        tenant_id: cluster-infra-logs
+        batch:
+          max_bytes: 1024000 # 1MB
+          max_events: 1000000
+        encoding:
+          codec: json
+        healthcheck:
+          enabled: true
+        labels:
+          openshift_cluster: moc/zero
+          cluster_log_level: infra-logs
+          k8s_namespace_name: "{{ kubernetes.namespace_name }}"
+
+      loki_sink_audit:
+        type: loki
+        inputs:
+        - loki_parser_audit
+        endpoint: http://opf-observatorium-loki-distributor-http.opf-observatorium.svc:3100
+        out_of_order_action: rewrite_timestamp
+        tenant_id: cluster-audit-logs
+        batch:
+          max_bytes: 1024000 # 1MB
+          max_events: 1000000
+        encoding:
+          codec: json
+        healthcheck:
+          enabled: true
+        labels:
+          openshift_cluster: moc/zero
+          cluster_log_level: audit-logs
           k8s_namespace_name: "{{ kubernetes.namespace_name }}"
 
       vector_metrics_prom_exporter:


### PR DESCRIPTION
Update Log Forwarding to send logs to Kafka instead of Elasticsearch
Update Vector Config to consume logs from kafka and push to Loki
Add grafana dataources for the newly added logging tenants (infra/audit)
Also add an oauth proxy for observatorium grafana. Only accounts that have access to the `openshift-logging` namespace can view infra and audit logs.