### PR TITLE
feat: add sre to argocd-group

### DIFF
--- a/argocd/overlays/moc-infra/configs/argo_rbac_cm/policy.csv
+++ b/argocd/overlays/moc-infra/configs/argo_rbac_cm/policy.csv
@@ -26,3 +26,4 @@ g, workshops, role:standard-user
 g, b4mad, role:standard-user
 g, lab-cicd, role:standard-user
 g, apicurio, role:standard-user
+g, sre, role:standard-user


### PR DESCRIPTION
Add SRE group to policy.csv so they can use ArgoCD web interface.