### PR TITLE
feat: Add default limit ranges to opf-kafka

### DIFF
--- a/cluster-scope/base/core/namespaces/opf-kafka/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/opf-kafka/kustomization.yaml
@@ -4,6 +4,7 @@ components:
 - ../../../../components/project-admin-rolebindings/odh-admin
 - ../../../../components/monitoring-rbac
 - ../../../../components/odh-dashboard
+- ../../../../components/limitranges/default
 kind: Kustomization
 namespace: opf-kafka
 resources:


### PR DESCRIPTION
Resolves: https://github.com/operate-first/SRE/issues/400#issuecomment-938519419
Closing: https://github.com/operate-first/SRE/issues/400

If namespace has `ResourceQuota` and there's no limit range, pods fail to be submitted if they don't have resources request/limits.

In this case Strimzi is not setting requests/limits in it's operator deployments. Hence the ReplicaSet fails to submit Pods.

Adding `LimitRange` to `opf-kafka` namespace solves this issue. 