### PR TITLE
feat: Allow operate-first project apps to be listed by public

### DIFF
--- a/argocd/overlays/moc-infra/configs/argo_rbac_cm/policy.csv
+++ b/argocd/overlays/moc-infra/configs/argo_rbac_cm/policy.csv
@@ -8,6 +8,8 @@ p, role:standard-user, gpgkeys, get, *, allow
 
 # Define a custom default role for a public anonymous users with read only access to workshops apps
 p, role:readonly-public, applications, get, workshops/*, allow
+# Workshop's app of apps lives in operate-first project, allow apps in this project to be listed as well
+p, role:readonly-public, applications, get, operate-first/*, allow
 
 # Give Openshift group (argocd-admins) the argocd admin role with unrestricted argocd access
 g, argocd-admins, role:admin


### PR DESCRIPTION
App of apps lives in operate first project for security reasons (deploys to argocd namespace), we need users to be able to see the app. It probably deserves it's own project, but this is quick and dirty solution for now 