### PR TITLE
feat: setup cluster resources required for tekton dashboard

### DIFF
--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/extensions.dashboard.tekton.dev/customresourcedefinition.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/extensions.dashboard.tekton.dev/customresourcedefinition.yaml
@@ -1,0 +1,43 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/part-of: tekton-dashboard
+  name: extensions.dashboard.tekton.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.apiVersion
+    name: API version
+    type: string
+  - JSONPath: .spec.name
+    name: Kind
+    type: string
+  - JSONPath: .spec.displayname
+    name: Display name
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: dashboard.tekton.dev
+  names:
+    categories:
+    - tekton
+    - tekton-dashboard
+    kind: Extension
+    plural: extensions
+    shortNames:
+    - ext
+    - exts
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/extensions.dashboard.tekton.dev/kustomization.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/extensions.dashboard.tekton.dev/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- customresourcedefinition.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/tekton-dashboard/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/tekton-dashboard/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- tekton-dashboard-backend.yaml
+- tekton-dashboard-extensions.yaml
+- tekton-dashboard-tenant.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/tekton-dashboard/tekton-dashboard-backend.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/tekton-dashboard/tekton-dashboard-backend.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/part-of: tekton-dashboard
+  name: tekton-dashboard-backend
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-dashboard-backend
+subjects:
+- kind: ServiceAccount
+  name: tekton-dashboard
+  namespace: tekton-pipelines

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/tekton-dashboard/tekton-dashboard-extensions.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/tekton-dashboard/tekton-dashboard-extensions.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/part-of: tekton-dashboard
+  name: tekton-dashboard-extensions
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-dashboard-extensions
+subjects:
+  - kind: ServiceAccount
+    name: tekton-dashboard
+    namespace: tekton-pipelines

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/tekton-dashboard/tekton-dashboard-tenant.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/tekton-dashboard/tekton-dashboard-tenant.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/part-of: tekton-dashboard
+  name: tekton-dashboard-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-dashboard-tenant
+subjects:
+  - kind: ServiceAccount
+    name: tekton-dashboard
+    namespace: tekton-pipelines

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/tekton-dashboard/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/tekton-dashboard/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- tekton-dashboard-backend.yaml
+- tekton-dashboard-dashboard.yaml
+- tekton-dashboard-extensions.yaml
+- tekton-dashboard-pipelines.yaml
+- tekton-dashboard-tenant.yaml
+- tekton-dashboard-triggers.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/tekton-dashboard/tekton-dashboard-backend.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/tekton-dashboard/tekton-dashboard-backend.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/part-of: tekton-dashboard
+  name: tekton-dashboard-backend
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - tekton.dev
+  resources:
+  - clustertasks
+  - clustertasks/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - triggers.tekton.dev
+  resources:
+  - clustertriggerbindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dashboard.tekton.dev
+  resources:
+  - extensions
+  verbs:
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - clustertasks
+  - clustertasks/status
+  verbs:
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - triggers.tekton.dev
+  resources:
+  - clustertriggerbindings
+  verbs:
+  - create
+  - update
+  - delete
+  - patch
+  - add

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/tekton-dashboard/tekton-dashboard-dashboard.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/tekton-dashboard/tekton-dashboard-dashboard.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/part-of: tekton-dashboard
+  name: tekton-dashboard-dashboard
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/tekton-dashboard/tekton-dashboard-extensions.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/tekton-dashboard/tekton-dashboard-extensions.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/part-of: tekton-dashboard
+  name: tekton-dashboard-extensions
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.dashboard.tekton.dev/aggregate-to-dashboard: "true"

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/tekton-dashboard/tekton-dashboard-pipelines.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/tekton-dashboard/tekton-dashboard-pipelines.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/part-of: tekton-dashboard
+  name: tekton-dashboard-pipelines
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/tekton-dashboard/tekton-dashboard-tenant.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/tekton-dashboard/tekton-dashboard-tenant.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/part-of: tekton-dashboard
+  name: tekton-dashboard-tenant
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dashboard.tekton.dev
+  resources:
+  - extensions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - pods/log
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks
+  - taskruns
+  - pipelines
+  - pipelineruns
+  - pipelineresources
+  - conditions
+  - tasks/status
+  - taskruns/status
+  - pipelines/status
+  - pipelineruns/status
+  - taskruns/finalizers
+  - pipelineruns/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - triggers.tekton.dev
+  resources:
+  - eventlisteners
+  - triggerbindings
+  - triggertemplates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks
+  - taskruns
+  - pipelines
+  - pipelineruns
+  - pipelineresources
+  - conditions
+  - taskruns/finalizers
+  - pipelineruns/finalizers
+  - tasks/status
+  - taskruns/status
+  - pipelines/status
+  - pipelineruns/status
+  verbs:
+  - create
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - triggers.tekton.dev
+  resources:
+  - eventlisteners
+  - triggerbindings
+  - triggertemplates
+  verbs:
+  - create
+  - update
+  - delete
+  - patch
+  - add

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/tekton-dashboard/tekton-dashboard-triggers.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/tekton-dashboard/tekton-dashboard-triggers.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/part-of: tekton-dashboard
+  name: tekton-dashboard-triggers
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - list

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ../common
   - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/prowjobs.prow.k8s.io
+  - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/extensions.dashboard.tekton.dev
   - ../../../../base/config.openshift.io/oauths/cluster
   - ../../../../base/core/namespaces/acme-operator
   - ../../../../base/core/namespaces/opf-ci-pipelines
@@ -25,7 +26,9 @@ resources:
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-interceptor-opf-ci-pipelines
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/scc-privileged-opf-ci-pipelines-aicoe-ci
+  - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/tekton-dashboard
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/acme-operator
+  - ../../../../base/rbac.authorization.k8s.io/clusterroles/tekton-dashboard
   - ../../../../base/user.openshift.io/groups/cluster-admins
 
 generators:


### PR DESCRIPTION
setup cluster resources required for tekton dashboard
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


Tekton dashboard is a one-stop place to view all the openshift pipelines running. 
https://github.com/tektoncd/dashboard/blob/main/docs/install.md