### PR TITLE
feat: Set better meteor limit range

### DIFF
--- a/cluster-scope/base/core/namespaces/aicoe-meteor/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/aicoe-meteor/kustomization.yaml
@@ -2,11 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
     - namespace.yaml
+    - limitrange.yaml
 components:
     - ../../../../components/project-admin-rolebindings/operate-first
     - ../../../../components/project-admin-rolebindings/data-science
     - ../../../../components/project-admin-rolebindings/thoth
     - ../../../../components/resourcequotas/large
-    - ../../../../components/limitranges/default
     - ../../../../components/monitoring-rbac
 namespace: aicoe-meteor

--- a/cluster-scope/base/core/namespaces/aicoe-meteor/limitrange.yaml
+++ b/cluster-scope/base/core/namespaces/aicoe-meteor/limitrange.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: default
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: "2"
+        memory: 8Gi
+      defaultRequest:
+        cpu: 300m
+        memory: 400Mi


### PR DESCRIPTION
Tekton pipelines uses default limitranges for default settings. This change will make tekton steps use better and larger limits by default.

/cc @4n4nd @HumairAK 