### PR TITLE
enabling workflow and workflow template CRDs

### DIFF
--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
 
   - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/extensions.dashboard.tekton.dev
   - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/prowjobs.prow.k8s.io
+  - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/workflow.argoproj.io
+  - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/workflowtemplate.argoproj.io
   - ../../../../base/config.openshift.io/oauths/cluster
   - ../../../../base/core/namespaces/acme-operator
   - ../../../../base/core/namespaces/democratic-csi


### PR DESCRIPTION
Allow deploying argo workflows on Smaug

Facing issues while submitting resources, same as on rick cluster.

```
no matches for kind "WorkflowTemplate" in version "argoproj.io/v1alpha1"
```

in response to: https://github.com/thoth-station/thoth-application/issues/1971