### PR TITLE
feat: move ci-prow namespace to smaug

### DIFF
--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 
 resources:
   - ../common
+  - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/prowjobs.prow.k8s.io
   - ../../../../base/config.openshift.io/oauths/cluster
   - ../../../../base/core/namespaces/acme-operator
    - ../../../../base/core/namespaces/opf-ci-prow

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/prowjobs.prow.k8s.io
   - ../../../../base/config.openshift.io/oauths/cluster
   - ../../../../base/core/namespaces/acme-operator
-   - ../../../../base/core/namespaces/opf-ci-prow
+  - ../../../../base/core/namespaces/opf-ci-prow
   - ../../../../base/core/namespaces/opf-ci-test-pods
   - ../../../../base/operators.coreos.com/subscriptions/cert-manager
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - ../common
   - ../../../../base/config.openshift.io/oauths/cluster
   - ../../../../base/core/namespaces/acme-operator
+    - ../../../../base/core/namespaces/opf-ci-prow
+  - ../../../../base/core/namespaces/opf-ci-test-pods
   - ../../../../base/operators.coreos.com/subscriptions/cert-manager
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/acme-operator

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - ../common
   - ../../../../base/config.openshift.io/oauths/cluster
   - ../../../../base/core/namespaces/acme-operator
-    - ../../../../base/core/namespaces/opf-ci-prow
+   - ../../../../base/core/namespaces/opf-ci-prow
   - ../../../../base/core/namespaces/opf-ci-test-pods
   - ../../../../base/operators.coreos.com/subscriptions/cert-manager
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator

--- a/cluster-scope/overlays/prod/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/zero/kustomization.yaml
@@ -59,8 +59,6 @@ resources:
   - ../../../../base/core/namespaces/opf-alertreceiver
   - ../../../../base/core/namespaces/opf-argo
   - ../../../../base/core/namespaces/opf-ci-pipelines
-  - ../../../../base/core/namespaces/opf-ci-prow
-  - ../../../../base/core/namespaces/opf-ci-test-pods
   - ../../../../base/core/namespaces/opf-dashboard
   - ../../../../base/core/namespaces/opf-datacatalog
   - ../../../../base/core/namespaces/opf-google-spark-operator


### PR DESCRIPTION
Moving namespace of ci-prow from zero cluster to smaug.
Related: https://github.com/operate-first/argocd-apps/pull/186