### PR TITLE
Migrate thoth-station test namespace to rick cluster

### DIFF
--- a/cluster-scope/base/core/namespaces/thoth-test-core/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/thoth-test-core/resourcequota.yaml
@@ -4,8 +4,8 @@ metadata:
   name: thoth-test-core-custom
 spec:
   hard:
-    limits.cpu: '16'
+    limits.cpu: '8'
     limits.memory: 32Gi
-    requests.cpu: '16'
+    requests.cpu: '8'
     requests.memory: 32Gi
     requests.storage: 40Gi

--- a/cluster-scope/overlays/prod/emea/rick/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/rick/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
     - ../../../../base/core/namespaces/openshift-storage
     - ../../../../base/core/namespaces/opf-monitoring
     - ../../../../base/core/namespaces/thoth-website-prod
+    - ../../../../base/core/namespaces/thoth-test-core
     - ../../../../base/operators.coreos.com/operatorgroups/openshift-local-storage-zj22x
     - ../../../../base/operators.coreos.com/operatorgroups/openshift-storage-24n7x
     - ../../../../base/operators.coreos.com/operatorgroups/opf-monitoring

--- a/cluster-scope/overlays/prod/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/zero/kustomization.yaml
@@ -94,7 +94,6 @@ resources:
   - ../../../../base/core/namespaces/thoth-infra-prod
   - ../../../../base/core/namespaces/thoth-middletier-prod
   - ../../../../base/core/namespaces/thoth-pulp-experiments
-  - ../../../../base/core/namespaces/thoth-test-core
   - ../../../../base/core/namespaces/uky-hpc-workload-generator
   - ../../../../base/core/namespaces/ws-ml-prague
   - ../../../../base/core/persistentvolumeclaims/image-registry-storage


### PR DESCRIPTION
Migrate thoth-station test namespace to rick cluster
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Fixes: https://github.com/operate-first/support/issues/372