### PR TITLE
Schedule trino workers to os-wrk-1 on zero.

### DIFF
--- a/cluster-scope/base/core/namespaces/opf-trino/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/opf-trino/resourcequota.yaml
@@ -4,9 +4,9 @@ metadata:
   name: opf-trino-custom
 spec:
   hard:
-    limits.cpu: '8'
-    limits.memory: 40Gi
-    requests.cpu: '4'
-    requests.memory: 40Gi
+    limits.cpu: '40'
+    limits.memory: 100Gi
+    requests.cpu: '20'
+    requests.memory: 80Gi
     requests.storage: 20Gi
     count/objectbucketclaims.objectbucket.io: 1

--- a/kfdefs/overlays/moc/zero/opf-trino/kustomization.yaml
+++ b/kfdefs/overlays/moc/zero/opf-trino/kustomization.yaml
@@ -23,7 +23,11 @@ patchesJson6902:
               - name: trino_memory_request
                 value: 8Gi
               - name: trino_memory_limit
-                value: 8Gi
+                value: 16Gi
+              - name: trino_cpu_request
+                value: 4
+              - name: trino_cpu_limit
+                value: 8
             repoRef:
               name: opf
               path: odh-manifests/trino

--- a/odh-manifests/trino/base/trino-worker-dc.yaml
+++ b/odh-manifests/trino/base/trino-worker-dc.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trino-worker
+  labels:
+    instance: trino
+    role: trino-worker
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      instance: trino
+      role: trino-worker
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        instance: trino
+        role: trino-worker
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: os-wrk-1
+      tolerations:
+        - key: "no-storage"
+          value: "true"
+          effect: "NoExecute"
+      volumes:
+        - name: trino-config-volume
+          secret:
+            secretName: trino-config
+            defaultMode: 420
+            items:
+              - key: config-worker.properties
+                path: config-worker.properties
+              - key: jvm.config
+                path: jvm.config
+              - key: log.properties
+                path: log.properties
+              - key: node.properties
+                path: node.properties
+        - name: trino-catalogs-volume
+          secret:
+            secretName: trino-catalog
+            defaultMode: 420
+            items:
+              - key: hive.properties
+                path: hive.properties
+      containers:
+        - resources:
+            requests:
+              cpu: $(trino_cpu_request)
+              memory: $(trino_memory_request)
+            limits:
+              cpu: $(trino_cpu_limit)
+              memory: $(trino_memory_limit)
+          name: trino-worker
+          command:
+            - /usr/lib/trino/bin/run-trino
+          env:
+            - name: POD_ID
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.uid
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: $(s3_credentials_secret)
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: $(s3_credentials_secret)
+                  key: AWS_SECRET_ACCESS_KEY
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: trino-config-volume
+              mountPath: /etc/trino
+            - name: trino-catalogs-volume
+              mountPath: /etc/trino/catalog
+          image: $(trino_image)
+          args:
+            - --config=/etc/trino/config-worker.properties


### PR DESCRIPTION
Using overrides here to change resource usages (cpu:8, mem: 16Gi), and adds the toleration/node selectors to run on os-wrk-1