### PR TITLE
Add OSC manifests to opf apps repo.

### DIFF
--- a/acme-operator/overlays/osc/osc-cl1/issuer-letsencrypt-live.yaml
+++ b/acme-operator/overlays/osc/osc-cl1/issuer-letsencrypt-live.yaml
@@ -1,0 +1,12 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: letsencrypt-live
+  annotations:
+    acme.openshift.io/priority: "100"
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+  labels:
+    managed-by: "openshift-acme"
+    type: "CertIssuer"
+data:
+  "cert-issuer.types.acme.openshift.io": '{"type":"ACME","acmeCertIssuer":{"directoryUrl":"https://acme-v02.api.letsencrypt.org/directory"}}'

--- a/acme-operator/overlays/osc/osc-cl1/kustomization.yaml
+++ b/acme-operator/overlays/osc/osc-cl1/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../base
+- issuer-letsencrypt-live.yaml
+namespace: acme-operator

--- a/cloudbeaver/overlays/osc/osc-cl1/add_configs.yaml
+++ b/cloudbeaver/overlays/osc/osc-cl1/add_configs.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudbeaver
+spec:
+  template:
+    spec:
+      volumes:
+        - name: configs
+          configMap:
+            name: cloudbeaver-config
+      containers:
+        - name: cloudbeaver
+          volumeMounts:
+            - name: configs
+              mountPath: /opt/cloudbeaver/conf

--- a/cloudbeaver/overlays/osc/osc-cl1/configs/cloudbeaver.conf
+++ b/cloudbeaver/overlays/osc/osc-cl1/configs/cloudbeaver.conf
@@ -1,0 +1,59 @@
+// Main server configuration
+// https://github.com/dbeaver/cloudbeaver/wiki/Server-configuration
+{
+    server: {
+        serverPort: 8978,
+
+        workspaceLocation: "workspace",
+        contentRoot: "web",
+        driversLocation: "drivers",
+
+        rootURI: "/",
+        serviceURI: "/api/",
+
+        productConfiguration: "conf/product.conf",
+
+        expireSessionAfterPeriod: 1800000,
+
+        develMode: false,
+
+        database: {
+            driver="h2_embedded",
+            url: "jdbc:h2:${workspace}/.data/cb.h2.dat",
+
+            createDatabase: true,
+
+            initialDataConfiguration: "conf/initial-data.conf",
+
+            pool: {
+                minIdleConnections: 4,
+                maxIdleConnections: 10,
+                maxConnections: 100,
+                validationQuery: "SELECT 1"
+            }
+        }
+
+    },
+    app: {
+        anonymousAccessEnabled: true,
+        anonymousUserRole: "user",
+        supportsCustomConnections: false,
+
+        publicCredentialsSaveEnabled: true,
+        adminCredentialsSaveEnabled: true
+
+        /*
+        enabledDrivers: [
+            "postgresql:postgres-jdbc",
+            "mysql:mysql8",
+            "mysql:mariaDB",
+            "generic:sqlite_jdbc",
+            "generic:derby_server",
+            "generic:h2_embedded",
+            "jaybird:jaybird",
+        ]
+        */
+
+    }
+
+}

--- a/cloudbeaver/overlays/osc/osc-cl1/configs/initial-data-sources.conf
+++ b/cloudbeaver/overlays/osc/osc-cl1/configs/initial-data-sources.conf
@@ -1,0 +1,65 @@
+{
+    "folders": {},
+    "connections": {
+        "sqlite_xerial-sample-database": {
+            "provider": "generic",
+            "driver": "sqlite_jdbc",
+            "name": "SQLite - Chinook (Sample)",
+            "save-password": true,
+            "read-only": false,
+            "configuration": {
+                "database": "${application.path}/../samples/db/Chinook.sqlitedb",
+                "type": "dev",
+                "auth-model": "native"
+            }
+        },
+        "postgresql-template-1": {
+            "provider": "postgresql",
+            "driver": "postgres-jdbc",
+            "name": "PostgreSQL (Template)",
+            "save-password": false,
+            "template": true,
+            "read-only": true,
+            "configuration": {
+                "host": "localhost",
+                "port": "5432",
+                "database": "postgres",
+                "url": "jdbc:postgresql://localhost:5432/postgres",
+                "type": "dev",
+                "provider-properties": {
+                    "@dbeaver-show-non-default-db@": "false"
+                }
+            }
+        },
+        "trino_operate_first": {
+            "provider": "generic",
+            "driver": "trino_jdbc",
+            "name": "ODH Trino",
+            "save-password": true,
+            "show-system-objects": true,
+            "read-only": false,
+            "configuration": {
+                "host": "trino-secure-odh-trino.apps.odh-cl1.apps.os-climate.org",
+                "port": "443",
+                "url": "jdbc:trino://trino-secure-odh-trino.apps.odh-cl1.apps.os-climate.org:443",
+                "type": "dev",
+                "properties": {
+                    "SSLVerification": "FULL",
+                    "SSL": "true"
+                },
+                "auth-model": "native"
+            }
+        }
+    },
+    "connection-types": {
+        "dev": {
+            "name": "Development",
+            "color": "255,255,255",
+            "description": "Regular development database",
+            "auto-commit": true,
+            "confirm-execute": false,
+            "confirm-data-change": false,
+            "auto-close-transactions": false
+        }
+    }
+}

--- a/cloudbeaver/overlays/osc/osc-cl1/configs/initial-data.conf
+++ b/cloudbeaver/overlays/osc/osc-cl1/configs/initial-data.conf
@@ -1,0 +1,16 @@
+{
+  roles: [
+    {
+      roleId: "admin",
+      name: "Admin",
+      description: "Administrative access. Has all permissions.",
+      permissions: [ "public", "admin" ]
+    },
+    {
+      roleId: "user",
+      name: "User",
+      description: "Standard user",
+      permissions: [ "public" ]
+    }
+  ]
+}

--- a/cloudbeaver/overlays/osc/osc-cl1/configs/product.conf
+++ b/cloudbeaver/overlays/osc/osc-cl1/configs/product.conf
@@ -1,0 +1,32 @@
+// Product configuration. Customized web application behavior
+// It is in JSONC format
+// https://github.com/dbeaver/cloudbeaver/wiki/Product-configuration-parameters
+{
+  // Global properties
+  core: {
+    // User defaults
+    user: {
+      defaultTheme: "light",
+      defaultLanguage: "en"
+    },
+    app: {
+      // Log viewer config
+      logViewer: {
+        refreshTimeout: 3000,
+        logBatchSize: 1000,
+        maxLogRecords: 2000,
+        maxFailedRequests: 3
+      }
+    }
+  },
+  plugin_data_spreadsheet_new: {
+    hidden: false
+  },
+  plugin_data_export: {
+    disabled: false
+  },
+  // Notifications config
+  core_events: {
+    notificationsPool: 5
+  }
+}

--- a/cloudbeaver/overlays/osc/osc-cl1/kustomization.yaml
+++ b/cloudbeaver/overlays/osc/osc-cl1/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: odh-trino
+resources:
+  - ../../../base
+patchesStrategicMerge:
+  - add_configs.yaml
+  - secure-route.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: cloudbeaver-config
+    files:
+      - configs/cloudbeaver.conf
+      - configs/initial-data-sources.conf
+      - configs/initial-data.conf
+      - configs/product.conf

--- a/cloudbeaver/overlays/osc/osc-cl1/secure-route.yaml
+++ b/cloudbeaver/overlays/osc/osc-cl1/secure-route.yaml
@@ -1,0 +1,6 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: cloudbeaver
+  annotations:
+    kubernetes.io/tls-acme: "true"

--- a/cluster-scope/base/core/namespaces/odh-jupyterhub/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/odh-jupyterhub/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+components:
+- ../../../../components/project-admin-rolebindings/odh-admin
+- ../../../../components/monitoring-rbac
+kind: Kustomization
+namespace: odh-jupyterhub
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/odh-jupyterhub/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/odh-jupyterhub/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "OS-C Climate: JupyterHub"
+  name: odh-jupyterhub
+spec: {}

--- a/cluster-scope/base/core/namespaces/odh-superset/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/odh-superset/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+components:
+- ../../../../components/project-admin-rolebindings/odh-admin
+- ../../../../components/monitoring-rbac
+kind: Kustomization
+namespace: odh-superset
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/odh-superset/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/odh-superset/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "OS-C Climate: Superset"
+  name: odh-superset
+spec: {}

--- a/cluster-scope/base/core/namespaces/odh-trino/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/odh-trino/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+components:
+- ../../../../components/project-admin-rolebindings/odh-admin
+- ../../../../components/monitoring-rbac
+kind: Kustomization
+namespace: odh-trino
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/odh-trino/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/odh-trino/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "OS-C Climate: Trino"
+  name: odh-trino
+spec: {}

--- a/cluster-scope/base/user.openshift.io/groups/odh-users/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/odh-users/group.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: odh-users
+users: []

--- a/cluster-scope/base/user.openshift.io/groups/odh-users/kustomization.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/odh-users/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- group.yaml

--- a/cluster-scope/overlays/prod/osc/common/groups/odh-admin.yaml
+++ b/cluster-scope/overlays/prod/osc/common/groups/odh-admin.yaml
@@ -1,0 +1,8 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+    name: odh-admin
+users:
+    - hukhan
+    - mmikhail
+    - redmikhail

--- a/cluster-scope/overlays/prod/osc/common/groups/odh-users.yaml
+++ b/cluster-scope/overlays/prod/osc/common/groups/odh-users.yaml
@@ -1,0 +1,9 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+    name: odh-users
+users:
+    - caldeirav
+    - erikerlandson
+    - oindrillac
+    - guimou

--- a/cluster-scope/overlays/prod/osc/common/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/common/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../../base/user.openshift.io/groups/odh-admin
+  - ../../../../base/user.openshift.io/groups/odh-users
+
+patchesStrategicMerge:
+  - groups/odh-admin.yaml
+  - groups/odh-users.yaml

--- a/cluster-scope/overlays/prod/osc/osc-cl1/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../common
+  - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/kfdefs.kfdef.apps.kubeflow.org
+  - ../../../../base/core/namespaces/acme-operator
+  - ../../../../base/core/namespaces/dex
+  - ../../../../base/core/namespaces/kubeflow
+  - ../../../../base/core/namespaces/opendatahub-operator
+  - ../../../../base/core/namespaces/odh-jupyterhub
+  - ../../../../base/core/namespaces/odh-superset
+  - ../../../../base/core/namespaces/odh-trino
+  - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator
+  - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/opendatahub-operator
+  - ../../../../base/rbac.authorization.k8s.io/clusterroles/acme-operator
+  - ../../../../base/rbac.authorization.k8s.io/clusterroles/opendatahub-operator

--- a/dex/overlays/osc/.sops.yaml
+++ b/dex/overlays/osc/.sops.yaml
@@ -1,0 +1,3 @@
+creation_rules:
+  - encrypted_regex: '^(data|stringData)$'
+    pgp: '0508677DD04952D06A943D5B4DC4116D360E3276'

--- a/dex/overlays/osc/osc-cl1/dex-clients.enc.yaml
+++ b/dex/overlays/osc/osc-cl1/dex-clients.enc.yaml
@@ -1,0 +1,40 @@
+kind: Secret
+apiVersion: v1
+metadata:
+    name: dex-clients
+    annotations:
+        kustomize.config.k8s.io/behavior: replace
+stringData:
+    SUPERSET_SECRET: ENC[AES256_GCM,data:fSPCyYDsZpUQ6feMJJS84hfc9c1M1c4B8AWMkSlyDeo8zun7NW5kVZtVQhffRGicZtkKzTgPfOUS/5EEnZpHDw==,iv:kjDZu6tsifWW2GfDBmHiEdsiD8TfT7dtmeAtsTdqjls=,tag:Dsv4u9ayHgntNl5qADtBOw==,type:str]
+    TRINO_SECRET: ENC[AES256_GCM,data:2NjyvL7O/TZcYJX0xBOCSCsoC5vlMZMPthu7rok6/xmlFO/p9sL/V51MZZgfnh/GUv1nj7lmuLWpGw0juqAesA==,iv:X1UTYquhIwSLFK3l3BRTE70qyaiKEB7m9SF407IRPbI=,tag:wNwyt4Bje0dx1VvnfJ2WxQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-08-23T21:08:55Z'
+    mac: ENC[AES256_GCM,data:WueKJxXbPEpmKmpbvuDO0kgGUsNrPhpGl7UrKccQoNyAfo0Oa2rhySCUgXgoPfJ4nUHc7DZM3cQx9aflmqR7TIf6ke2e/hLkikOafqD7HYuUo6gIkAK71Rcr3tAPvzE7qd3RoY2uGUwndA9Qoye1oTgJ6XNLvz0ZEhHuHMY2Jmw=,iv:mshZjD2zRqafRnKFjplVoCJyoi0XVtkrIsRwEb7QweA=,tag:ACDTgNc/EaFcH2HwHYXHEQ==,type:str]
+    pgp:
+    -   created_at: '2021-08-23T21:08:55Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA9aKBcudqifiARAAMa0HsOUPMW31/XooK4C42g7V0eb51U65JseCCn/G36E1
+            yzw9nWogDtF9en5Ef+Qub3V6jO0zF7a52/QN38iC057y8QozCt/RI3stCfd75oUt
+            mYt8LIggZuHxq+KEbg4jK8GzE/5ghLAS+DVlV8QuZ+lqDX+j+XJux93av8zDC+s5
+            Bk/2fYLyY+xlLNrcba8zBcZbnDq5k3GWXOOC5FHe3QusZy2+xNM8r05F3iMBqNbx
+            UxqydqDem2fsoTSYU6fHm2HxOeIih0FX3DUyUh5NLyGTDBG5fVtmx/PfzA/vwyBe
+            FT/Cd553GXGLZsagFX6rog69k46Y217qjzI/MB/RFQEhyvR4ti2Q4EMfiptwjv/1
+            MBTkdOZMTau7hlS10h90LQEEQau7xLH6WfeETntB0t5+Dw0bfex7B3a3fQBChj0+
+            nCS2txB5YhfIEbguYrL4SzbzI9Und7VznxAqNQ9/szmtNDP+lw4F1VuKL2RCDXDm
+            qzcntv0wLaT9pDg1IIqqoQ9FkKYbH02xwuYWRKqjftm63UPW7vxQm41sLO2xIGAn
+            Rp58BPrW/MrJtBCw3RLDbpFCFuAHjerc2nGSa4+4GS4l6o3NomvsXccupQdUdXX1
+            Ld3b3iQWp8BA/QIu1gZj3hh09s9xBXR9o37e8Qq6All2n0URQrMLyB+e92fLn4jS
+            4AHkIOYlxnpeujzDwXjzCP6utuG2pOCB4P3hdn7gneIxYEcD4EzlPUivVfKf4z05
+            ZFncwPljLosMVxdyr8BFEhxGo9WdqCTgpORPbCcpTaNTAc+J5YZVq5Io4l6t2hnh
+            QfcA
+            =H1Mh
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^(data|stringData)$
+    version: 3.6.1

--- a/dex/overlays/osc/osc-cl1/dex-cm.yaml
+++ b/dex/overlays/osc/osc-cl1/dex-cm.yaml
@@ -1,0 +1,51 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: dex
+data:
+  config.yaml: |
+    issuer: http://dex-dex.apps.odh-cl1.apps.os-climate.org
+
+    storage:
+      type: memory
+
+    web:
+      http: "0.0.0.0:5556"
+
+    grpc:
+      addr: "0.0.0.0:5557"
+
+    telemetry:
+      http: "0.0.0.0:5558"
+
+    oauth2:
+      skipApprovalScreen: true
+
+    staticClients:
+      - id: superset
+        name: Superset
+        redirectURIs:
+          - http://superset-odh-superset.apps.odh-cl1.apps.os-climate.org/oauth-authorized/dex
+          - https://superset-secure-odh-superset.apps.odh-cl1.apps.os-climate.org/oauth-authorized/dex
+          - http://superset-secure-odh-superset.apps.odh-cl1.apps.os-climate.org/oauth-authorized/dex
+        secretEnv: SUPERSET_SECRET
+
+      - id: trino
+        name: Trino
+        redirectURIs:
+          - https://trino-secure-odh-trino.apps.odh-cl1.apps.os-climate.org/oauth2/callback
+          - https://trino-route-odh-trino.apps.odh-cl1.apps.os-climate.org
+        secretEnv: TRINO_SECRET
+
+    connectors:
+      - type: openshift
+        id: openshift
+        name: OpenShift
+        config:
+          issuer: https://kubernetes.default.svc
+          clientID: system:serviceaccount:dex:dex
+          clientSecret: $OPENSHIFT_CLIENT_SECRET
+          redirectURI: http://dex-dex.apps.odh-cl1.apps.os-climate.org/callback
+          groups:
+            - system:authenticated

--- a/dex/overlays/osc/osc-cl1/dex-sa.yaml
+++ b/dex/overlays/osc/osc-cl1/dex-sa.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dex
+  annotations:
+    kustomize.config.k8s.io/behavior: replace
+    serviceaccounts.openshift.io/oauth-redirecturi.dex: "callback"
+    serviceaccounts.openshift.io/oauth-redirectreference.dex: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"dex"}}'

--- a/dex/overlays/osc/osc-cl1/kustomization.yaml
+++ b/dex/overlays/osc/osc-cl1/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: dex
+resources:
+  - ../../../base
+patchesStrategicMerge:
+  - dex-cm.yaml
+  - dex-sa.yaml
+generators:
+  - secret-generator.yaml

--- a/dex/overlays/osc/osc-cl1/secret-generator.yaml
+++ b/dex/overlays/osc/osc-cl1/secret-generator.yaml
@@ -1,0 +1,6 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: secret-generator
+files:
+  - dex-clients.yaml

--- a/kubeflow-components/base/kustomization.yaml
+++ b/kubeflow-components/base/kustomization.yaml
@@ -2,6 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow
-
-# resources:
-#   - kfdef.yaml
+resources:
+  - kfdef.yaml

--- a/kubeflow-components/overlays/osc/osc-cl1/kustomization.yaml
+++ b/kubeflow-components/overlays/osc/osc-cl1/kustomization.yaml
@@ -1,9 +1,5 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow
 resources:
-  - profiles
-  - roles
-  - rolebindings
-#  - ../../../base
+  - ../../../base

--- a/kubeflow-components/overlays/osc/osc-cl1/ml-pipeline-route.yaml
+++ b/kubeflow-components/overlays/osc/osc-cl1/ml-pipeline-route.yaml
@@ -1,0 +1,14 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: ml-pipeline-ui
+  labels:
+    app: ml-pipeline-ui
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+spec:
+  to:
+    kind: Service
+    name: ml-pipeline-ui
+  port:
+    targetPort: http

--- a/odh-operator/overlays/osc/osc-cl1/kustomization.yaml
+++ b/odh-operator/overlays/osc/osc-cl1/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base


### PR DESCRIPTION
The PR introduces manifests for os-climate cluster `osc-cl1`, no changes are made to `zero/infra/rick`. See commits for details on what's added. (No actual changes to any live deployment will be made, argocd apps will follow this pr for the respective services being added.) 

In the OSC cluster I've used `odh-*` prefixes for the odh namespaces, instead of `opf-*` hence the addition of those namespaces.