### PR TITLE
feat: add user workload monitoring to devconfus2021 cluster

### DIFF
--- a/cluster-scope/overlays/prod/emea/devconfus2021/configmaps/cluster-monitoring-config.yaml
+++ b/cluster-scope/overlays/prod/emea/devconfus2021/configmaps/cluster-monitoring-config.yaml
@@ -1,0 +1,9 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true

--- a/cluster-scope/overlays/prod/emea/devconfus2021/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/devconfus2021/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
     - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/opendatahub-operator
     - ../../../../base/rbac.authorization.k8s.io/clusterroles/opendatahub-operator
     - ../../../../base/user.openshift.io/groups/cluster-admins
-
+    - configmaps/cluster-monitoring-config.yaml
 generators:
     - secret-generator.yaml
 


### PR DESCRIPTION
Adding user workload monitoring to devconfus2021 cluster as a part of https://github.com/operate-first/SRE/issues/370 .