### PR TITLE
scrape metrics from openshift pipelines services

### DIFF
--- a/kfdefs/overlays/moc/zero/opf-monitoring/servicemonitors/kustomization.yaml
+++ b/kfdefs/overlays/moc/zero/opf-monitoring/servicemonitors/kustomization.yaml
@@ -4,8 +4,9 @@ kind: Kustomization
 commonLabels:
   prometheus: odh-monitoring
 resources:
-  - observatorium-servicemonitor.yaml
-  - argocd-servicemonitor.yaml
   - apicurio-registry-servicemonitor.yaml
+  - argocd-servicemonitor.yaml
   - meteor-operator-servicemonitor.yaml
   - meteor-servicemonitor.yaml
+  - observatorium-servicemonitor.yaml
+  - openshift-pipelines-servicemonitor.yaml

--- a/kfdefs/overlays/moc/zero/opf-monitoring/servicemonitors/openshift-pipelines-servicemonitor.yaml
+++ b/kfdefs/overlays/moc/zero/opf-monitoring/servicemonitors/openshift-pipelines-servicemonitor.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: openshift-pipelines-monitor
+  labels:
+    monitor-component: openshift-pipelines
+spec:
+  endpoints:
+    - port: http-metrics
+  namespaceSelector:
+    matchNames:
+      - openshift-pipelines
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: tekton-pipelines


### PR DESCRIPTION
scrape metrics from openshift pipelines services
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


openshift-pipelines exposes metrics on the port http-metrics.
It would be great to scrape them.