### PR TITLE
alertreciever argo migration to go alongside the app one

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/alertreceiver.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/alertreceiver.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: alertreceiver
+spec:
+  destination:
+    name: smaug
+    namespace: opf-alertreceiver
+  project: cluster-management
+  source:
+    path: alertreceiver/overlays/moc/smaug
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - alertreceiver.yaml
   - cert-manager.yaml
   - cloudbeaver.yaml
   - cluster-resources.yaml

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - ../../../../base/core/namespaces/koku-metrics-operator
   - ../../../../base/core/namespaces/openshift-nmstate
   - ../../../../base/core/namespaces/openshift-pipelines
+  - ../../../../base/core/namespaces/opf-alertreceiver
   - ../../../../base/core/namespaces/opf-ci-pipelines
   - ../../../../base/core/namespaces/opf-ci-prow
   - ../../../../base/core/namespaces/opf-ci-test-pods


### PR DESCRIPTION
This is the argocd portion that goes alongside the application piece of the migration Normally these both would have been one pr in the new workflow, however, the original pr was started before the change. This addresses Tom's comments in https://github.com/operate-first/apps/issues/1073.