### PR TITLE
chore: Add durandom to approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,7 @@ approvers:
   - HumairAK
   - tumido
   - larsks
+  - durandom
 
 reviewers:
   - 4n4nd


### PR DESCRIPTION
Add @durandom to `approvers` so he can `/approve` and get stuff merged. Not adding him to `reviewers` so he's not getting assigned to review PRs etc.