### PR TITLE
ignore the metadata label from thoth graph sync apps

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/emea/balrog/thoth/prod/prod-thoth-graph-sync-backend.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/emea/balrog/thoth/prod/prod-thoth-graph-sync-backend.yaml
@@ -24,3 +24,8 @@ spec:
       name: graph-sync-job
       jsonPointers:
         - /metadata/labels
+    - group: template.openshift.io
+      kind: Template
+      name: graph-sync
+      jsonPointers:
+        - /metadata/labels

--- a/argocd/overlays/moc-infra/applications/envs/emea/balrog/thoth/prod/prod-thoth-graph-sync-middletier.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/emea/balrog/thoth/prod/prod-thoth-graph-sync-middletier.yaml
@@ -24,3 +24,8 @@ spec:
       name: graph-sync-job
       jsonPointers:
         - /metadata/labels
+    - group: template.openshift.io
+      kind: Template
+      name: graph-sync
+      jsonPointers:
+        - /metadata/labels

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/thoth/prod/prod-thoth-graph-sync-backend.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/thoth/prod/prod-thoth-graph-sync-backend.yaml
@@ -24,3 +24,8 @@ spec:
       name: graph-sync-job
       jsonPointers:
         - /metadata/labels
+    - group: template.openshift.io
+      kind: Template
+      name: graph-sync
+      jsonPointers:
+        - /metadata/labels

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/thoth/prod/prod-thoth-graph-sync-middletier.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/thoth/prod/prod-thoth-graph-sync-middletier.yaml
@@ -24,3 +24,8 @@ spec:
       name: graph-sync-job
       jsonPointers:
         - /metadata/labels
+    - group: template.openshift.io
+      kind: Template
+      name: graph-sync
+      jsonPointers:
+        - /metadata/labels


### PR DESCRIPTION
ignore the metadata label from thoth graph sync apps
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


This would ignore the labels which are not needed for sync of the thoth graph app.
Related-to: thoth-station/thoth-application#2054

