### PR TITLE
Update rick oidc oauth config CA and issuer url.

### DIFF
--- a/cluster-scope/overlays/prod/emea/rick/oauths/cluster_patch.yaml
+++ b/cluster-scope/overlays/prod/emea/rick/oauths/cluster_patch.yaml
@@ -8,8 +8,6 @@ spec:
     - mappingMethod: claim
       name: operate-first
       openID:
-        ca:
-          name: kube-root-ca.crt
         claims:
           email:
             - email
@@ -21,5 +19,5 @@ spec:
         clientSecret:
           name: operate-first-sso-secret
         extraScopes: []
-        issuer: https://keycloak-opf-auth.apps.moc-infra.massopen.cloud/auth/realms/operate-first
+        issuer: https://keycloak-keycloak.apps.moc-infra.massopen.cloud/auth/realms/operate-first
       type: OpenID


### PR DESCRIPTION
We were encountering the following errors: 

```
E0811 16:33:27.517143       1 base_controller.go:250] "ConfigObserver" controller failed to sync "key", err: failed to apply IDP operate-first config: x509: certificate signed by unknown authority
I0811 16:33:27.518051       1 status_controller.go:213] clusteroperator/authentication diff {"status":{"conditions":[{"lastTransitionTime":"2021-08-05T21:47:01Z","message":"OAuthServerConfigObservationDegraded: failed to apply IDP operate-first config: x509: certificate signed by unknown authority","reason":"AsExpected","status":"False","type":"Degraded"},{"lastTransitionTime":"2021-08-09T09:28:15Z","message":"All is well","reason":"AsExpected","status":"False","type":"Progressing"},{"lastTransitionTime":"2021-08-10T03:46:41Z","message":"OAuthServerDeploymentAvailable: availableReplicas==2","reason":"AsExpected","status":"True","type":"Available"},{"lastTransitionTime":"2021-06-23T08:48:19Z","message":"All is well","reason":"AsExpected","status":"True","type":"Upgradeable"}]}}
I0811 16:33:27.528074       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"openshift-authentication-operator", Name:"openshift-authentication-operator", UID:"", APIVersion:"v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'OperatorStatusChanged' Status for clusteroperator/authentication changed: Degraded message changed from "All is well" to "OAuthServerConfigObservationDegraded: failed to apply IDP operate-first config: x509: certificate signed by unknown authority"
I0811 16:33:27.730937       1 request.go:655] Throttling request took 1.996713023s, request: GET:https://172.30.0.1:443/api/v1/namespaces/openshift-config-managed/secrets?labelSelector=encryption.apiserver.operator.openshift.io%2Fcomponent%3Dopenshift-oauth-apiserver
```



From [here](https://docs.openshift.com/container-platform/4.7/authentication/identity_providers/configuring-oidc-identity-provider.html#identity-provider-oidc-CR_configuring-oidc-identity-provider) it seems to suggest that the CA bundle is supposed to validate the issuer's certs, but this is from infra, where the certs are issued via letsencrypt so we shouldn't need to do this, so I removed it. 

Also, the oidc auth uri was incorrect, this should fix it. 