### PR TITLE
Change trino compute to str.

### DIFF
--- a/kfdefs/overlays/moc/zero/opf-trino/kustomization.yaml
+++ b/kfdefs/overlays/moc/zero/opf-trino/kustomization.yaml
@@ -21,13 +21,13 @@ patchesJson6902:
               - name: s3_credentials_secret
                 value: opf-datacatalog-bucket
               - name: trino_memory_request
-                value: 8Gi
+                value: "8Gi"
               - name: trino_memory_limit
-                value: 16Gi
+                value: "16Gi"
               - name: trino_cpu_request
-                value: 4
+                value: "4"
               - name: trino_cpu_limit
-                value: 8
+                value: "8"
             repoRef:
               name: opf
               path: odh-manifests/zero/trino


### PR DESCRIPTION
To solve ODH errors: 

```
E0825 14:07:43.403996       1 reflector.go:125] pkg/mod/k8s.io/client-go@v0.0.0-20190620085101-78d2af792bab/tools/cache/reflector.go:98: Failed to list *v1.KfDef: v1.KfDefList.Items: []v1.KfDef: v1.KfDef.Spec: v1.KfDefSpec.Applications: []v1.Application: v1.Application.KustomizeConfig: v1.KustomizeConfig.Parameters: []v1.NameValue: v1.NameValue.v1.NameValue.Value: ReadString: expects " or n, but found 4, error found in #10 byte of ...|,"value":4},{"name":|..., bigger context ...|lue":"16Gi"},{"name":"trino_cpu_request","value":4},{"name":"trino_cpu_limit","value":8}],"repoRef":|...
```