### PR TITLE
Use latest for experimental elyra notebook image

### DIFF
--- a/kfdefs/base/jupyterhub/notebook-images/experimental-elyra-notebook-imagestream.yaml
+++ b/kfdefs/base/jupyterhub/notebook-images/experimental-elyra-notebook-imagestream.yaml
@@ -16,7 +16,7 @@ spec:
       openshift.io/imported-from: quay.io/thoth-station/s2i-lab-elyra
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-lab-elyra:v0.0.8
-    name: "v0.0.8"
+      name: quay.io/thoth-station/s2i-lab-elyra:latest
+    name: "latest"
     referencePolicy:
       type: Source


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

Experimental should allow for testing latest changes in the image.