### PR TITLE
fix: Diffing in ACM ArgoCD app

### DIFF
--- a/argocd/overlays/moc-infra/configs/argo_cm/resource.exclusions
+++ b/argocd/overlays/moc-infra/configs/argo_cm/resource.exclusions
@@ -5,3 +5,9 @@
   - "TaskRun"
   clusters:
   - "*"
+- apiGroups:
+  - "internal.open-cluster-management.io"
+  kinds:
+  - "ManagedClusterInfo"
+  clusters:
+  - "*"


### PR DESCRIPTION
Next patch to https://github.com/operate-first/SRE/issues/391 

This should fix the `ManagedClusterInfo` pruning. This PR makes ArgoCD ignore those resources completely, so they should never appear on the app screen again. 