### PR TITLE
correct the path for user-api in rick

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/emea/rick/thoth/test/test-thoth-user-api.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/emea/rick/thoth/test/test-thoth-user-api.yaml
@@ -7,7 +7,7 @@ spec:
   project: thoth
   source:
     repoURL: 'https://github.com/thoth-station/thoth-application.git'
-    path: user-api/overlays/test
+    path: user-api/overlays/rick-test
     targetRevision: master
   destination:
     name: rick


### PR DESCRIPTION
correct the path for user-api in rick
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Fixes: https://github.com/thoth-station/thoth-application/issues/2003

Details:
wrong overlay was linked before, corrected it with this PR.