### PR TITLE
add external label to moc/zero prometheus

### DIFF
--- a/odh-manifests/zero/prometheus/operator/base/prometheus.yaml
+++ b/odh-manifests/zero/prometheus/operator/base/prometheus.yaml
@@ -20,6 +20,8 @@ spec:
   serviceAccountName: prometheus-k8s
   serviceMonitorSelector: {}
   securityContext: {}
+  externalLabels:
+    prometheus: moc/zero
   ruleSelector:
     matchLabels:
       prometheus: odh-monitoring


### PR DESCRIPTION
This will add a label `prometheus: moc/zero` to all the metrics exported using remotewrite