### PR TITLE
Re-add hive.properties to osc trino catalog.

### DIFF
--- a/odh-manifests/osc-cl1/trino/base/trino-catalog-secret.yaml
+++ b/odh-manifests/osc-cl1/trino/base/trino-catalog-secret.yaml
@@ -3,6 +3,19 @@ kind: Secret
 metadata:
   name: trino-catalog
 stringData:
+  hive.properties: |
+    connector.name=hive-hadoop2
+    hive.metastore.uri=thrift://hive-metastore:9083
+    hive.s3.endpoint=$(s3_endpoint_url_prefix)$(s3_endpoint_url)
+    hive.s3.signer-type=S3SignerType
+    hive.s3.path-style-access=true
+    hive.s3.staging-directory=/tmp
+    hive.s3.ssl.enabled=false
+    hive.s3.sse.enabled=false
+    hive.allow-drop-table=true
+    hive.parquet.use-column-names=true
+    hive.recursive-directories=true
+
   default.properties: |
     connector.name=hive-hadoop2
     hive.metastore.uri=thrift://hive-metastore:9083


### PR DESCRIPTION
Seems like this catalog is required for some reason, otherwise workers will not boot up, possibly coordinator as well though not tested.

