### PR TITLE
feat: Up meteor quota limit

### DIFF
--- a/cluster-scope/base/core/namespaces/aicoe-meteor/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/aicoe-meteor/kustomization.yaml
@@ -3,10 +3,10 @@ kind: Kustomization
 resources:
     - namespace.yaml
     - limitrange.yaml
+    - resourcequota.yaml
 components:
     - ../../../../components/project-admin-rolebindings/operate-first
     - ../../../../components/project-admin-rolebindings/data-science
     - ../../../../components/project-admin-rolebindings/thoth
-    - ../../../../components/resourcequotas/large
     - ../../../../components/monitoring-rbac
 namespace: aicoe-meteor

--- a/cluster-scope/base/core/namespaces/aicoe-meteor/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/aicoe-meteor/resourcequota.yaml
@@ -1,0 +1,12 @@
+kind: ResourceQuota
+apiVersion: v1
+metadata:
+  name: aicoe-meteor-custom
+spec:
+  hard:
+    requests.cpu: "4"
+    requests.memory: 16Gi
+    limits.cpu: "16"
+    limits.memory: 30Gi
+    requests.storage: 80Gi
+    count/objectbucketclaims.objectbucket.io: 1


### PR DESCRIPTION
I think I need to request bigger quota limit for the meteor namespace.

Together with #911 the default cumulative limit went up, because each container has 4 CPU limit by default. So if a pod has 3 containers it's limit is 6 cores now. It will probably never use it but we need to be able to schedule it. This should keep requests low and raise limits for now. I'll look into better way to influnce those limits in future.