### PR TITLE
Increase cluster-monitoring storage size to 150Gi

### DIFF
--- a/cluster-scope/overlays/prod/moc/zero/configmaps/cluster-monitoring-config.yaml
+++ b/cluster-scope/overlays/prod/moc/zero/configmaps/cluster-monitoring-config.yaml
@@ -13,4 +13,4 @@ data:
          volumeMode: Filesystem
          resources:
            requests:
-             storage: 100Gi
+             storage: 150Gi


### PR DESCRIPTION
Openshift Monitoring Prometheus Instance PVCs are full, we need to increase their size.