### PR TITLE
Update osc trino oauth configs.

### DIFF
--- a/odh-manifests/osc-cl1/trino/base/trino-config-secret.yaml
+++ b/odh-manifests/osc-cl1/trino/base/trino-config-secret.yaml
@@ -21,6 +21,8 @@ stringData:
     http-server.authentication.oauth2.userinfo-url=http://dex-dex.apps.odh-cl1.apps.os-climate.org/userinfo
     http-server.authentication.oauth2.client-id=trino
     http-server.authentication.oauth2.client-secret=${ENV:TRINO_OAUTH_SECRET}
+    http-server.authentication.oauth2.scopes=openid,groups,email
+    http-server.authentication.oauth2.principal-field=email
   config-worker.properties: |-
     coordinator=false
     http-server.http.port=8080
@@ -89,7 +91,7 @@ stringData:
     group-provider.name=file
     file.group-file=/etc/trino/group-mapping.properties
   group-mapping.properties: |-
-    admins:admin,erik,hukhan,mikhail,ricardo,vincent,erikerlandson,caldeirav
+    admins:admin,erik,hukhan,mikhail,ricardo,vincent,erikerlandson,caldeirav,HumairAK
     aicoe_osc_demo:oindrillac,aakankshaduggal,shreyanand,michaelclifford,chauhankaranraj,sankbad,isabelizimm,harshad16,durandom,erikerlandson
     os_climate_corporate_data_project:ludans,caldeirav,DavWinkel,rmorais1,andraNew,ChristianMeyndt,ttschmucker,toki8,LeaADeleris,JeremyGohBNP,amirqamar
     climate_itr_tool_project:joriscram,alexanu,caldeirav,DavWinkel,ChristianMeyndt,hbaltzell,ttschmucker,toki8,LeylaJavadova,christian-schellnegger,roland-mf,franz-mf,EWinter21


### PR DESCRIPTION
This change will force trino to use github usernames as the "user" identity within trino when using Oauth.