### PR TITLE
chore: Fix formatting for kustomize edit

### DIFF
--- a/acm/overlays/moc/infra/managedclusters/kustomization.yaml
+++ b/acm/overlays/moc/infra/managedclusters/kustomization.yaml
@@ -1,9 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - balrog.yaml
-  - curator.yaml
-  - ocp-prod.yaml
-  - osc-cl1.yaml
-  - rick.yaml
-  - smaug.yaml
+- balrog.yaml
+- curator.yaml
+- ocp-prod.yaml
+- osc-cl1.yaml
+- rick.yaml
+- smaug.yaml

--- a/argocd/overlays/moc-infra/applications/app-of-apps/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/app-of-apps/kustomization.yaml
@@ -2,11 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: argocd
 resources:
-  - app-of-apps-balrog.yaml
-  - app-of-apps-curator.yaml
-  - app-of-apps-infra.yaml
-  - app-of-apps-ocp-prod.yaml
-  - app-of-apps-osc-cl1.yaml
-  - app-of-apps-rick.yaml
-  - app-of-apps-smaug.yaml
-  - workshops-app-of-apps.yaml
+- app-of-apps-balrog.yaml
+- app-of-apps-curator.yaml
+- app-of-apps-infra.yaml
+- app-of-apps-ocp-prod.yaml
+- app-of-apps-osc-cl1.yaml
+- app-of-apps-rick.yaml
+- app-of-apps-smaug.yaml
+- workshops-app-of-apps.yaml

--- a/keycloak/overlays/moc/infra/secret-generator.yaml
+++ b/keycloak/overlays/moc/infra/secret-generator.yaml
@@ -2,12 +2,12 @@
 apiVersion: viaduct.ai/v1
 kind: ksops
 metadata:
-    name: secret-generator
+  name: secret-generator
 files:
-    - realm.enc.yaml
-    - clients/balrog.enc.yaml
-    - clients/curator.enc.yaml
-    - clients/infra.enc.yaml
-    - clients/rick.enc.yaml
-    - clients/smaug.enc.yaml
-    - clients/zero.enc.yaml
+  - realm.enc.yaml
+  - clients/balrog.enc.yaml
+  - clients/curator.enc.yaml
+  - clients/infra.enc.yaml
+  - clients/rick.enc.yaml
+  - clients/smaug.enc.yaml
+  - clients/zero.enc.yaml


### PR DESCRIPTION
With hitchhikers guide switching over to the `kustomize edit` via https://github.com/operate-first/hitchhikers-guide/pull/103 let's format the modified files beforehand (before the webinar recording).

Make the changeset of https://github.com/tumido/apps/commit/e4157cfe670122b43e2a7cc0c8fd44eded3a1eca a tiny bit smaller