### PR TITLE
Fix namespace for openshift-nfd operatorgroup

### DIFF
--- a/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-nfd/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/openshift-nfd/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: openshift-storage
+namespace: openshift-nfd
 resources:
 - operatorgroup.yaml


### PR DESCRIPTION
This corrects a typo in #1158.
