### PR TITLE
Rename osc phys landing trino catalog.

### DIFF
--- a/odh-manifests/osc-cl1/trino/base/trino-catalog-secret.yaml
+++ b/odh-manifests/osc-cl1/trino/base/trino-catalog-secret.yaml
@@ -35,7 +35,7 @@ stringData:
     hive.s3.aws-access-key=${ENV:DEMO1_AWS_ACCESS_KEY_ID}
     hive.s3.aws-secret-key=${ENV:DEMO1_AWS_SECRET_ACCESS_KEY}
 
-  osc-physical-landing.properties: |
+  osc_physical_landing.properties: |
     connector.name=hive-hadoop2
     hive.metastore.uri=thrift://hive-metastore-user-a:9083
     hive.s3.endpoint=${ENV:OSC_PHYSICAL_LANDING_S3_ENDPOINT_URL_PREFIX}${ENV:OSC_PHYSICAL_LANDING_S3_ENDPOINT}


### PR DESCRIPTION
Related: https://github.com/os-climate/os_c_data_commons/issues/52#issuecomment-917076509 

Dashes were causing issues with trino client. 