### PR TITLE
Resolve failing NodeNetworkConfigurationPolicy

### DIFF
--- a/cluster-scope/overlays/prod/moc/zero/nodenetworkconfigurationpolicies/moc-nfs-network.yaml
+++ b/cluster-scope/overlays/prod/moc/zero/nodenetworkconfigurationpolicies/moc-nfs-network.yaml
@@ -3,6 +3,7 @@ kind: NodeNetworkConfigurationPolicy
 metadata:
   name: moc-nfs-network-enp4s0f1np1
 spec:
+  Parallel: true
   nodeSelector:
     moc/primary-interface: enp4s0f1np1
   desiredState:
@@ -23,6 +24,7 @@ kind: NodeNetworkConfigurationPolicy
 metadata:
   name: moc-nfs-network-enp4s0f1
 spec:
+  Parallel: true
   nodeSelector:
     moc/primary-interface: enp4s0f1
   desiredState:
@@ -43,6 +45,7 @@ kind: NodeNetworkConfigurationPolicy
 metadata:
   name: moc-nfs-network-eno2
 spec:
+  Parallel: true
   nodeSelector:
     moc/primary-interface: eno2
   desiredState:


### PR DESCRIPTION
There is a failing NodeNetworkConfigurationPolicy on the zero cluster:

    $ oc get nncp
    NAME                          STATUS
    moc-nfs-network-eno2          SuccessfullyConfigured
    moc-nfs-network-enp4s0f1      ConfigurationProgressing
    moc-nfs-network-enp4s0f1np1   SuccessfullyConfigured

This causes us to lose network connectivity when an affected node
reboots. According to case 02961182 [1], this is caused by
RHBZ#1967771 [2]. The resolution is described in a knowedgebase
article [3].

In order to clear the condition, we will need to delete and re-create
the affected policies. Once this change merges we will delete the
resources and allow ArgoCD to re-create them.

[1]: https://access.redhat.com/support/cases/#/case/02961182
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1967771
[3]: https://access.redhat.com/solutions/6096871
