### PR TITLE
enabling service monitor deployment

### DIFF
--- a/argocd/overlays/moc-infra/projects/global_project.yaml
+++ b/argocd/overlays/moc-infra/projects/global_project.yaml
@@ -126,6 +126,8 @@ spec:
       kind: StorageLocation
     - group: metrics.k8s.io
       kind: PodMetrics
+    - group: monitoring.coreos.com
+      kind: ServiceMonitor
     - group: networking.k8s.io
       kind: Ingress
     - group: networking.k8s.io


### PR DESCRIPTION
Related to issue [420 in support](https://github.com/operate-first/support/issues/420). Currently, argocd cannot deploy service monitors, and it ties into the question of how this should be done. Not sure if there are any better ways of going about this.