### PR TITLE
setup thoth prescriptions-refresh-job app for deployment

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/thoth/prod/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/thoth/prod/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
 - prod-thoth-package-extract.yaml
 - prod-thoth-package-releases.yaml
 - prod-thoth-package-update.yaml
+- prod-thoth-prescriptions-refresh-job.yaml
 - prod-thoth-purge-job.yaml
 - prod-thoth-revsolver.yaml
 - prod-thoth-security-indicators.yaml

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/thoth/prod/prod-thoth-prescriptions-refresh-job.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/thoth/prod/prod-thoth-prescriptions-refresh-job.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: prod-thoth-prescriptions-refresh-job
+spec:
+  project: thoth
+  source:
+    repoURL: "https://github.com/thoth-station/thoth-application.git"
+    path: prescriptions-refresh-job/overlays/moc
+    targetRevision: HEAD
+  destination:
+    name: smaug
+    namespace: thoth-middletier-prod
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - Validate=false


### PR DESCRIPTION
setup thoth prescriptions-refresh-job app for deployment
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Depends-On: https://github.com/thoth-station/thoth-application/pull/2065
This would set up the app prescriptions-refresh-job 