### PR TITLE
Add auth via dex to grafana on zero.

### DIFF
--- a/dex/base/dex-sa.yaml
+++ b/dex/base/dex-sa.yaml
@@ -4,5 +4,6 @@ kind: ServiceAccount
 metadata:
   name: dex
   annotations:
-    serviceaccounts.openshift.io/oauth-redirecturi.dex: "api/dex/callback"
+    kustomize.config.k8s.io/behavior: replace
+    serviceaccounts.openshift.io/oauth-redirecturi.dex: "callback"
     serviceaccounts.openshift.io/oauth-redirectreference.dex: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"dex"}}'

--- a/dex/overlays/dev/dex-cm.yaml
+++ b/dex/overlays/dev/dex-cm.yaml
@@ -32,7 +32,13 @@ data:
       - id: grafana
         name: Grafana
         redirectURIs:
-          - https://grafana-route-opf-monitoring.apps-crc.testing/login/generic_oauth
+          - https://grafana-opf-monitoring.apps.zero.massopen.cloud/login/generic_oauth
+        secretEnv: GRAFANA_SECRET
+
+      - id: grafana-observatorium
+        name: Grafana Observatorium
+        redirectURIs:
+          - https://grafana-opf-observatorium.apps.zero.massopen.cloud/login/generic_oauth
         secretEnv: GRAFANA_SECRET
 
       - id: hue

--- a/dex/overlays/moc/zero/dex-cm.yaml
+++ b/dex/overlays/moc/zero/dex-cm.yaml
@@ -5,7 +5,7 @@ metadata:
   name: dex
 data:
   config.yaml: |
-    issuer: http://dex-server-opf-auth.apps.zero.massopen.cloud/api/dex
+    issuer: http://dex-dex.apps.zero.massopen.cloud
 
     storage:
       type: memory
@@ -32,15 +32,14 @@ data:
       - id: grafana
         name: Grafana
         redirectURIs:
-          - https://grafana-route-opf-monitoring.apps.zero.massopen.cloud/login/generic_oauth
+          - https://grafana-opf-monitoring.apps.zero.massopen.cloud/login/generic_oauth
         secretEnv: GRAFANA_SECRET
 
-      - id: hue
-        name: Hue
+      - id: grafana-observatorium
+        name: GrafanaObservatorium
         redirectURIs:
-          - https://hue-opf-datacatalog.apps.zero.massopen.cloud/oidc/callback
-          - https://hue-opf-datacatalog.apps.zero.massopen.cloud/hue/oidc_failed
-        secretEnv: HUE_SECRET
+          - https://grafana-opf-observatorium.apps.zero.massopen.cloud/login/generic_oauth
+        secretEnv: GRAFANA_SECRET
 
     connectors:
       - type: openshift
@@ -48,8 +47,8 @@ data:
         name: OpenShift
         config:
           issuer: https://kubernetes.default.svc
-          clientID: system:serviceaccount:opf-auth:dex
+          clientID: system:serviceaccount:dex:dex
           clientSecret: $OPENSHIFT_CLIENT_SECRET
-          redirectURI: http://dex-server-opf-auth.apps.zero.massopen.cloud/api/dex/callback
+          redirectURI: http://dex-dex.apps.zero.massopen.cloud/callback
           groups:
             - system:authenticated

--- a/docs/observatorium/loki/README.md
+++ b/docs/observatorium/loki/README.md
@@ -60,7 +60,7 @@ More Info on [/query_range](https://grafana.com/docs/loki/latest/api/#get-lokiap
 
 ### Grafana
 
-- url: https://grafana-route-opf-observatorium.apps.zero.massopen.cloud/
+- url: https://grafana-opf-observatorium.apps.zero.massopen.cloud/
 
 This is the endpoint for Grafana that can be used to query logs from Loki in a UI.
 
@@ -68,4 +68,4 @@ To be able to query logs using Grafana, you will need to add a Grafana Datasourc
 specific to your Org-ID (the `'X-Scope-OrgID'` header). To do that instructions are available [here](./add_loki_grafana_datasource.md).
 
 An example query should be accessible at the following url: <br>
-https://grafana-route-opf-observatorium.apps.zero.massopen.cloud/explore?orgId=1&left=["1607519717000","1607526347000","loki-opf-example",{"expr":"{app%3D\"my-app-1\"}"}]
+https://grafana-opf-observatorium.apps.zero.massopen.cloud/explore?orgId=1&left=["1607519717000","1607526347000","loki-opf-example",{"expr":"{app%3D\"my-app-1\"}"}]

--- a/docs/odh/grafana/README.md
+++ b/docs/odh/grafana/README.md
@@ -11,7 +11,7 @@ Dashboards can be represented by the `GrafanaDashboard` custom resource or by th
 
 ## Adding the Dashboards
 
-Grafana can be accessed at: https://grafana-route-opf-monitoring.apps.zero.massopen.cloud/.
+Grafana can be accessed at: https://grafana-opf-monitoring.apps.zero.massopen.cloud/.
 
 To add your dashboards to Grafana, you will need to create a `GrafanaDashboard` custom resource. To do this, you can follow the instructions available [here](./add_grafana_dashboard.md).
 

--- a/docs/odh/grafana/add_permissions_to_grafana.md
+++ b/docs/odh/grafana/add_permissions_to_grafana.md
@@ -1,0 +1,38 @@
+# Adding permissions in Grafana
+
+All Grafana deployments are configured via OAUTH using the Dex connector. Permissions are distributed by mapping Grafana
+[roles][roles] to OCP groups. This is done by updating the `role_attribute_path` as described [here][role_mapping] via
+the Grafana CR.
+
+# Give OCP group Grafana role
+Navigate to the Grafana CR, for the Grafana instance on the MOC environment [here][moc_environment].
+Find the attribute: `role_attribute_path` under `spec.config.auth.generic_oauth`
+
+You will see something like the following:
+
+```yaml
+  role_attribute_path: |
+    contains(groups[*], 'operate-first') && 'Admin' ||
+    contains(groups[*], 'data-science') && 'Viewer' ||
+    'Deny'
+```
+
+Add a line before `Deny` in the form of `contains(groups[*], '<YOUR_OCP_GROUP>') && '<GRAFANA_ROLE>' ||`.
+For example if we wanted to give the OCP group "my-team" the "Editor" Grafana role, we would update the field like so:
+
+```yaml
+  role_attribute_path: |
+    contains(groups[*], 'operate-first') && 'Admin' ||
+    contains(groups[*], 'data-science') && 'Viewer' ||
+    contains(groups[*], 'my-team') && 'Editor' ||
+    'Deny'
+```
+
+Submit a PR with the changes.
+
+NOTE: The same applies for the observatorium CR found [here][observatorium_grafana].
+
+[roles]: https://grafana.com/docs/grafana/latest/permissions/organization_roles/
+[role_mapping]: https://grafana.com/docs/grafana/latest/auth/generic-oauth/#jmespath-examples
+[observatorium_grafana]: https://github.com/operate-first/apps/blob/master/observatorium/base/instance/grafana.yaml
+[moc_environment]: https://github.com/operate-first/apps/blob/master/odh-manifests/grafana/grafana/base/grafana.yaml

--- a/kfdefs/base/monitoring/blackbox-exporter/probe.yaml
+++ b/kfdefs/base/monitoring/blackbox-exporter/probe.yaml
@@ -19,7 +19,7 @@ spec:
       - http://superset-opf-superset.apps.zero.massopen.cloud/
       - https://hue-opf-datacatalog.apps.zero.massopen.cloud/desktop/debug/is_alive
       - http://thriftserver-opf-datacatalog.apps.zero.massopen.cloud/
-      - https://grafana-route-opf-monitoring.apps.zero.massopen.cloud/
+      - https://grafana-opf-monitoring.apps.zero.massopen.cloud/
       - https://kibana-openshift-logging.apps.zero.massopen.cloud/api/status
       - https://elasticsearch-openshift-logging.apps.zero.massopen.cloud/
       - http://istio-ingressgateway-istio-system.apps.zero.massopen.cloud/

--- a/kfdefs/overlays/moc/zero/opf-monitoring/kustomization.yaml
+++ b/kfdefs/overlays/moc/zero/opf-monitoring/kustomization.yaml
@@ -2,7 +2,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: opf-monitoring
-
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: grafana-config-overrides
+    literals:
+      - GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_STRICT=true
 resources:
   - ../../../../base/monitoring
   - dashboards

--- a/kfdefs/overlays/moc/zero/opf-monitoring/secrets/kustomization.yaml
+++ b/kfdefs/overlays/moc/zero/opf-monitoring/secrets/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: opf-monitoring
-
+generators:
+  - secret-generator.yaml
 resources:
   - prometheus-k8s.yaml

--- a/kfdefs/overlays/moc/zero/opf-monitoring/secrets/oauth-client-secret.enc.yaml
+++ b/kfdefs/overlays/moc/zero/opf-monitoring/secrets/oauth-client-secret.enc.yaml
@@ -1,0 +1,38 @@
+kind: Secret
+apiVersion: v1
+metadata:
+    name: oauth-client-secret
+stringData:
+    GRAFANA_CLIENT_SECRET: ENC[AES256_GCM,data:R1Vav5B3s7xF99xzYJWxDmz7MSqkkxhpGMdpftmfmfwan53n,iv:s9vFl/bxwnNx78thmmQulKYgRkfI4SCptHP3G79auBg=,tag:YoZBetd4Y1yg6vBj6GUO1w==,type:str]
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-08-12T00:58:31Z'
+    mac: ENC[AES256_GCM,data:vBx4IujQsDL0p0pS8h53bxIoTj5JuoFRnfO+gbvuETCU3B9/AISBXBzK4AxWOB9O4WvbRWDhkspSZUsXcbmr16Z8ZO/94mVACrbO5uS3Td5lZxCUlMa2LoQbXAMmN5xnRXxXdtDBW1nqJPgNlT+5QNSxaTqH2ffEWuioi/qjp2Q=,iv:rKlOgppBBcRFfU7o/u2DUp0F0Abdf4VRS2L1H1Bwc48=,tag:UA+JzMF3vNqQzUovSJwQ+g==,type:str]
+    pgp:
+    -   created_at: '2021-08-12T00:58:30Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA9aKBcudqifiARAAUWBastLjMASeDCAHB9br4LrebMkSPG6R4t5bbNKVodQo
+            3xecRoVueuhCnLsL6vlVVbKFdeNVNI7GmB8FaOKE/CHe6BZxC4qrwnBDvs6KACbR
+            rOIsL56DpNHo0qfnYBqmDMtiGwd9lryAUt0DChJweBJNSKIdDEvkXq8z8BG4eRWe
+            OkEpCeXT+ztIcFVAhB/ltj02keTtCp+Vetgc5IljjkrtjUh9sYQFdSUl+oT1vbJN
+            ZcjZ38ZTV4E8bUmlBbgz1LdmQkvJ+inJuxhWaNT9R/Nhyxt4dGyYHyFNPTm07y+I
+            oDhMV/IX41/dM8gqjJZDphNjPhu4O3YO7Xei0ty1vsk3NtRqaDcTBpiOJ2TzLssO
+            UKBwFdue901nx2GrxvIy1UUHyl1fPg9CCqftCvxjyLuTO22LEvA6z7cFtXxOEuiu
+            vfbZPpt7E9n/e7MQDljfosIW1MzK69n/yscSIYIx0MSzleUMmoOApcPWzgBwZy0Z
+            OmQ9GDoM0K/VQGsnhzIUtj2i1iubQbyRQhhyBp/tWS1dPYE1gK0TDQNHldCE5t//
+            1cX1+cZmUhwKBz6ONUjnUdoMuLoGVjEACNsdV4lPjI3c+NoXu3SlaQ+7Sf4ka0ZO
+            alsVCQ5RMAG80lwpzDFyuRzbFzCcqFgHGampilGv3vE32rSkj+OwdDhMkgTy9ifS
+            4AHkNR1EiCzuJBZ984jIB7w0F+HBxOAk4BPhd6/gUOJZxalH4LHlQMIAzV3uloDO
+            IfCxhpK+25iyD4drrd6U5k/F9eS7gk7gWeSvViAcoNl+7PwG7eMRkLJL4rN2M+7h
+            4GkA
+            =ipYZ
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^(users|data|stringData)$
+    version: 3.6.1

--- a/kfdefs/overlays/moc/zero/opf-monitoring/secrets/secret-generator.yaml
+++ b/kfdefs/overlays/moc/zero/opf-monitoring/secrets/secret-generator.yaml
@@ -1,0 +1,6 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: secret-generator
+files:
+  - oauth-client-secret.enc.yaml

--- a/observatorium/base/instance/example-oauth-client-secret.enc.yaml
+++ b/observatorium/base/instance/example-oauth-client-secret.enc.yaml
@@ -1,0 +1,7 @@
+kind: Secret
+apiVersion: v1
+metadata:
+    name: oauth-client-secret
+stringData:
+    GRAFANA_CLIENT_SECRET: SECRET
+type: Opaque

--- a/observatorium/base/instance/grafana.yaml
+++ b/observatorium/base/instance/grafana.yaml
@@ -2,69 +2,45 @@
 apiVersion: integreatly.org/v1alpha1
 kind: Grafana
 metadata:
-    name: grafana
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  name: grafana
 spec:
-    baseImage: quay.io/operate-first/grafana:8.0.6
-    config:
-        users:
-            viewers_can_edit: true
-            allow_sign_up: false
-            auto_assign_org: true
-            auto_assign_org_role: Viewer
-        auth:
-            disable_login_form: true
-        auth.anonymous:
-            enabled: true
-            org_role: Viewer
-        log:
-            level: warn
-            mode: console
-    dashboardLabelSelector:
-    -   matchExpressions:
-        -   key: app
-            operator: In
-            values:
+  baseImage: quay.io/operate-first/grafana:8.1.1
+  deployment:
+    envFrom:
+      - secretRef:
+          name: oauth-client-secret
+      - configMapRef:
+          name: grafana-config-overrides
+  config:
+    server:
+      root_url: https://grafana-opf-observatorium.apps.zero.massopen.cloud
+    auth.generic_oauth:
+      name: Dex
+      enabled: true
+      scopes: openid email groups profile
+      email_attribute_name: name
+      email_attribute_path: name
+      client_id: grafana-observatorium
+      client_secret: "${GRAFANA_CLIENT_SECRET}"
+      api_url: http://dex-dex.apps.zero.massopen.cloud/userinfo
+      auth_url: http://dex-dex.apps.zero.massopen.cloud/auth
+      token_url: http://dex-dex.apps.zero.massopen.cloud/token
+      role_attribute_path: >-
+        contains(groups[*], 'cluster-admins') && 'Admin' ||
+        contains(groups[*], 'operate-first') && 'Admin' ||
+        contains(groups[*], 'data-science') && 'Viewer' ||
+        'Deny'
+      role_attribute_strict: true
+    log:
+      level: warn
+      mode: console
+  dashboardLabelSelector:
+    - matchExpressions:
+        - key: app
+          operator: In
+          values:
             - grafana
-    containers:
-    -   args:
-        - -provider=openshift
-        - -pass-basic-auth=false
-        - -https-address=:9091
-        - -http-address=
-        - -email-domain=*
-        - -upstream=http://localhost:3000
-        - '-openshift-sar={"resource": "namespaces", "verb": "get"}'
-        - -openshift-service-account=grafana-serviceaccount
-        - -openshift-ca=/etc/pki/tls/cert.pem
-        - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        - -tls-cert=/etc/tls/private/tls.crt
-        - -tls-key=/etc/tls/private/tls.key
-        - -cookie-secret=SECRET
-        - -skip-auth-regex=^/metrics,/api/datasources,/api/dashboards
-        - '-openshift-sar={"resource": "namespaces", "verb": "get", "resourceName":
-            "openshift-logging", "namespace": "openshift-logging"}'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.7
-        name: oauth-proxy
-        ports:
-        -   containerPort: 9091
-            name: oauth-proxy
-        resources: {}
-        volumeMounts:
-        -   mountPath: /etc/tls/private
-            name: secret-grafana-tls
-            readOnly: false
-    ingress:
-        enabled: false
-    secrets:
-    - grafana-tls
-    service:
-        annotations:
-            service.alpha.openshift.io/serving-cert-secret-name: grafana-tls
-        ports:
-        -   name: oauth-proxy
-            port: 9091
-            protocol: TCP
-            targetPort: oauth-proxy
-    serviceAccount:
-        annotations:
-            serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana"}}'
+  ingress:
+    enabled: false

--- a/observatorium/base/instance/kustomization.yaml
+++ b/observatorium/base/instance/kustomization.yaml
@@ -9,3 +9,9 @@ resources:
   - observatorium.yaml
   - kfdef.yaml
   - grafana.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: grafana-config-overrides
+    literals:
+      - GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_STRICT=true

--- a/observatorium/overlays/moc/zero/routes/grafana-route.yaml
+++ b/observatorium/overlays/moc/zero/routes/grafana-route.yaml
@@ -8,7 +8,7 @@ spec:
     kind: Service
     name: grafana-service
   port:
-    targetPort: oauth-proxy
+    targetPort: grafana
   tls:
-    termination: reencrypt
+    termination: edge
     insecureEdgeTerminationPolicy: Redirect

--- a/observatorium/overlays/moc/zero/routes/kustomization.yaml
+++ b/observatorium/overlays/moc/zero/routes/kustomization.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - grafana-oauth-proxy.yaml
+  - grafana-route.yaml
   - loki-distributor.yaml
   - loki-query-frontend-oauth-proxy.yaml
   - thanos-query-frontend-oauth-proxy.yaml

--- a/observatorium/overlays/moc/zero/secrets/oauth-client-secret.enc.yaml
+++ b/observatorium/overlays/moc/zero/secrets/oauth-client-secret.enc.yaml
@@ -1,0 +1,38 @@
+kind: Secret
+apiVersion: v1
+metadata:
+    name: oauth-client-secret
+stringData:
+    GRAFANA_CLIENT_SECRET: ENC[AES256_GCM,data:R1Vav5B3s7xF99xzYJWxDmz7MSqkkxhpGMdpftmfmfwan53n,iv:s9vFl/bxwnNx78thmmQulKYgRkfI4SCptHP3G79auBg=,tag:YoZBetd4Y1yg6vBj6GUO1w==,type:str]
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-08-12T00:58:31Z'
+    mac: ENC[AES256_GCM,data:vBx4IujQsDL0p0pS8h53bxIoTj5JuoFRnfO+gbvuETCU3B9/AISBXBzK4AxWOB9O4WvbRWDhkspSZUsXcbmr16Z8ZO/94mVACrbO5uS3Td5lZxCUlMa2LoQbXAMmN5xnRXxXdtDBW1nqJPgNlT+5QNSxaTqH2ffEWuioi/qjp2Q=,iv:rKlOgppBBcRFfU7o/u2DUp0F0Abdf4VRS2L1H1Bwc48=,tag:UA+JzMF3vNqQzUovSJwQ+g==,type:str]
+    pgp:
+    -   created_at: '2021-08-12T00:58:30Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA9aKBcudqifiARAAUWBastLjMASeDCAHB9br4LrebMkSPG6R4t5bbNKVodQo
+            3xecRoVueuhCnLsL6vlVVbKFdeNVNI7GmB8FaOKE/CHe6BZxC4qrwnBDvs6KACbR
+            rOIsL56DpNHo0qfnYBqmDMtiGwd9lryAUt0DChJweBJNSKIdDEvkXq8z8BG4eRWe
+            OkEpCeXT+ztIcFVAhB/ltj02keTtCp+Vetgc5IljjkrtjUh9sYQFdSUl+oT1vbJN
+            ZcjZ38ZTV4E8bUmlBbgz1LdmQkvJ+inJuxhWaNT9R/Nhyxt4dGyYHyFNPTm07y+I
+            oDhMV/IX41/dM8gqjJZDphNjPhu4O3YO7Xei0ty1vsk3NtRqaDcTBpiOJ2TzLssO
+            UKBwFdue901nx2GrxvIy1UUHyl1fPg9CCqftCvxjyLuTO22LEvA6z7cFtXxOEuiu
+            vfbZPpt7E9n/e7MQDljfosIW1MzK69n/yscSIYIx0MSzleUMmoOApcPWzgBwZy0Z
+            OmQ9GDoM0K/VQGsnhzIUtj2i1iubQbyRQhhyBp/tWS1dPYE1gK0TDQNHldCE5t//
+            1cX1+cZmUhwKBz6ONUjnUdoMuLoGVjEACNsdV4lPjI3c+NoXu3SlaQ+7Sf4ka0ZO
+            alsVCQ5RMAG80lwpzDFyuRzbFzCcqFgHGampilGv3vE32rSkj+OwdDhMkgTy9ifS
+            4AHkNR1EiCzuJBZ984jIB7w0F+HBxOAk4BPhd6/gUOJZxalH4LHlQMIAzV3uloDO
+            IfCxhpK+25iyD4drrd6U5k/F9eS7gk7gWeSvViAcoNl+7PwG7eMRkLJL4rN2M+7h
+            4GkA
+            =ipYZ
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^(users|data|stringData)$
+    version: 3.6.1

--- a/observatorium/overlays/moc/zero/secrets/secret-generator.yaml
+++ b/observatorium/overlays/moc/zero/secrets/secret-generator.yaml
@@ -1,7 +1,8 @@
 apiVersion: viaduct.ai/v1
 kind: ksops
 metadata:
-  name: loki-objectstorage-secret-generator
+  name: secret-generator
 files:
   - ./secrets/loki-objectstorage-secret.enc.yaml
+  - ./secrets/oauth-client-secret.enc.yaml
   - ./secrets/thanos-objectstorage-secret.enc.yaml

--- a/odh-manifests/grafana/grafana/base/grafana.yaml
+++ b/odh-manifests/grafana/grafana/base/grafana.yaml
@@ -2,72 +2,45 @@
 apiVersion: integreatly.org/v1alpha1
 kind: Grafana
 metadata:
-    annotations:
-        argocd.argoproj.io/sync-wave: "1"
-    name: grafana
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  name: grafana
 spec:
-    baseImage: quay.io/operate-first/grafana:7.1.1
-    config:
-        security:
-            admin_user: "root"
-            admin_password: "secret"
-        users:
-            allow_sign_up: false
-            auto_assign_org: true
-            auto_assign_org_role: Viewer
-            viewers_can_edit: true
-        auth.anonymous:
-            enabled: true
-            org_role: Viewer
-        log:
-            level: warn
-            mode: console
-    dashboardLabelSelector:
-    -   matchExpressions:
-        -   key: app
-            operator: In
-            values:
+  baseImage: quay.io/operate-first/grafana:8.1.1
+  deployment:
+    envFrom:
+      - secretRef:
+          name: oauth-client-secret
+      - configMapRef:
+          name: grafana-config-overrides
+  config:
+    server:
+      root_url: https://grafana-opf-monitoring.apps.zero.massopen.cloud
+    auth.generic_oauth:
+      name: Dex
+      enabled: true
+      scopes: openid email groups profile
+      email_attribute_name: name
+      email_attribute_path: name
+      client_id: grafana
+      client_secret: "${GRAFANA_CLIENT_SECRET}"
+      api_url: http://dex-dex.apps.zero.massopen.cloud/userinfo
+      auth_url: http://dex-dex.apps.zero.massopen.cloud/auth
+      token_url: http://dex-dex.apps.zero.massopen.cloud/token
+      role_attribute_path: >-
+        contains(groups[*], 'cluster-admins') && 'Admin' ||
+        contains(groups[*], 'operate-first') && 'Admin' ||
+        contains(groups[*], 'data-science') && 'Viewer' ||
+        'Deny'
+      role_attribute_strict: true
+    log:
+      level: warn
+      mode: console
+  dashboardLabelSelector:
+    - matchExpressions:
+        - key: app
+          operator: In
+          values:
             - grafana
-    containers:
-    -   args:
-        - -provider=openshift
-        - -pass-basic-auth=false
-        - -https-address=:9091
-        - -http-address=
-        - -email-domain=*
-        - -upstream=http://localhost:3000
-        - '-openshift-sar={"resource": "namespaces", "verb": "get"}'
-        - -openshift-service-account=grafana-serviceaccount
-        - -openshift-ca=/etc/pki/tls/cert.pem
-        - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        - -tls-cert=/etc/tls/private/tls.crt
-        - -tls-key=/etc/tls/private/tls.key
-        - -cookie-secret=SECRET
-        - -skip-auth-regex=^/metrics,/api/datasources,/api/dashboards
-        - '-openshift-sar={"resource": "namespaces", "verb": "get", "resourceName":
-            "opf-monitoring", "namespace": "opf-monitoring"}'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.7
-        name: oauth-proxy
-        ports:
-        -   containerPort: 9091
-            name: oauth-proxy
-        resources: {}
-        volumeMounts:
-        -   mountPath: /etc/tls/private
-            name: secret-grafana-tls
-            readOnly: false
-    ingress:
-        enabled: false
-    secrets:
-    - grafana-tls
-    service:
-        annotations:
-            service.alpha.openshift.io/serving-cert-secret-name: grafana-tls
-        ports:
-        -   name: oauth-proxy
-            port: 9091
-            protocol: TCP
-            targetPort: oauth-proxy
-    serviceAccount:
-        annotations:
-            serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana"}}'
+  ingress:
+    enabled: false

--- a/odh-manifests/grafana/grafana/base/route.yaml
+++ b/odh-manifests/grafana/grafana/base/route.yaml
@@ -4,12 +4,11 @@ apiVersion: route.openshift.io/v1
 metadata:
   name: grafana
 spec:
-  host: grafana-route-opf-monitoring.apps.zero.massopen.cloud
   to:
     kind: Service
     name: grafana-service
   port:
-    targetPort: oauth-proxy
+    targetPort: grafana
   tls:
-    termination: reencrypt
+    termination: edge
     insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION
Resolve: #37 

Also does a few other things: 

- Remove hue client from dex 
- Fix dex redirect/issuer paths
- Fix dex SA namesspace
- Change Grafana route to match route metadata.name
- Add doc on how to give ocp groups grafana roles 

Those in the ocp groups `cluster-admins` / `operate-first` have Admin in Grafana, while those in `data-science` group have `viewer`