### PR TITLE
fix: add sre to secret generator

### DIFF
--- a/cluster-scope/overlays/prod/common/secret-generator.yaml
+++ b/cluster-scope/overlays/prod/common/secret-generator.yaml
@@ -34,6 +34,7 @@ files:
     - groups/sa-dach.enc.yaml
     - groups/sdap-mslsp.enc.yaml
     - groups/sigstore.enc.yaml
+    - groups/sre.enc.yaml
     - groups/team-pixel.enc.yaml
     - groups/thoth-devops.enc.yaml
     - groups/thoth.enc.yaml


### PR DESCRIPTION
Added fix because sre group was missing in secret-generator file. (issue https://github.com/operate-first/support/issues/318)