### PR TITLE
feat: Upgrade Infra to OCP 4.8 [part 1]

### DIFF
--- a/cluster-scope/overlays/prod/moc/infra/clusterversion.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/clusterversion.yaml
@@ -3,8 +3,8 @@ kind: ClusterVersion
 metadata:
   name: version
 spec:
-  channel: stable-4.6
+  channel: stable-4.7
   upstream: https://api.openshift.com/api/upgrades_info/v1/graph
   desiredUpdate:
-    image: quay.io/openshift-release-dev/ocp-release@sha256:f07ba64a24638e3bf8ff5d71b6f5bd400ed4501ed4aadf5f3a36ecda1ea75ec6
-    version: 4.6.31
+    image: quay.io/openshift-release-dev/ocp-release@sha256:96f00e5b0cde92488c42cd9395ff5a755c77f4273eb10aa83bc2707a8badf93f
+    version: 4.7.32

--- a/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
@@ -11,11 +11,15 @@ resources:
   - ../../../../base/core/namespaces/acme-operator
   - ../../../../base/core/namespaces/democratic-csi
   - ../../../../base/core/namespaces/keycloak
+  - ../../../../base/core/namespaces/openshift-nmstate
   - ../../../../base/core/namespaces/opf-alertreceiver
+  - ../../../../base/nmstate.io/nmstates/nmstate
   - ../../../../base/operator.openshift.io/ingresscontrollers/default
   - ../../../../base/operators.coreos.com/operatorgroups/keycloak
+  - ../../../../base/operators.coreos.com/operatorgroups/openshift-nmstate
   - ../../../../base/operators.coreos.com/operatorgroups/operator-acm-group
   - ../../../../base/operators.coreos.com/subscriptions/acm-operator-subscription
+  - ../../../../base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator
   - ../../../../base/operators.coreos.com/subscriptions/rhsso-operator
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/moc-nfs-democratic-csi-controller-rb
@@ -27,18 +31,13 @@ resources:
   - ../../../../base/storage.k8s.io/storageclasses/moc-nfs-csi
   - ../../../../base/user.openshift.io/groups/cluster-admins
 
-  # install cnv for nmstate support in 4.6
-  - ../../../../base/core/namespaces/openshift-cnv
-  - ../../../../base/operators.coreos.com/operatorgroups/openshift-cnv-rn5jf
-  - ../../../../base/operators.coreos.com/subscriptions/kubevirt-hyperconverged
-
   - clusterversion.yaml
-  - crc-provisioning-vlan.yaml
+  - nodenetworkconfigurationpolicies/crc-provisioning-vlan.yaml
   - kubeletconfigs/increase-worker-system-reserved-memory.yaml
   - metal3.io/provisionings/provisioning-configuration.yaml
   - nodenetworkconfigurationpolicies/moc-nfs-network.yaml
-  - ocp-prod-provisioning-vlan.yaml
-  - zero-provisioning-vlan.yaml
+  - nodenetworkconfigurationpolicies/ocp-prod-provisioning-vlan.yaml
+  - nodenetworkconfigurationpolicies/zero-provisioning-vlan.yaml
 
 generators:
   - secret-generator.yaml
@@ -48,5 +47,5 @@ patchesStrategicMerge:
   - configmaps/user-workload-monitoring-config.yaml
   - oauths/cluster_patch.yaml
   - storageclasses/moc-nfs-csi_patch.yaml
-  - subscriptions/kubevirt-hyperconverged_patch.yaml
+  - subscriptions/kubernetes-nmstate-operator_patch.yaml
   - groups/cluster-admins.yaml

--- a/cluster-scope/overlays/prod/moc/infra/nodenetworkconfigurationpolicies/crc-provisioning-vlan.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/nodenetworkconfigurationpolicies/crc-provisioning-vlan.yaml
@@ -1,68 +1,68 @@
-apiVersion: nmstate.io/v1alpha1
+apiVersion: nmstate.io/v1beta1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: zero-provisioning-vlan-ctrl-0
+  name: crc-provisioning-vlan-ctrl-0
 spec:
   nodeSelector:
     kubernetes.io/hostname: os-ctrl-0
   desiredState:
     interfaces:
-      - name: eno1.294
-        description: zero cluster provisioning network
+      - name: eno1.307
+        description: crc cluster provisioning network
         type: vlan
         state: up
         vlan:
           base-iface: eno1
-          id: 294
+          id: 307
         ipv4:
           enabled: true
           dhcp: false
           address:
-            - ip: 172.22.2.250
+            - ip: 172.22.1.250
               prefix-length: 24
 ---
-apiVersion: nmstate.io/v1alpha1
+apiVersion: nmstate.io/v1beta1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: zero-provisioning-vlan-ctrl-1
+  name: crc-provisioning-vlan-ctrl-1
 spec:
   nodeSelector:
     kubernetes.io/hostname: os-ctrl-1
   desiredState:
     interfaces:
-      - name: eno1.294
-        description: zero cluster provisioning network
+      - name: eno1.307
+        description: crc cluster provisioning network
         type: vlan
         state: up
         vlan:
           base-iface: eno1
-          id: 294
+          id: 307
         ipv4:
           enabled: true
           dhcp: false
           address:
-            - ip: 172.22.2.251
+            - ip: 172.22.1.251
               prefix-length: 24
 ---
-apiVersion: nmstate.io/v1alpha1
+apiVersion: nmstate.io/v1beta1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: zero-provisioning-vlan-ctrl-2
+  name: crc-provisioning-vlan-ctrl-2
 spec:
   nodeSelector:
     kubernetes.io/hostname: os-ctrl-2
   desiredState:
     interfaces:
-      - name: eno1.294
-        description: zero cluster provisioning network
+      - name: eno1.307
+        description: crc cluster provisioning network
         type: vlan
         state: up
         vlan:
           base-iface: eno1
-          id: 294
+          id: 307
         ipv4:
           enabled: true
           dhcp: false
           address:
-            - ip: 172.22.2.252
+            - ip: 172.22.1.252
               prefix-length: 24

--- a/cluster-scope/overlays/prod/moc/infra/nodenetworkconfigurationpolicies/moc-nfs-network.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/nodenetworkconfigurationpolicies/moc-nfs-network.yaml
@@ -1,4 +1,4 @@
-apiVersion: nmstate.io/v1alpha1
+apiVersion: nmstate.io/v1beta1
 kind: NodeNetworkConfigurationPolicy
 metadata:
   name: moc-nfs-network

--- a/cluster-scope/overlays/prod/moc/infra/nodenetworkconfigurationpolicies/ocp-prod-provisioning-vlan.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/nodenetworkconfigurationpolicies/ocp-prod-provisioning-vlan.yaml
@@ -1,68 +1,68 @@
-apiVersion: nmstate.io/v1alpha1
+apiVersion: nmstate.io/v1beta1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: crc-provisioning-vlan-ctrl-0
+  name: ocp-prod-provisioning-vlan-ctrl-0
 spec:
   nodeSelector:
     kubernetes.io/hostname: os-ctrl-0
   desiredState:
     interfaces:
-      - name: eno1.307
-        description: crc cluster provisioning network
+      - name: eno1.209
+        description: ocp-prod provisioning network
         type: vlan
         state: up
         vlan:
           base-iface: eno1
-          id: 307
+          id: 209
         ipv4:
           enabled: true
           dhcp: false
           address:
-            - ip: 172.22.1.250
+            - ip: 172.22.3.250
               prefix-length: 24
 ---
-apiVersion: nmstate.io/v1alpha1
+apiVersion: nmstate.io/v1beta1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: crc-provisioning-vlan-ctrl-1
+  name: ocp-prod-provisioning-vlan-ctrl-1
 spec:
   nodeSelector:
     kubernetes.io/hostname: os-ctrl-1
   desiredState:
     interfaces:
-      - name: eno1.307
-        description: crc cluster provisioning network
+      - name: eno1.209
+        description: ocp-prod provisioning network
         type: vlan
         state: up
         vlan:
           base-iface: eno1
-          id: 307
+          id: 209
         ipv4:
           enabled: true
           dhcp: false
           address:
-            - ip: 172.22.1.251
+            - ip: 172.22.3.251
               prefix-length: 24
 ---
-apiVersion: nmstate.io/v1alpha1
+apiVersion: nmstate.io/v1beta1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: crc-provisioning-vlan-ctrl-2
+  name: ocp-prod-provisioning-vlan-ctrl-2
 spec:
   nodeSelector:
     kubernetes.io/hostname: os-ctrl-2
   desiredState:
     interfaces:
-      - name: eno1.307
-        description: crc cluster provisioning network
+      - name: eno1.209
+        description: ocp prod-provisioning network
         type: vlan
         state: up
         vlan:
           base-iface: eno1
-          id: 307
+          id: 209
         ipv4:
           enabled: true
           dhcp: false
           address:
-            - ip: 172.22.1.252
+            - ip: 172.22.3.252
               prefix-length: 24

--- a/cluster-scope/overlays/prod/moc/infra/nodenetworkconfigurationpolicies/zero-provisioning-vlan.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/nodenetworkconfigurationpolicies/zero-provisioning-vlan.yaml
@@ -1,68 +1,68 @@
-apiVersion: nmstate.io/v1alpha1
+apiVersion: nmstate.io/v1beta1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: ocp-prod-provisioning-vlan-ctrl-0
+  name: zero-provisioning-vlan-ctrl-0
 spec:
   nodeSelector:
     kubernetes.io/hostname: os-ctrl-0
   desiredState:
     interfaces:
-      - name: eno1.209
-        description: ocp-prod provisioning network
+      - name: eno1.294
+        description: zero cluster provisioning network
         type: vlan
         state: up
         vlan:
           base-iface: eno1
-          id: 209
+          id: 294
         ipv4:
           enabled: true
           dhcp: false
           address:
-            - ip: 172.22.3.250
+            - ip: 172.22.2.250
               prefix-length: 24
 ---
-apiVersion: nmstate.io/v1alpha1
+apiVersion: nmstate.io/v1beta1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: ocp-prod-provisioning-vlan-ctrl-1
+  name: zero-provisioning-vlan-ctrl-1
 spec:
   nodeSelector:
     kubernetes.io/hostname: os-ctrl-1
   desiredState:
     interfaces:
-      - name: eno1.209
-        description: ocp-prod provisioning network
+      - name: eno1.294
+        description: zero cluster provisioning network
         type: vlan
         state: up
         vlan:
           base-iface: eno1
-          id: 209
+          id: 294
         ipv4:
           enabled: true
           dhcp: false
           address:
-            - ip: 172.22.3.251
+            - ip: 172.22.2.251
               prefix-length: 24
 ---
-apiVersion: nmstate.io/v1alpha1
+apiVersion: nmstate.io/v1beta1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: ocp-prod-provisioning-vlan-ctrl-2
+  name: zero-provisioning-vlan-ctrl-2
 spec:
   nodeSelector:
     kubernetes.io/hostname: os-ctrl-2
   desiredState:
     interfaces:
-      - name: eno1.209
-        description: ocp prod-provisioning network
+      - name: eno1.294
+        description: zero cluster provisioning network
         type: vlan
         state: up
         vlan:
           base-iface: eno1
-          id: 209
+          id: 294
         ipv4:
           enabled: true
           dhcp: false
           address:
-            - ip: 172.22.3.252
+            - ip: 172.22.2.252
               prefix-length: 24

--- a/cluster-scope/overlays/prod/moc/infra/subscriptions/kubernetes-nmstate-operator_patch.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/subscriptions/kubernetes-nmstate-operator_patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kubernetes-nmstate-operator
+  namespace: openshift-nmstate
+spec:
+  channel: "4.7"

--- a/cluster-scope/overlays/prod/moc/infra/subscriptions/kubevirt-hyperconverged_patch.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/subscriptions/kubevirt-hyperconverged_patch.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: kubevirt-hyperconverged
-  namespace: openshift-cnv
-spec:
-  channel: "stable"
-  startingCSV: "kubevirt-hyperconverged-operator.v2.5.4"


### PR DESCRIPTION
Upgrading Rick cluster via upgrade path mentioned here: https://access.redhat.com/labs/ocpupgradegraph/update_path?channel=stable-4.6&arch=x86_64&is_show_hot_fix=false&current_ocp_version=4.6.31&target_ocp_version=4.8.13
Part of: https://github.com/operate-first/SRE/issues/365