### PR TITLE
Add imagestream for aicoe osc demo notebooks image.

### DIFF
--- a/kfdefs/overlays/osc/osc-cl1/jupyterhub/kustomization.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/jupyterhub/kustomization.yaml
@@ -5,3 +5,4 @@ namespace: odh-jupyterhub
 resources:
   - kfdef.yaml
   - profiles
+  - notebook-images

--- a/kfdefs/overlays/osc/osc-cl1/jupyterhub/notebook-images/aicoe-osc-demo.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/jupyterhub/notebook-images/aicoe-osc-demo.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: aicoe-osc-demo
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url:
+      "https://github.com/os-climate/aicoe-osc-demo"
+    opendatahub.io/notebook-image-name:
+      "AICoE OS-Climate Demo"
+    opendatahub.io/notebook-image-desc:
+      "Jupyter notebooks for the Nimbus and the Cirrus demos for OS-Climate"
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: "v.10"
+      from:
+        kind: DockerImage
+        name: quay.io/os-climate/aicoe-osc-demo:v.10
+      annotations:
+        openshift.io/imported-from: quay.io/os-climate/aicoe-osc-demo
+      importPolicy:
+        scheduled: true

--- a/kfdefs/overlays/osc/osc-cl1/jupyterhub/notebook-images/kustomization.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/jupyterhub/notebook-images/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - aicoe-osc-demo.yaml


### PR DESCRIPTION
- Created a `notebook-images` directory for any custom notebook images
- Added imagestream for [demo notebooks](https://github.com/os-climate/aicoe-osc-demo) created for OS-Climate