### PR TITLE
Remove hive drop tables for iceberg in trino on osc.

### DIFF
--- a/odh-manifests/osc-cl1/trino/base/trino-catalog-secret.yaml
+++ b/odh-manifests/osc-cl1/trino/base/trino-catalog-secret.yaml
@@ -47,7 +47,6 @@ stringData:
     hive.s3.staging-directory=/tmp
     hive.s3.ssl.enabled=false
     hive.s3.sse.enabled=false
-    hive.allow-drop-table=true
     hive.parquet.use-column-names=true
     hive.recursive-directories=true
     hive.non-managed-table-writes-enabled=true


### PR DESCRIPTION
Related: https://github.com/os-climate/os_c_data_commons/issues/77

This was causing trino to crash, I guess it's not supported by trino for iceberg. 