### PR TITLE
feat: Deploy NFD

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/emea/rick/cluster-management/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/emea/rick/cluster-management/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - cluster-resources.yaml
   - local-storage.yaml
   - kubevirt-hyperconverged.yaml
+  - nfd.yaml

--- a/argocd/overlays/moc-infra/applications/envs/emea/rick/cluster-management/nfd.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/emea/rick/cluster-management/nfd.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nfd
+spec:
+  destination:
+    name: rick
+    namespace: openshift-nfd
+  project: cluster-management
+  source:
+    path: nfd/overlays/emea/rick
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - moc-nfs-democratic-csi.yaml
   - node-labeler.yaml
   - odh-operator.yaml
+  - nfd.yaml

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/nfd.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/nfd.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nfd
+spec:
+  destination:
+    name: smaug
+    namespace: openshift-nfd
+  project: cluster-management
+  source:
+    path: nfd/overlays/moc/smaug
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/nfd/base/kustomization.yaml
+++ b/nfd/base/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-nfd
+resources:
+- nfd.yaml

--- a/nfd/base/nfd.yaml
+++ b/nfd/base/nfd.yaml
@@ -1,0 +1,10 @@
+apiVersion: nfd.openshift.io/v1
+kind: NodeFeatureDiscovery
+metadata:
+  name: nfd-instance
+  namespace: openshift-nfd
+spec:
+  operand:
+    namespace: openshift-nfd
+  workerConfig:
+    configData: ""

--- a/nfd/overlays/emea/rick/kustomization.yaml
+++ b/nfd/overlays/emea/rick/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../base

--- a/nfd/overlays/moc/smaug/kustomization.yaml
+++ b/nfd/overlays/moc/smaug/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../base


### PR DESCRIPTION
Deploys node feature discovery to `smaug` and `rick` as our workload clusters.

Resolves: https://github.com/operate-first/support/issues/408

I see no point in creating overlays that simply include only base and no original modifications or additions to the manifests. WDYT about referencing `base` directly?