### PR TITLE
Fix typo in osc trino config rules.

### DIFF
--- a/odh-manifests/osc-cl1/trino/base/trino-config-secret.yaml
+++ b/odh-manifests/osc-cl1/trino/base/trino-config-secret.yaml
@@ -120,7 +120,7 @@ stringData:
         "allow": "all"
       },
       {
-        "group": "demo_group_*"
+        "group": "demo_group_*",
         "catalog": "osc_datacommons_dev",
         "allow": "all"
       },


### PR DESCRIPTION
Trino breaking: 
```
    "group": "data_commons_project","[truncated 2160 bytes]; line: 14, column: 6] (through reference chain: io.trino.plugin.base.security.FileBasedSystemAccessControlRules["catalogs"]->java.util.ArrayList[2])
	at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:390)
	at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:361)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer._deserializeFromArray(CollectionDeserializer.java:371)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:244)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:28)
	at com.fasterxml.jackson.databind.deser.std.ReferenceTypeDeserializer.deserialize(ReferenceTypeDeserializer.java:197)
	at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:542)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeWithErrorWrapping(BeanDeserializer.java:565)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:449)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1405)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:362)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:195)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:322)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4593)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3609)
	at io.trino.plugin.base.util.JsonUtils.parseJson(JsonUtils.java:84)
	at io.trino.plugin.base.util.JsonUtils.parseJson(JsonUtils.java:53)
	... 17 more
Caused by: com.fasterxml.jackson.core.JsonParseException: Unexpected character ('"' (code 34)): was expecting comma to separate Object entries
 at [Source: (byte[])"{
  "catalogs": [
  {
    "group": "admins|data_commons_project",
    "allow": "all"
  },
  {
    "group": "aicoe_osc_demo|os_climate_corporate_data_project|climate_itr_tool_project|physical_risk_project",
    "catalog": "osc_datacommons_dev",
    "allow": "all"
  },
  {
    "group": "demo_group_*"
    "catalog": "osc_datacommons_dev",
    "allow": "all"
  },
  {
    "allow": "none"
  }
  ],
  "schemas": [
  {
    "group": "admins",
    "owner": true
  },
  {
```

missing a comma in rules.json