### PR TITLE
Add PVC full alerts for Jupyterhub users

### DIFF
--- a/cluster-scope/overlays/prod/common/alertmanager-main-secret.yaml
+++ b/cluster-scope/overlays/prod/common/alertmanager-main-secret.yaml
@@ -211,6 +211,11 @@ stringData:
               match:
                 cluster: elasticsearch
                 prometheus: openshift-monitoring/k8s
+            - receiver: Github
+              match_re:
+                namespace: ^.*jupyterhub              # Alerts for Jupyterhub namespaces
+              match:
+                prometheus: openshift-monitoring/k8s
         - receiver: Watchdog
           match:
             alertname: Watchdog

--- a/kfdefs/overlays/moc/smaug/opf-jupyterhub/alerts.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-jupyterhub/alerts.yaml
@@ -1,0 +1,28 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: jupyterhub-alerts
+spec:
+  groups:
+    - name: jupyterhub
+      rules:
+        - alert: PVCFillingUp
+          annotations:
+            description: >-
+              The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
+              }} in Namespace {{ $labels.namespace }} is only {{ $value |
+              humanizePercentage }} free.
+            summary: PersistentVolume is filling up.
+            # Tag the user who owns the PVC
+            user: >-
+              @{{ reReplaceAll "^jupyterhub-nb-|-pvc$" ""
+              $labels.persistentvolumeclaim }}
+            # Link the runbook with instructions to fix this issue
+            runbook: >-
+              https://github.com/operate-first/SRE/blob/master/runbooks/jupyterhub.md#insufficient-disk-space-for-notebook-pod
+          # Alert when 90% of PVC is full
+          expr: >-
+            kubelet_volume_stats_available_bytes{namespace="opf-jupyterhub"}/kubelet_volume_stats_capacity_bytes{namespace="opf-jupyterhub"}
+            < 0.1
+          labels:
+            severity: critical

--- a/kfdefs/overlays/moc/smaug/opf-jupyterhub/kustomization.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-jupyterhub/kustomization.yaml
@@ -5,4 +5,5 @@ namespace: opf-jupyterhub
 
 resources:
   - ../../../../base/jupyterhub
+  - alerts.yaml
   - ./pvcs/


### PR DESCRIPTION
This will add PVC full alerts for jupyterhub users. These alerts will be sent to the github alertreceiver.
In these alerts, the Jupyterhub runbook is linked so that users can try to fix the issue by themselves.
Also, users will be tagged in the alert issue using their github handle.

Example alert issue: https://github.com/operate-first/alerts/issues/22570