### PR TITLE
default to read/select privs on all schema in osc_datacommons_dev

### DIFF
--- a/odh-manifests/osc-cl1/trino/base/trino-config-secret.yaml
+++ b/odh-manifests/osc-cl1/trino/base/trino-config-secret.yaml
@@ -216,7 +216,6 @@ stringData:
       },
       {
         "catalog": "osc_datacommons_dev",
-        "schema": "company_data|pudl|urgentem|information_schema",
         "privileges": ["SELECT"]
       },
       {


### PR DESCRIPTION
Eventually there will be data commons schema, or tables, which will not be universally visible, but none of these exist yet, and we can design the access control rules on a case-by-case basis.  For now it will reduce config churn to allow read privs on all the tables we currently have in `osc_datacommons_dev`