### PR TITLE
add low-privilege demo users and groups

### DIFF
--- a/odh-manifests/osc-cl1/trino/base/trino-config-secret.yaml
+++ b/odh-manifests/osc-cl1/trino/base/trino-config-secret.yaml
@@ -52,6 +52,9 @@ stringData:
     file.password-file=/etc/trino/password.db
   password.db: |-
     admin:$2y$10$WDwsrDy1Uwa7giTJrRAo1O5MoRjbWi8zT6ugCkibA8KSS5Dx7TQS.
+    demo_user_a:$2y$10$a7GDbDqfPT.BWc7j8f8hd.JqpKVg2C5DoQzxlXLn65G5jxeuy8IF.
+    demo_user_b:$2y$10$.QzM/8kRXVjRs10hTzOfxOYklhOV1XgnPnQdx/HPqeRau3LTt1vG6
+    demo_user_c:$2y$10$C46oSxaFd5ewL9KwXXiN.eNGGeLLn8mqL5ffuapcmoqzKZsV3RMjm
     erik:$2y$10$Mt86mngLFB2nigY/GlMHI.iWQPPk5ieKf5WbkX4BeebBJhNQn01U6
     hukhan:$2y$10$JW7F4BPVPh2J8GS5N9z5t.lmgaQKylrcZt9T3NSPRCzT8kiyrHCii
     mikhail:$2y$10$kk/XazcoKmZGRvUwiM6kgex5QUEOTnVCmk5mU290gXTkArmEdAvLC
@@ -98,6 +101,9 @@ stringData:
     climate_itr_tool_project:joriscram,alexanu,caldeirav,DavWinkel,ChristianMeyndt,hbaltzell,ttschmucker,toki8,LeylaJavadova,christian-schellnegger,roland-mf,franz-mf,EWinter21
     physical_risk_project:NikolaosDimakis,MichaelTiemannOSC,joemoorhouse,mariestephanieprevot,dbferri
     data_commons_project:caldeirav,MichaelTiemannOSC,erikerlandson
+    demo_group_a:demo_user_a,demo_user_c
+    demo_group_b:demo_user_b,demo_user_c
+    demo_group_c:demo_user_c
   access-control.properties: |-
     access-control.name=file
     security.config-file=/etc/trino/rules.json
@@ -110,6 +116,11 @@ stringData:
       },
       {
         "group": "aicoe_osc_demo|os_climate_corporate_data_project|climate_itr_tool_project|physical_risk_project",
+        "catalog": "osc_datacommons_dev",
+        "allow": "all"
+      },
+      {
+        "group": "demo_group_*"
         "catalog": "osc_datacommons_dev",
         "allow": "all"
       },
@@ -174,6 +185,10 @@ stringData:
         "catalog": "osc_datacommons_dev",
         "schema": "demo",
         "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP"]
+      },
+      {
+        "group": "demo_group_*",
+        "privileges": []
       },
       {
         "group": "os_climate_corporate_data_project",


### PR DESCRIPTION
adds:
- demo_user_a, demo_user_b, demo_user_c
- demo_group_a, demo_group_b, demo_group_c
- each user has same password `os-climate-rocks!`, which is low-value and therefore usable in demonstrations or labs.

the intent of the access control config is:
- `demo_group_*` has full privileges in schema `osc_datacommon_dev.demo`
- For all other schema, `demo_group_*` has no privileges.