### PR TITLE
feat: add user workload monitoring to smaug cluster

### DIFF
--- a/cluster-scope/overlays/prod/moc/smaug/configmaps/cluster-monitoring-config.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/configmaps/cluster-monitoring-config.yaml
@@ -1,0 +1,9 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -38,6 +38,7 @@ resources:
   - ../../../../base/user.openshift.io/groups/cluster-admins
   - ingresscontrollers/default.yaml
   - machineconfigs/99-vlan-210-nfs.yaml
+  - configmaps/cluster-monitoring-config.yaml
 
 generators:
   - secret-generator.yaml


### PR DESCRIPTION
Added user workoad monitoring config map as a base for deployment of monitoring on smaug.
Resolves operate-first/SRE#294