### PR TITLE
fix: JupyterHub single user profile sizes split

### DIFF
--- a/odh-manifests/jupyterhub/base/jupyterhub-singleuser-profiles-configmap.yaml
+++ b/odh-manifests/jupyterhub/base/jupyterhub-singleuser-profiles-configmap.yaml
@@ -54,29 +54,3 @@ data:
               spark_image: 'quay.io/radanalyticsio/openshift-spark-py36:2.4.5-2'
             return:
               SPARK_CLUSTER: 'metadata.name'
-
-      sizes:
-      - name: Medium
-        resources:
-          requests:
-            memory: 2Gi
-            cpu: 100m
-          limits:
-            memory: 4Gi
-            cpu: 2
-      - name: Large - CPU intensive
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 1
-          limits:
-            memory: 8Gi
-            cpu: 4
-      - name: Large - Memory intensive
-        resources:
-          requests:
-            memory: 16Gi
-            cpu: 100m
-          limits:
-            memory: 32Gi
-            cpu: 4

--- a/odh-manifests/jupyterhub/base/jupyterhub-singleuser-profiles-sizes-configmap.yaml
+++ b/odh-manifests/jupyterhub/base/jupyterhub-singleuser-profiles-sizes-configmap.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: odh-jupyterhub-sizes
+  labels:
+    jupyterhub: singleuser-profiles
+data:
+  jupyterhub-singleuser-profiles.yaml: |
+      sizes:
+      - name: Medium
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 100m
+          limits:
+            memory: 4Gi
+            cpu: 2
+      - name: Large - CPU intensive
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 1
+          limits:
+            memory: 8Gi
+            cpu: 4
+      - name: Large - Memory intensive
+        resources:
+          requests:
+            memory: 16Gi
+            cpu: 100m
+          limits:
+            memory: 32Gi
+            cpu: 4


### PR DESCRIPTION
Adopts: https://github.com/opendatahub-io/odh-manifests/pull/398 

`sizes` and `profiles` were split into 2 different configmaps which are later merged.

CM `odh-jupyterhub-sizes` respects the [upstream manifest](https://github.com/opendatahub-io/odh-manifests/blob/master/jupyterhub/jupyterhub/base/jupyterhub-singleuser-profiles-sizes-configmap.yaml) and sets our custom values.
CM `jupyter-singleuser-profiles` remains the same (without sizes) because of https://github.com/operate-first/apps/pull/744