### PR TITLE
Add clustersets and gitops mgmt as per acm 2.3

### DIFF
--- a/acm/overlays/moc/infra/gitopsclusters/argocd-managed.yaml
+++ b/acm/overlays/moc/infra/gitopsclusters/argocd-managed.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps.open-cluster-management.io/v1alpha1
+kind: GitOpsCluster
+metadata:
+  name: argocd-managed
+  namespace: argocd
+spec:
+  argoServer:
+    argoNamespace: argocd
+    cluster: local-cluster
+  placementRef:
+    apiVersion: cluster.open-cluster-management.io/v1alpha1
+    kind: Placement
+    name: argocd-managed-clusters

--- a/acm/overlays/moc/infra/gitopsclusters/kustomization.yaml
+++ b/acm/overlays/moc/infra/gitopsclusters/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - argocd-managed.yaml

--- a/acm/overlays/moc/infra/klusterletaddonconfigs/kustomization.yaml
+++ b/acm/overlays/moc/infra/klusterletaddonconfigs/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - alex.yaml
+  - balrog.yaml
+  - curator.yaml
+  - local-cluster.yaml
+  - ocp-prod.yaml
+  - osc-cl1.yaml
+  - rick.yaml
+  - smaug.yaml
+  - zero.yaml

--- a/acm/overlays/moc/infra/kustomization.yaml
+++ b/acm/overlays/moc/infra/kustomization.yaml
@@ -4,13 +4,10 @@ kind: Kustomization
 
 resources:
   - ../../../base
+  - gitopsclusters
+  - klusterletaddonconfigs
+  - managedclusters
+  - managedclustersetbindings
+  - managedclustersets
+  - placements
   - provider-connections
-  - klusterletaddonconfigs/alex.yaml
-  - klusterletaddonconfigs/balrog.yaml
-  - klusterletaddonconfigs/curator.yaml
-  - klusterletaddonconfigs/local-cluster.yaml
-  - klusterletaddonconfigs/ocp-prod.yaml
-  - klusterletaddonconfigs/osc-cl1.yaml
-  - klusterletaddonconfigs/rick.yaml
-  - klusterletaddonconfigs/smaug.yaml
-  - klusterletaddonconfigs/zero.yaml

--- a/acm/overlays/moc/infra/managedclusters/balrog.yaml
+++ b/acm/overlays/moc/infra/managedclusters/balrog.yaml
@@ -1,0 +1,6 @@
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  name: balrog
+  labels:
+    cluster.open-cluster-management.io/clusterset: argocd-managed

--- a/acm/overlays/moc/infra/managedclusters/curator.yaml
+++ b/acm/overlays/moc/infra/managedclusters/curator.yaml
@@ -1,0 +1,6 @@
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  name: curator
+  labels:
+    cluster.open-cluster-management.io/clusterset: argocd-managed

--- a/acm/overlays/moc/infra/managedclusters/kustomization.yaml
+++ b/acm/overlays/moc/infra/managedclusters/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - balrog.yaml
+  - curator.yaml
+  - ocp-prod.yaml
+  - osc-cl1.yaml
+  - rick.yaml
+  - smaug.yaml

--- a/acm/overlays/moc/infra/managedclusters/ocp-prod.yaml
+++ b/acm/overlays/moc/infra/managedclusters/ocp-prod.yaml
@@ -1,0 +1,6 @@
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  name: ocp-prod
+  labels:
+    cluster.open-cluster-management.io/clusterset: argocd-managed

--- a/acm/overlays/moc/infra/managedclusters/osc-cl1.yaml
+++ b/acm/overlays/moc/infra/managedclusters/osc-cl1.yaml
@@ -1,0 +1,6 @@
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  name: osc-cl1
+  labels:
+    cluster.open-cluster-management.io/clusterset: argocd-managed

--- a/acm/overlays/moc/infra/managedclusters/rick.yaml
+++ b/acm/overlays/moc/infra/managedclusters/rick.yaml
@@ -1,0 +1,6 @@
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  name: rick
+  labels:
+    cluster.open-cluster-management.io/clusterset: argocd-managed

--- a/acm/overlays/moc/infra/managedclusters/smaug.yaml
+++ b/acm/overlays/moc/infra/managedclusters/smaug.yaml
@@ -1,0 +1,6 @@
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  name: smaug
+  labels:
+    cluster.open-cluster-management.io/clusterset: argocd-managed

--- a/acm/overlays/moc/infra/managedclustersetbindings/argocd-managed.yaml
+++ b/acm/overlays/moc/infra/managedclustersetbindings/argocd-managed.yaml
@@ -1,0 +1,7 @@
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+kind: ManagedClusterSetBinding
+metadata:
+  name: argocd-managed
+  namespace: argocd
+spec:
+  clusterSet: argocd-managed

--- a/acm/overlays/moc/infra/managedclustersetbindings/kustomization.yaml
+++ b/acm/overlays/moc/infra/managedclustersetbindings/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - argocd-managed.yaml

--- a/acm/overlays/moc/infra/managedclustersets/argocd-managed.yaml
+++ b/acm/overlays/moc/infra/managedclustersets/argocd-managed.yaml
@@ -1,0 +1,5 @@
+kind: ManagedClusterSet
+apiVersion: clusterview.open-cluster-management.io/v1alpha1
+metadata:
+  name: argocd-managed
+spec: {}

--- a/acm/overlays/moc/infra/managedclustersets/kustomization.yaml
+++ b/acm/overlays/moc/infra/managedclustersets/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - argocd-managed.yaml

--- a/acm/overlays/moc/infra/placements/argocd-managed-clusters.yaml
+++ b/acm/overlays/moc/infra/placements/argocd-managed-clusters.yaml
@@ -1,0 +1,8 @@
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+kind: Placement
+metadata:
+  name: argocd-managed-clusters
+  namespace: argocd
+spec:
+  clusterSets:
+    - argocd-managed

--- a/acm/overlays/moc/infra/placements/kustomization.yaml
+++ b/acm/overlays/moc/infra/placements/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - argocd-managed-clusters.yaml


### PR DESCRIPTION
Okay so the way they are doing integration with argocd seems to have changed.

Old way: [here](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.2/html/manage_applications/managing-applications#gitops-pattern) where we just update the one field `applicationManager.argocdCluster`. When onboarding balrog, this didn't add the argocd secret. That's because...

The new way: [here](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.3/html/applications/managing-applications#gitops-config) 

Which requires you to have a cluster-set, which is in tech preview, but I set it up on live to test it out and it indeed added balrog to the argocd cluster list (i.e. created the secret). 

This required adding various new manifests as you can find in the PR. Read more about it [here](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.3/html/applications/managing-applications#gitops-config) and [here](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.3/html/clusters/managedclustersets). 


Anyways, the end result is to add a new cluster to argocd you need to just add a label to the corresponding cluster `ManagedCluster` resource. All clusters in this clusterset should be auto added to argocd. 