### PR TITLE
Update security context perms for argocd.

### DIFF
--- a/argocd/base/deployments/argocd-application-controller_patch.yaml
+++ b/argocd/base/deployments/argocd-application-controller_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: argocd-application-controller
+spec:
+  template:
+    spec:
+      containers:
+        - name: argocd-application-controller
+          # TODO: argocd image user should be set to 999 to avoid https://github.com/argoproj/argo-cd/issues/6851
+          securityContext:
+            runAsNonRoot: false

--- a/argocd/base/deployments/argocd-repo-server_patch.yaml
+++ b/argocd/base/deployments/argocd-repo-server_patch.yaml
@@ -6,18 +6,21 @@ spec:
   template:
     spec:
       containers:
-      - name: argocd-repo-server
-        env:
-        - name: GNUPGHOME
-          value: /home/argocd/.gnupg
-        volumeMounts:
-        - name: key
-          mountPath: /key
-        lifecycle:
-          postStart:
-            exec:
-              command: ["/bin/sh", "-c", "gpg --import /key/*"]
+        - name: argocd-repo-server
+          env:
+            - name: GNUPGHOME
+              value: /home/argocd/.gnupg
+          volumeMounts:
+            - name: key
+              mountPath: /key
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", "gpg --import /key/*"]
+          # This is so we can run the lifecycle poststart cmd w/o issues
+          securityContext:
+            readOnlyRootFilesystem: false
       volumes:
-      - name: key
-        secret:
-          secretName: ksops-pgp-key
+        - name: key
+          secret:
+            secretName: ksops-pgp-key

--- a/argocd/base/kustomization.yaml
+++ b/argocd/base/kustomization.yaml
@@ -11,6 +11,7 @@ patchesStrategicMerge:
 - deployments/argocd-repo-server_patch.yaml
 - deployments/argocd-server_patch.yaml
 - deployments/argocd-dex-server_patch.yaml
+- deployments/argocd-application-controller_patch.yaml
 images:
 - name: quay.io/argoproj/argocd
   newName: quay.io/operate-first/argocd


### PR DESCRIPTION
For app controller we need to update the image to use user `999` to avoid: https://github.com/argoproj/argo-cd/issues/6851 

```
Error: container has runAsNonRoot and image has non-numeric user (argocd), cannot verify user is non-root
```
For now I just disabled this. 

For repo-server, we need the gpg folder writeable so I disabled their read only protection for root. The error this resolves is: 

```
Exec lifecycle hook ([/bin/sh -c gpg --import /key/*]) for Container "argocd-repo-server" in Pod "argocd-repo-server-84bf4ccc88-9qr7c_argocd(91b1ef75-50dd-429a-bdb9-608d995e0491)" failed - error: command '/bin/sh -c gpg --import /key/*' exited with 2: gpg: Fatal: can't create directory '/home/argocd/.gnupg': Read-only file system , message: "gpg: Fatal: can't create directory '/home/argocd/.gnupg': Read-only file system\n"
```