### PR TITLE
patch the correct name of the overlay for prow-pods app

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/ci-prow-test-pods.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/ci-prow-test-pods.yaml
@@ -18,7 +18,7 @@ spec:
       kind: CronJob
   project: operate-first
   source:
-    path: prow/overlays/cnv-prod-test-pods
+    path: prow/overlays/smaug-test-pods
     repoURL: https://github.com/thoth-station/thoth-application.git
     targetRevision: master
   syncPolicy:


### PR DESCRIPTION
patch the correct name of the overlay for prow-pods app
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

The name of the overlay is changed. 

Related-to: https://github.com/thoth-station/thoth-application/pull/2059
