### PR TITLE
Add service monitor for meteor

### DIFF
--- a/cluster-scope/base/core/namespaces/aicoe-meteor/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/aicoe-meteor/kustomization.yaml
@@ -8,4 +8,5 @@ components:
     - ../../../../components/project-admin-rolebindings/thoth
     - ../../../../components/resourcequotas/small
     - ../../../../components/limitranges/default
+    - ../../../../components/monitoring-rbac
 namespace: aicoe-meteor

--- a/kfdefs/overlays/moc/zero/opf-monitoring/servicemonitors/kustomization.yaml
+++ b/kfdefs/overlays/moc/zero/opf-monitoring/servicemonitors/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - observatorium-servicemonitor.yaml
   - argocd-servicemonitor.yaml
   - apicurio-registry-servicemonitor.yaml
+  - meteor-servicemonitor.yaml

--- a/kfdefs/overlays/moc/zero/opf-monitoring/servicemonitors/meteor-servicemonitor.yaml
+++ b/kfdefs/overlays/moc/zero/opf-monitoring/servicemonitors/meteor-servicemonitor.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: meteor-shower-monitor
+  labels:
+    monitor-component: meteor-shower
+spec:
+  endpoints:
+    - port: http
+  namespaceSelector:
+    matchNames:
+      - aicoe-meteor
+  selector: {}


### PR DESCRIPTION
This addresses https://github.com/AICoE/meteor/issues/51

We want to enable prometheus monitoring for the meteor web application: http://meteor-shower-aicoe-meteor.apps.zero.massopen.cloud/