### PR TITLE
wip: feat: Onboard ibmcloud-managed-cluster cluster

### DIFF
--- a/acm/overlays/moc/infra/managedclusters/ibmcloud-managed-cluster.yaml
+++ b/acm/overlays/moc/infra/managedclusters/ibmcloud-managed-cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  name: ibmcloud-managed-cluster
+  labels:
+    cluster.open-cluster-management.io/clusterset: argocd-managed

--- a/acm/overlays/moc/infra/managedclusters/kustomization.yaml
+++ b/acm/overlays/moc/infra/managedclusters/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 - rick.yaml
 - smaug.yaml
 - demo.yaml
+- ibmcloud-managed-cluster.yaml

--- a/alertreceiver/overlays/apac/ibmcloud-managed-cluster/kustomization.yaml
+++ b/alertreceiver/overlays/apac/ibmcloud-managed-cluster/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../common
+
+patchesJson6902:
+  - patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/args/0
+        value: --label=environment/apac/ibmcloud-managed-cluster
+    target:
+      group: apps
+      kind: Deployment
+      name: github-receiver
+      version: v1

--- a/argocd/overlays/moc-infra/applications/app-of-apps/app-of-apps-ibmcloud-managed-cluster.yaml
+++ b/argocd/overlays/moc-infra/applications/app-of-apps/app-of-apps-ibmcloud-managed-cluster.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: opf-app-of-apps-ibmcloud-managed-cluster
+spec:
+  destination:
+    namespace: argocd
+    name: moc-infra
+  project: operate-first
+  source:
+    path: argocd/overlays/moc-infra/applications/envs/apac/ibmcloud-managed-cluster
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false
+    - ApplyOutOfSyncOnly=true

--- a/argocd/overlays/moc-infra/applications/app-of-apps/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/app-of-apps/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
 - app-of-apps-smaug.yaml
 - workshops-app-of-apps.yaml
 - app-of-apps-demo.yaml
+- app-of-apps-ibmcloud-managed-cluster.yaml

--- a/argocd/overlays/moc-infra/applications/envs/apac/ibmcloud-managed-cluster/cluster-management/alertreceiver.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/apac/ibmcloud-managed-cluster/cluster-management/alertreceiver.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: alertreceiver
+spec:
+  destination:
+    name: ibmcloud-managed-cluster
+    namespace: opf-alertreceiver
+  project: cluster-management
+  source:
+    path: alertreceiver/overlays/apac/ibmcloud-managed-cluster
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/argocd/overlays/moc-infra/applications/envs/apac/ibmcloud-managed-cluster/cluster-management/cluster-resources.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/apac/ibmcloud-managed-cluster/cluster-management/cluster-resources.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cluster-resources
+spec:
+  destination:
+    name: ibmcloud-managed-cluster
+    namespace: open-cluster-management-agent
+  ignoreDifferences:
+    - group: imageregistry.operator.openshift.io
+      jsonPointers:
+        - /spec/defaultRoute
+        - /spec/httpSecret
+        - /spec/proxy
+        - /spec/requests
+        - /spec/rolloutStrategy
+      kind: Config
+      name: cluster
+  project: cluster-management
+  source:
+    path: cluster-scope/overlays/prod/apac/ibmcloud-managed-cluster
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false
+    - ApplyOutOfSyncOnly=true

--- a/argocd/overlays/moc-infra/applications/envs/apac/ibmcloud-managed-cluster/cluster-management/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/apac/ibmcloud-managed-cluster/cluster-management/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-resources.yaml
+- alertreceiver.yaml

--- a/argocd/overlays/moc-infra/applications/envs/apac/ibmcloud-managed-cluster/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/apac/ibmcloud-managed-cluster/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+nameSuffix: -ibmcloud-managed-cluster
+namespace: argocd
+resources:
+- cluster-management

--- a/cluster-scope/overlays/prod/apac/common/kustomization.yaml
+++ b/cluster-scope/overlays/prod/apac/common/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../common

--- a/cluster-scope/overlays/prod/apac/ibmcloud-managed-cluster/configmaps/cluster-monitoring-config.yaml
+++ b/cluster-scope/overlays/prod/apac/ibmcloud-managed-cluster/configmaps/cluster-monitoring-config.yaml
@@ -1,0 +1,12 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+    prometheusK8s:
+      externalLabels:
+        cluster: apac/ibmcloud-managed-cluster

--- a/cluster-scope/overlays/prod/apac/ibmcloud-managed-cluster/configmaps/user-workload-monitoring-config.yaml
+++ b/cluster-scope/overlays/prod/apac/ibmcloud-managed-cluster/configmaps/user-workload-monitoring-config.yaml
@@ -1,0 +1,10 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    prometheus:
+      externalLabels:
+        cluster: apac/ibmcloud-managed-cluster

--- a/cluster-scope/overlays/prod/apac/ibmcloud-managed-cluster/groups/cluster-admins.yaml
+++ b/cluster-scope/overlays/prod/apac/ibmcloud-managed-cluster/groups/cluster-admins.yaml
@@ -1,0 +1,9 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: cluster-admins
+users:
+  - tumido
+  - humairak
+  - 4n4nd
+  - larsks

--- a/cluster-scope/overlays/prod/apac/ibmcloud-managed-cluster/kustomization.yaml
+++ b/cluster-scope/overlays/prod/apac/ibmcloud-managed-cluster/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../common
+- ../../../../base/config.openshift.io/oauths/cluster
+- ../../../../base/user.openshift.io/groups/cluster-admins
+- ../../../../base/core/configmaps/cluster-monitoring-config
+- ../../../../base/core/configmaps/user-workload-monitoring-config
+- ../../../../base/core/namespaces/opf-alertreceiver
+
+patchesStrategicMerge:
+- configmaps/cluster-monitoring-config.yaml
+- configmaps/user-workload-monitoring-config.yaml
+- groups/cluster-admins.yaml
+- oauths/cluster_patch.yaml
+
+generators:
+- secret-generator.yaml

--- a/cluster-scope/overlays/prod/apac/ibmcloud-managed-cluster/oauths/cluster_patch.yaml
+++ b/cluster-scope/overlays/prod/apac/ibmcloud-managed-cluster/oauths/cluster_patch.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec:
+  identityProviders:
+    - mappingMethod: claim
+      name: operate-first
+      openID:
+        claims:
+          email:
+            - email
+          name:
+            - name
+          preferredUsername:
+            - preferred_username
+        clientID: ibmcloud-managed-cluster
+        clientSecret:
+          name: operate-first-sso-secret
+        extraScopes: []
+        issuer: https://keycloak-keycloak.apps.moc-infra.massopen.cloud/auth/realms/operate-first
+      type: OpenID

--- a/cluster-scope/overlays/prod/apac/ibmcloud-managed-cluster/oauths/operate-first-sso-secret.enc.yaml
+++ b/cluster-scope/overlays/prod/apac/ibmcloud-managed-cluster/oauths/operate-first-sso-secret.enc.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: operate-first-sso-secret
+    namespace: openshift-config
+    annotations:
+        argocd.argoproj.io/compare-options: IgnoreExtraneous
+        argocd.argoproj.io/sync-options: Prune=false
+type: Opaque
+stringData:
+    clientSecret: ENC[AES256_GCM,data:tQO0vz6JntYZBRRbSm7mLStOa7nXAJ/XkMRoTTt8bUdPTIhK,iv:JNZ5Bh/mDCn15qr6HNh1LuFY4dkSCe2KlOgy+6YW3XM=,tag:qfL5xPj9Ly711JLs0yxgyg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2021-10-11T11:46:15Z"
+    mac: ENC[AES256_GCM,data:3+7SYYhZxcspdEWzGPkfsj578jJE7cS8YALGrHHKyFldxqUChbSPlaPYGksQVYyoF9WChGOb1EgcbTM6IpevcDQSFbsbe5HNAtR4wdL0UPgibXsHgK2BYZvi8VZ3esEnB1bk8qEDVFX+QJu42mgUMf79dY4G+05UNsyY7tB454M=,iv:23QjUFkfm/WOLTunqBPiKHZHty896sKiDOOwe4Bjjwc=,tag:MCci6VREYb8BN0Mzwjf0Eg==,type:str]
+    pgp:
+        - created_at: "2021-10-11T11:46:14Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA9aKBcudqifiARAAp1h6AcQU6Aktm8N5LNVNA5PDlsV8ZKBNQ3vD9lGWhIJ6
+            RoEsFGFAPIUwNzcQE3sAVEyW9Mf/7KVo4t5NAdbV9DaRiJvO4zy9/P0CTd94bIyG
+            jaXzKQiHf/+ZaUqYjFZnGFjuUNCfddla/MLQqae7AMR2a2JL+pSR8JnRXsXYyIWl
+            0gURTEhIYVh6AcfNhLu/T6R9K8BoRBaFcw6CJ/JQvyMZZYG5x3nyTIZkXLxtlLdL
+            L3K4Ky7/w8oRGc+fNcgjLxVgIuZ9t74ZmgHKgHwhNjD1UedAk2XPrkVEkEJkSCEy
+            e2Jeu6KTU/Os3y7w9siJRk99ld//PzDYUGWh55AGGY8bnT7Jubb1xEfmN2K/pXqC
+            VJw2imKbMrWeSPy0T/5ZOv7nUbePWnbOB493ZJVNjduQyv0WN0g3Ay4CXIti3uXQ
+            Ph0J7eVkRBhXeW7MkFxJluTCAuGyhJe9KUC+1rFtJCqMyvt5UGvxmFR5Wu3TWWzu
+            ryLSNZfC6kTxzyeaMDzHmc1hgk9a4nLDkH6gqtyK7QPzSkze4rGYcVfrpwcMSjWr
+            iwLshuiGdIzo2d1PwOj3CNHpmAbnKFZbcqDvpVILyH+I8RTmBP4jhgOdfN62+Go/
+            iZMXZxQudpsbl4G3EdqaWEEvrZ7OFzyvjcb6WT1M0+aQRRrqKC3zD9/AXOhZ/XLS
+            5gHVYHVYYMVGGdSuQfnbIuHUQWomW5zV3vrEeQcdgNAmCHcbaV22Xs0Xg//+GyyJ
+            mDZLWUgCj9yri8VNtGyDBYfkQCsu+fOglwCpGOwdHABTP+I7yzsiAA==
+            =uufn
+            -----END PGP MESSAGE-----
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.1

--- a/cluster-scope/overlays/prod/apac/ibmcloud-managed-cluster/secret-generator.yaml
+++ b/cluster-scope/overlays/prod/apac/ibmcloud-managed-cluster/secret-generator.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: secret-generator
+files:
+  - oauths/operate-first-sso-secret.enc.yaml

--- a/keycloak/overlays/moc/infra/clients/ibmcloud-managed-cluster.enc.yaml
+++ b/keycloak/overlays/moc/infra/clients/ibmcloud-managed-cluster.enc.yaml
@@ -1,0 +1,52 @@
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakClient
+metadata:
+    name: ibmcloud-managed-cluster
+    labels:
+        client: ibmcloud-managed-cluster
+spec:
+    client:
+        clientId: ibmcloud-managed-cluster
+        defaultClientScopes:
+            - profile
+        description: A cluster in IBM Cloud
+        name: ibmcloud-managed-cluster cluster
+        protocol: openid-connect
+        secret: ENC[AES256_GCM,data:j3lF/XcVrEUAThX7mGGtYfKOm/LzW8iOdYCozhb1HFEw+Fyz,iv:ESsSC65AAFie6JjvQ+RjEX/Rqp0D0p8ahqG6eKzZaK0=,tag:PBjVNkwbDLnQkEgxsa9vVQ==,type:str]
+        standardFlowEnabled: true
+        redirectUris:
+            - https://oauth-openshift.ibmcloud-managed-cluster-b8ef7649236a07f2b2866d2585e12cb2-0000.jp-tok.containers.appdomain.cloud/oauth2callback/operate-first
+    realmSelector:
+        matchLabels:
+            realm: operate-first
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2021-10-11T11:46:07Z"
+    mac: ENC[AES256_GCM,data:aoa9MXNLo1/Dc0wKoYwFEMocbyrnEb6kD9AM6u2z07KgQ4AtcbpdYG+vSEtEbm9CRpS6+efLep+XeDMZQy8ifb51wJSPPUblboXrTVCFRTrjSSnu699H1ROAMZ9JUhjEy1j17Kc9rXPiorgKyiTzhryIlYSyOwZ14I/m/9P1jLg=,iv:Tm+OIMuFw5RhK7Cx7JPh2ldOd0Hvw2b5gACFiBe4BKY=,tag:VyJpqxtEBg8jM29jfmRTSQ==,type:str]
+    pgp:
+        - created_at: "2021-10-11T11:46:07Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA9aKBcudqifiARAAliWmzmnkr2Cu/eV2ECimXCA/eqvZ9xRMLNIXAVFWw1i4
+            ijzAcpm45pjKmOVQ/TwU2T7IRaEl/YuiiTXpldN/1NTQopmZdgeRGwkBk8pQNLrZ
+            uRtPq/GD2TiwUMVlwaGxxtClKVqlowrZ3I9IcMz1OnzdspQ498f5z771/Y8omDw0
+            rTbcgfFcPTvJsPdB/TdzuuHnj28hz4GwdBUj5KKa6VL6hEWdGC/Yj1TpgYBGR7vi
+            hQs5ElhdK5sHmt4qojwC+WJH5tSLYP7/PXc9KyO2DEZeeu4inbQqdgpFN4R14QnU
+            DMm/qzUIleQ3E5kLMmPntGIq8gplqMjvvFZV5Uf3Q5z9U6cte3NcytkUnxvznXab
+            ndvyLtTUjE6v8GyL+t//K3z3NrTW6NH0T2EOdWHbHU5hgoRkOLgHogOLOnF3/Xq6
+            z3ENqtK+DoBg5D58Kghf5CmE+MRQfgxLar7y7glyC7lihPfw/Lzbl0Yv8SX4tS9x
+            0v8/ZZI8RogaTzyqaAalIUQTskba6p6U1f07jn7UVcaSr1XEPG4Orkca6J9RU14X
+            jVXnjj3XOR8CBFYhKeXqk4o2YYL/LnGyG47+l96eJNPZrq/0L1egb2RZZ7c6+zI2
+            e+luvrj+KXX2nUHucJt6qqlQFMMfX47GoQyDO1Z/LIfsxgLw+HeVCEr8TEM0sXrS
+            5gEy69PWW9RvpHd2WLizaHBpsQeVmzycnoFG0DpLl6QjgD8CAk86ip2b4QDgbCZ/
+            g4+taXHzo1lI75BJgnp0gZfkl248X15IiE/+BV0l3zZvruI2wBe5AA==
+            =Qxau
+            -----END PGP MESSAGE-----
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^secret$
+    version: 3.7.1

--- a/keycloak/overlays/moc/infra/secret-generator.yaml
+++ b/keycloak/overlays/moc/infra/secret-generator.yaml
@@ -12,3 +12,4 @@ files:
   - clients/smaug.enc.yaml
   - clients/zero.enc.yaml
   - clients/demo.enc.yaml
+  - clients/ibmcloud-managed-cluster.enc.yaml


### PR DESCRIPTION
Part of: https://github.com/operate-first/support/issues/405

wip until we resolve OAuth/console access. It seems there's no clasic Oauth service deployment on the cluster - well known url for oauth openshift service is reporting no service and console doesn't use oauth service. Instead it uses IBM SSO.

This PR also brings attention to our `cluster-scope/overlays` structure again. Does it still make sense to keep overlays organized by a physical region or does it make more sense to group cluster overlays by their provider? I think we have more per-provider related changes than per-region manifests...