### PR TITLE
fix: Odh operator namespace missing on Devconf cluster

### DIFF
--- a/cluster-scope/overlays/prod/emea/devconfus2021/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/devconfus2021/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
     - ../../../../base/config.openshift.io/oauths/cluster
     - ../../../../base/core/namespaces/aicoe-meteor
     - ../../../../base/core/namespaces/kubeflow
+    - ../../../../base/core/namespaces/opendatahub-operator
     - ../../../../base/core/namespaces/opf-dashboard
     - ../../../../base/core/namespaces/opf-jupyterhub
     - ../../../../base/operators.coreos.com/subscriptions/openshift-pipelines-operator-rh


### PR DESCRIPTION
SSIA