### PR TITLE
Update curator to use common pull-secret

### DIFF
--- a/cluster-scope/overlays/prod/moc/curator/secret-generator.yaml
+++ b/cluster-scope/overlays/prod/moc/curator/secret-generator.yaml
@@ -6,3 +6,4 @@ metadata:
 files:
   - oauths/moc-sso-client-secret.enc.yaml
   - ingresscontrollers/default-ingress-certificate.enc.yaml
+  - ../common/pull-secret.enc.yaml


### PR DESCRIPTION
The curator cluster was still configured to use Ilana's expired pull
secret.
