### PR TITLE
Update trino version for osc cluster.

### DIFF
--- a/kfdefs/overlays/osc/osc-cl1/trino/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino/kfdef.yaml
@@ -25,6 +25,8 @@ spec:
             value: s3.us-east-1.amazonaws.com
           - name: s3_credentials_secret
             value: odh-datacatalog-bucket
+          - name: trino_image
+            value: quay.io/opendatahub/trino:362
         repoRef:
           name: opf
           path: odh-manifests/osc-cl1/trino

--- a/odh-manifests/osc-cl1/trino/base/trino-config-secret.yaml
+++ b/odh-manifests/osc-cl1/trino/base/trino-config-secret.yaml
@@ -8,18 +8,17 @@ stringData:
     coordinator=true
     node-scheduler.include-coordinator=false
 
-    discovery-server.enabled=true
     discovery.uri=http://localhost:8080
 
     web-ui.authentication.type=oauth2
     http-server.authentication.type=PASSWORD,oauth2
     http-server.process-forwarded=true
     http-server.http.port=8080
-    http-server.https.port=8443
-    http-server.https.keystore.path=/etc/pki/tls/cert.pem
+    http-server.authentication.oauth2.issuer=http://dex-dex.apps.odh-cl1.apps.os-climate.org
     http-server.authentication.oauth2.auth-url=http://dex-dex.apps.odh-cl1.apps.os-climate.org/auth
     http-server.authentication.oauth2.token-url=http://dex-dex.apps.odh-cl1.apps.os-climate.org/token
     http-server.authentication.oauth2.jwks-url=http://dex-dex.apps.odh-cl1.apps.os-climate.org/keys
+    http-server.authentication.oauth2.userinfo-url=http://dex-dex.apps.odh-cl1.apps.os-climate.org/userinfo
     http-server.authentication.oauth2.client-id=trino
     http-server.authentication.oauth2.client-secret=${ENV:TRINO_OAUTH_SECRET}
   config-worker.properties: |-


### PR DESCRIPTION
Updates trino image version so we can get this change: https://github.com/trinodb/trino/pull/8641/commits 

There's some deprecated configs I had to remove to support this upgrade @rimolive for your reference. 

The upgrade also required us to identify the oauth issuer. 