### PR TITLE
Converted osc catalog names to lowercase.

### DIFF
--- a/odh-manifests/osc-cl1/trino/base/trino-catalog-secret.yaml
+++ b/odh-manifests/osc-cl1/trino/base/trino-catalog-secret.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   name: trino-catalog
 stringData:
-  OSC_DataCommons_Dev.properties: |
+  osc_datacommons_dev.properties: |
     connector.name=hive-hadoop2
     hive.metastore.uri=thrift://hive-metastore-osc_datacommons_dev:9083
     hive.s3.endpoint=${ENV:OSC_DATACOMMONS_DEV_S3_ENDPOINT_URL_PREFIX}${ENV:OSC_DATACOMMONS_DEV_S3_ENDPOINT}
@@ -19,7 +19,7 @@ stringData:
     hive.s3.aws-access-key=${ENV:OSC_DATACOMMONS_DEV_AWS_ACCESS_KEY_ID}
     hive.s3.aws-secret-key=${ENV:OSC_DATACOMMONS_DEV_AWS_SECRET_ACCESS_KEY}
 
-  OSC_DataCommons_Prod.properties: |
+  osc_datacommons_prod.properties: |
     connector.name=hive-hadoop2
     hive.metastore.uri=thrift://hive-metastore-osc-datacommons-prod:9083
     hive.s3.endpoint=${ENV:OSC_DATACOMMONS_PROD_S3_ENDPOINT_URL_PREFIX}${ENV:OSC_DATACOMMONS_PROD_S3_ENDPOINT}


### PR DESCRIPTION
Trino does not allow uppercase catalog names apparently: 

```
2021-09-29T20:39:21.615Z	ERROR	main	io.trino.server.Server	catalogName is not lowercase: OSC_DataCommons_Prod
java.lang.IllegalArgumentException: catalogName is not lowercase: OSC_DataCommons_Prod
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:443)
	at io.trino.metadata.MetadataUtil.checkLowerCase(MetadataUtil.java:92)
	at io.trino.metadata.MetadataUtil.checkCatalogName(MetadataUtil.java:67)
	at io.trino.metadata.Catalog.<init>(Catalog.java:51)
	at io.trino.connector.ConnectorManager.createCatalog(ConnectorManager.java:257)
	at io.trino.connector.ConnectorManager.createCatalog(ConnectorManager.java:210)
	at io.trino.connector.ConnectorManager.createCatalog(ConnectorManager.java:196)
	at io.trino.metadata.StaticCatalogStore.loadCatalog(StaticCatalogStore.java:88)
	at io.trino.metadata.StaticCatalogStore.loadCatalogs(StaticCatalogStore.java:68)
	at io.trino.server.Server.doStart(Server.java:124)
	at io.trino.server.Server.lambda$start$0(Server.java:77)
	at io.trino.$gen.Trino_362____20210929_203904_1.run(Unknown Source)
	at io.trino.server.Server.start(Server.java:77)
	at io.trino.server.TrinoServer.main(TrinoServer.java:38)
```