### PR TITLE
Provide osc admins acm access to osc cluster.

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:admin:osc-cl1/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:admin:osc-cl1/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: open-cluster-management:admin:osc-cl1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: open-cluster-management:admin:osc-cl1
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: osc-admins

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:admin:osc-cl1/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:admin:osc-cl1/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrolebinding.yaml

--- a/cluster-scope/base/user.openshift.io/groups/osc-admins/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/osc-admins/group.yaml
@@ -1,0 +1,6 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: osc-admins
+users:
+  - redmikhail

--- a/cluster-scope/base/user.openshift.io/groups/osc-admins/kustomization.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/osc-admins/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - group.yaml

--- a/cluster-scope/overlays/prod/common/kustomization.yaml
+++ b/cluster-scope/overlays/prod/common/kustomization.yaml
@@ -29,6 +29,7 @@ resources:
     - ../../../base/user.openshift.io/groups/open-aiops
     - ../../../base/user.openshift.io/groups/operate-first
     - ../../../base/user.openshift.io/groups/osc
+    - ../../../base/user.openshift.io/groups/osc-admins
     - ../../../base/user.openshift.io/groups/prometheus-anomaly-detector
     - ../../../base/user.openshift.io/groups/pulp
     - ../../../base/user.openshift.io/groups/quarkus

--- a/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/moc-nfs-democratic-csi-controller-rb
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/moc-nfs-democratic-csi-node-rb
+  - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:admin:osc-cl1
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/acme-operator
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/moc-nfs-democratic-csi-controller-cr
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/moc-nfs-democratic-csi-node-cr


### PR DESCRIPTION
This should give @redmikhail access to the osc cluster in acm, the role is already created by acm. 

For ref see: https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.3/html/access_control/access-control#overview-of-roles

Related: https://github.com/operate-first/support/issues/389