### PR TITLE
correct the overlays path for Thoth graph-sync service

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/emea/balrog/thoth/prod/prod-thoth-graph-sync-backend.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/emea/balrog/thoth/prod/prod-thoth-graph-sync-backend.yaml
@@ -7,7 +7,7 @@ spec:
   project: thoth
   source:
     repoURL: "https://github.com/thoth-station/thoth-application.git"
-    path: graph-sync/overlays/aws-prod
+    path: graph-sync/overlays/aws-prod/backend
     targetRevision: master
   destination:
     name: balrog

--- a/argocd/overlays/moc-infra/applications/envs/emea/balrog/thoth/prod/prod-thoth-graph-sync-middletier.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/emea/balrog/thoth/prod/prod-thoth-graph-sync-middletier.yaml
@@ -7,7 +7,7 @@ spec:
   project: thoth
   source:
     repoURL: "https://github.com/thoth-station/thoth-application.git"
-    path: graph-sync/overlays/aws-prod
+    path: graph-sync/overlays/aws-prod/middletier
     targetRevision: master
   destination:
     name: balrog

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/thoth/prod/prod-thoth-graph-sync-backend.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/thoth/prod/prod-thoth-graph-sync-backend.yaml
@@ -7,7 +7,7 @@ spec:
   project: thoth
   source:
     repoURL: "https://github.com/thoth-station/thoth-application.git"
-    path: graph-sync/overlays/moc-prod
+    path: graph-sync/overlays/moc-prod/backend
     targetRevision: master
   destination:
     name: smaug

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/thoth/prod/prod-thoth-graph-sync-middletier.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/thoth/prod/prod-thoth-graph-sync-middletier.yaml
@@ -7,7 +7,7 @@ spec:
   project: thoth
   source:
     repoURL: "https://github.com/thoth-station/thoth-application.git"
-    path: graph-sync/overlays/moc-prod
+    path: graph-sync/overlays/moc-prod/middletier
     targetRevision: master
   destination:
     name: smaug


### PR DESCRIPTION
correct the overlays path for graph-sync service
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


We have to change the overlay location. 
so this fixes them
Related-To: https://github.com/thoth-station/thoth-application/pull/2015
