### PR TITLE
feat: setup clusterbinding required for ofp-ci-pipelines

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-interceptor-opf-ci-pipelines/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-interceptor-opf-ci-pipelines/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cluster-interceptor-opf-ci-pipelines
+subjects:
+  - kind: ServiceAccount
+    name: aicoe-ci-webhook
+    namespace: opf-ci-pipelines
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-pipelines-clusterinterceptors

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-interceptor-opf-ci-pipelines/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-interceptor-opf-ci-pipelines/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrolebinding.yaml

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -23,6 +23,8 @@ resources:
   - ../../../../base/operators.coreos.com/subscriptions/cert-manager
   - ../../../../base/operators.coreos.com/subscriptions/openshift-pipelines-operator-rh
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator
+  - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-interceptor-opf-ci-pipelines
+  - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/scc-privileged-opf-ci-pipelines-aicoe-ci
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/acme-operator
   - ../../../../base/user.openshift.io/groups/cluster-admins
 


### PR DESCRIPTION
setup clusterbinding required for ofp-ci-pipelines
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


smaug cluster is on openshift 4.8, with which the openshift-pipelines v0.15.0 is shipped
the application ofp-ci-pipelines requires these crb setups to function properly. 