### PR TITLE
fix: Mark cephfs storageclass default on rick

### DIFF
--- a/cluster-scope/overlays/prod/emea/rick/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/rick/kustomization.yaml
@@ -29,6 +29,7 @@ resources:
     - ../../../../base/rbac.authorization.k8s.io/clusterroles/acme-operator
     - ../../../../base/rbac.authorization.k8s.io/clusterroles/oauth-token-access-review
     - ../../../../base/user.openshift.io/groups/cluster-admins
+    - ../../../../base/storage.k8s.io/storageclasses/ocs-storagecluster-cephfs
 
 generators:
     - secret-generator.yaml
@@ -36,6 +37,7 @@ generators:
 patchesStrategicMerge:
     - oauths/cluster_patch.yaml
     - groups/cluster-admins.yaml
+    - storageclasses/ocs-storagecluster-cephfs_patch.yaml
     - subscriptions/local-storage-operator_patch.yaml
     - subscriptions/ocs-operator_patch.yaml
     - subscriptions/openshift-pipelines-operator-rh_patch.yaml

--- a/cluster-scope/overlays/prod/emea/rick/storageclasses/ocs-storagecluster-cephfs_patch.yaml
+++ b/cluster-scope/overlays/prod/emea/rick/storageclasses/ocs-storagecluster-cephfs_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ocs-storagecluster-cephfs
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"


### PR DESCRIPTION
Follow up to https://github.com/operate-first/apps/pull/1075

Without specifying a storageclass, the PVC won't bound, since there's no default.