### PR TITLE
Add nmstate subscription

### DIFF
--- a/cluster-scope/base/core/namespaces/openshift-nmstate/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-nmstate/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-nmstate
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/openshift-nmstate/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-nmstate/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Openshift Nmstate Operator"
+    openshift.io/requester: operate-first
+  name: openshift-nmstate
+spec: {}

--- a/cluster-scope/base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-nmstate
+resources:
+- subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kubernetes-nmstate-operator
+spec:
+  channel: DEFINED_IN_OVERLAY
+  installPlanApproval: Automatic
+  name: kubernetes-nmstate-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -22,6 +22,7 @@ resources:
   - ../../../../base/core/namespaces/thoth-infra-prod
   - ../../../../base/core/namespaces/thoth-middletier-prod
   - ../../../../base/operators.coreos.com/subscriptions/cert-manager
+  - ../../../../base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator
   - ../../../../base/operators.coreos.com/subscriptions/openshift-pipelines-operator-rh
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-interceptor-opf-ci-pipelines
@@ -34,4 +35,5 @@ generators:
 
 patchesStrategicMerge:
   - oauths/cluster_patch.yaml
+  - subscriptions/kubernetes-nmstate-operator_patch.yaml
   - subscriptions/openshift-pipelines-operator-rh_patch.yaml

--- a/cluster-scope/overlays/prod/moc/smaug/subscriptions/kubernetes-nmstate-operator_patch.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/subscriptions/kubernetes-nmstate-operator_patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kubernetes-nmstate-operator
+  namespace: openshift-nmstate
+spec:
+  channel: 4.8


### PR DESCRIPTION
Part of operate-first/SRE#379

This adds the nmstate operator to smaug so that we have a declarative network configuration mechanism available.

This PR does not create an operatorgroup because many operators seem to do that automatically. If you think it needs one, please let me know.

