### PR TITLE
feat: Add imageregistry storage to Rick

### DIFF
--- a/cluster-scope/base/core/persistentvolumeclaims/image-registry-storage/persistentvolumeclaim.yaml
+++ b/cluster-scope/base/core/persistentvolumeclaims/image-registry-storage/persistentvolumeclaim.yaml
@@ -10,4 +10,3 @@ spec:
     requests:
       storage: 200Gi
   volumeMode: Filesystem
-  storageClassName: moc-nfs-csi

--- a/cluster-scope/overlays/prod/emea/rick/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/rick/kustomization.yaml
@@ -14,6 +14,8 @@ resources:
     - ../../../../base/core/namespaces/opf-kafka
     - ../../../../base/core/namespaces/thoth-website-prod
     - ../../../../base/core/namespaces/thoth-test-core
+    - ../../../../base/core/persistentvolumeclaims/image-registry-storage
+    - ../../../../base/imageregistry.operator.openshift.io/configs/cluster
     - ../../../../base/operators.coreos.com/operatorgroups/openshift-local-storage-zj22x
     - ../../../../base/operators.coreos.com/operatorgroups/openshift-storage-24n7x
     - ../../../../base/operators.coreos.com/operatorgroups/opf-monitoring


### PR DESCRIPTION
Resolves: https://github.com/operate-first/support/issues/377

Also uses the default storage class now.