### PR TITLE
Fix: Triage party github token secret

### DIFF
--- a/triage-party/overlays/moc/smaug/secret.enc.yaml
+++ b/triage-party/overlays/moc/smaug/secret.enc.yaml
@@ -2,16 +2,16 @@ apiVersion: v1
 kind: Secret
 metadata:
     name: triage-party-github-token
-data:
-    token: ENC[AES256_GCM,data:EUbnyTIkkJxOP4vrKpL/izdmazT8oIFIeoM1sggULcm0MrCCO/1UWg==,iv:jXTqZqFE10XIM6CJ0+8A0xLE+b3tWEpZosuz8J0siFU=,tag:VuW0kjjjAWQY/LzFx8rigQ==,type:str]
+stringData:
+    token: ENC[AES256_GCM,data:1pQg2uTCMmH2fNdwatH3GDnA0PgVjQzSGzOvWTRQ/gsMo+An0xaXBg==,iv:dqtqk5LR1+ZIJu1DnJm4m1uWCUet2lcW5XU/pchmT6Y=,tag:ytoCZDuDj6sv7PqMKUOWiA==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2021-09-30T18:29:48Z"
-    mac: ENC[AES256_GCM,data:ne1+jm5bEKh5vLEPufKOTNXFyjOf5whggzppgWG3D1LymtcXKWstTJmdvXvqspKXXAp5crfZKA9uaJASP33J5aYQXXFPqCWI9UC1KiU4y6Fq1Ok+o9CkZriNRssxyTwq9bvaHsr6AfNQNGqwS3UjHw9JK0AKsBh/RKDDZojdnNU=,iv:zR5QKxzciC0TRzdai0Jm+tSaLoCiFMOhmicvI0059OI=,tag:pJ+4AWGoo0em9Sx4+NngpQ==,type:str]
+    lastmodified: "2021-10-14T17:00:28Z"
+    mac: ENC[AES256_GCM,data:E0XlX7hhfaV32fusUh7Z9NNJFMAVYY6ysG4VHFxAedWwgwZzdyh2JuEeKKY6ulX8qVP6dctYR7diPaYLqI1NxlBc7fpmId4Vw3t6ddRTeVf0/zfQFi2MlTE6XIY6S07dH5PohUZvTbOm9pnIbLBBkBlzVHZPhs+15e9nFRcIyig=,iv:o9TzJHsBLLXx0ia8CEX2V4LdcBU7vyfdNFxihlqi+6o=,tag:65S4q6jnc2DH4g9JLwZ5GQ==,type:str]
     pgp:
         - created_at: "2021-09-30T18:29:48Z"
           enc: |-


### PR DESCRIPTION
`data` in a secret needs to be base64 encoded so changed it to `stringData` 

Resolves https://github.com/operate-first/support/issues/423