### PR TITLE
Fix AICoE OSC demo ImageStream

### DIFF
--- a/kfdefs/overlays/osc/osc-cl1/jupyterhub/notebook-images/aicoe-osc-demo.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/jupyterhub/notebook-images/aicoe-osc-demo.yaml
@@ -16,10 +16,10 @@ spec:
   lookupPolicy:
     local: true
   tags:
-    - name: "v.10"
+    - name: "latest"
       from:
         kind: DockerImage
-        name: quay.io/os-climate/aicoe-osc-demo:v.10
+        name: quay.io/os-climate/aicoe-osc-demo:latest
       annotations:
         openshift.io/imported-from: quay.io/os-climate/aicoe-osc-demo
       importPolicy:


### PR DESCRIPTION
This PR changes the tag from `v.10` to `latest` in the ImageStream for AICoE OSC demo, so that jupyterhub (on the OS-Climate cluster) has the latest image.