### PR TITLE
fix: Up quota for triage party so acme can schedule pods

### DIFF
--- a/cluster-scope/base/core/namespaces/opf-triage-party/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/opf-triage-party/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 components:
     - ../../../../components/project-admin-rolebindings/operate-first
     - ../../../../components/limitranges/default
-    - ../../../../components/resourcequotas/x-small
+    - ../../../../components/resourcequotas/small
 namespace: opf-triage-party


### PR DESCRIPTION
I was wondering why Triage Party has no HTTPS route so I've looked up the namespace and I saw that acme controller is unable to schedule pods in there due to quota. I've workarounded it temporarily by scaling dow the triage party deployment which allowed acme pods to schedule. Once they've provisioned the cert I've scaled the Triage party back up.

Some day acme will need to renew the certs, upgrading quota should resolve the scheduling.