### PR TITLE
Add cert-manager, issuer, cert to osc cluster.

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl1/cluster-management/cert-manager.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl1/cluster-management/cert-manager.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+spec:
+  destination:
+    name: osc-cl1
+    namespace: openshift-ingress
+  project: cluster-management
+  source:
+    repoURL: https://github.com/operate-first/apps.git
+    path: cert-manager/overlays/route53/us-east-1/osc-cl1
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl1/cluster-management/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl1/cluster-management/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - cert-manager.yaml
   - cluster-resources.yaml
   - acme-operator.yaml
   - dex.yaml

--- a/cert-manager/overlays/route53/us-east-1/osc-cl1/certificate.yaml
+++ b/cert-manager/overlays/route53/us-east-1/osc-cl1/certificate.yaml
@@ -1,0 +1,8 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ingress-certificate
+  namespace: openshift-ingress
+spec:
+  dnsNames:
+    - "*.apps.odh-cl1.apps.os-climate.org"

--- a/cert-manager/overlays/route53/us-east-1/osc-cl1/issuer.yaml
+++ b/cert-manager/overlays/route53/us-east-1/osc-cl1/issuer.yaml
@@ -1,0 +1,24 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: ingress-letsencrypt-production
+  namespace: openshift-ingress
+spec:
+  acme:
+    email: ops-team@operate-first.cloud
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: ingress-certificate
+    solvers:
+      - dns01:
+          cnameStrategy: Follow
+          route53:
+            accessKeyID: AKIAZNQ2HXS5NOCJNRWM
+            hostedZoneID: Z04490453K6YE8HM7YHJ6
+            region: us-east-1
+            secretAccessKeySecretRef:
+              key: secret-access-key
+              name: route53
+          selector:
+            dnsZones:
+              - apps.os-climate.org

--- a/cert-manager/overlays/route53/us-east-1/osc-cl1/kustomization.yaml
+++ b/cert-manager/overlays/route53/us-east-1/osc-cl1/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../base
+  - issuer.yaml
+generators:
+  - secret-generator.yaml
+patchesStrategicMerge:
+  - certificate.yaml

--- a/cert-manager/overlays/route53/us-east-1/osc-cl1/route53.enc.yaml
+++ b/cert-manager/overlays/route53/us-east-1/osc-cl1/route53.enc.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: route53
+    namespace: openshift-ingress
+stringData:
+    secret-access-key: ENC[AES256_GCM,data:JqRjyh4/9lLxLaqC3SJsiIA6LJkiAGT//BbwDHS3U1OiY2l3phiIpA==,iv:GFXwzWkHlGqFHLF6245p7glJ58qiPeT0haxSEXRER5o=,tag:s6lB4mSG1R3/PgnBmnmrzA==,type:str]
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-10-07T17:37:27Z'
+    mac: ENC[AES256_GCM,data:DAogUA/Wvy6pT8LYkLBA2kmRacl157cuLeqFcfUxhD0Zqha62D1uS0d8qr6XQx0rwst5xDO0tgV445DPMPBshV8XfcbpRREZjf4s49xUpr+2UyR16Q0KYhoAL3nfZ56CX1pq66kr2AGNaBgYEiXeVD1WN/tWbDRvE4awD+tRrZ0=,iv:5tCWmCqqR884cx3m3J9MYhHyHqwuFC/UVsK3ZB4ADKY=,tag:bCnjhbXjr0wlC100USOAvA==,type:str]
+    pgp:
+    -   created_at: '2021-10-07T17:37:26Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA9aKBcudqifiARAAxOygmnwnqaRrP8VZwstL9ZOOHjIUTuHLnZQgJtcZXG0R
+            MKc0DNdnoA7bWOKLJHaJTcDhH5YcaDRecgBs6IY96v3CUddVCFTNWnlfUJYqaxpY
+            vdQC1EoWeFXqc0xXi1XLUw3eIWbU+tysry+ZcuaTIvALvcXLbM7PeT63ssBt6KwY
+            MlvpmNblZoww8GcCDWVrL+W80PY6NF/30TVIm0yfkZCnyHn6+G6L3pvYGt2KIrQK
+            OrfKnQZ9G8yl6GjEE2HfsvryN6wLIJ/DuB2LxnJ0jd89awkL80X0I5dg/ArfY6vZ
+            zhXq49hXAtK1NeRvSS76H5OyFT9zTKyQNqmYQiM99mZAYAhH9UZZqaRxQhWPUPHW
+            0mma0qaxdMl2OAbsngFah/Old12Nesuqk24h1Eu4sJupqafNfCZeGlaEcYrF5doW
+            mFY189clOmiXyUGdVTRaNdFe7LkY96LrqMkuf3DwhQDm49jTCwEjSBC+mrhyE1Gg
+            Z7la8ROSy+5cC++jvyYAn4CXABrqu3R/OVgr0IlDmg0I0MkXxWwRmKY2WHgUmoOJ
+            Mz4swqFLQ5S5r1eUphO699uRP2JUPG6MwuQsrth15voju7CCrloRljj+cAWklOvT
+            2ycJ9nu7ergogIaJu993BYfZlQJ+AvmmGxF/p1Jq6WEIJEa8StclY0057oS4irbS
+            4AHkHSWK5TEonaMnYl6XJ4UQVOEXi+C14DThtaXg3uJeoNzh4ATlh/qoCyu1sFPU
+            nvGLl6PmPDQiwuBL4C7RhiyjtJwC/wDgPeTPVmWC20KOSfmp14+x1VSu4kBUYLHh
+            9OAA
+            =Eesz
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^(users|data|stringData)$
+    version: 3.6.1

--- a/cert-manager/overlays/route53/us-east-1/osc-cl1/secret-generator.yaml
+++ b/cert-manager/overlays/route53/us-east-1/osc-cl1/secret-generator.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: secret-generator
+files:
+  - route53.enc.yaml

--- a/cluster-scope/overlays/prod/osc/osc-cl1/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ../../../../base/core/namespaces/odh-jupyterhub
   - ../../../../base/core/namespaces/odh-superset
   - ../../../../base/core/namespaces/odh-trino
+  - ../../../../base/operators.coreos.com/subscriptions/cert-manager
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-rb
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/opendatahub-operator


### PR DESCRIPTION
For https://github.com/os-climate/data-platform-demo/issues/18

I've tried to make this non-conflicting with https://github.com/operate-first/apps/pull/1120
however https://github.com/operate-first/apps/pull/1120 will need to restructure a bit more to take into account the fact that not all aws clusters are from the same account (like in this case). 