### PR TITLE
fix: Remove nmstate from Smaug, revert to CNV

### DIFF
--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -38,7 +38,6 @@ resources:
   - ../../../../base/core/namespaces/openshift-cnv
   - ../../../../base/core/namespaces/openshift-logging
   - ../../../../base/core/namespaces/openshift-nfd
-  - ../../../../base/core/namespaces/openshift-nmstate
   - ../../../../base/core/namespaces/openshift-operators
   - ../../../../base/core/namespaces/openshift-pipelines
   - ../../../../base/core/namespaces/openshift-vertical-pod-autoscaler
@@ -73,14 +72,12 @@ resources:
   - ../../../../base/core/namespaces/thoth-pulp-experiments
   - ../../../../base/core/namespaces/ushift-dev
   - ../../../../base/core/persistentvolumeclaims/image-registry-storage
-  - ../../../../base/nmstate.io/nmstates/nmstate
   - ../../../../base/imageregistry.operator.openshift.io/configs/cluster
   - ../../../../base/operators.coreos.com/operatorgroups/cluster-logging
   - ../../../../base/operators.coreos.com/catalogsources/meteor-operator
   - ../../../../base/operators.coreos.com/operatorgroups/koku-metrics-operator
   - ../../../../base/operators.coreos.com/operatorgroups/openshift-cnv-rn5jf
   - ../../../../base/operators.coreos.com/operatorgroups/meteor-operator
-  - ../../../../base/operators.coreos.com/operatorgroups/openshift-nmstate
   - ../../../../base/operators.coreos.com/operatorgroups/openshift-nfd
   - ../../../../base/operators.coreos.com/operatorgroups/openshift-vertical-pod-autoscaler
   - ../../../../base/operators.coreos.com/operatorgroups/opf-monitoring
@@ -88,7 +85,6 @@ resources:
   - ../../../../base/operators.coreos.com/subscriptions/cert-manager
   - ../../../../base/operators.coreos.com/subscriptions/cluster-logging
   - ../../../../base/operators.coreos.com/subscriptions/koku-metrics-operator
-  - ../../../../base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator
   - ../../../../base/operators.coreos.com/subscriptions/kubevirt-hyperconverged
   - ../../../../base/operators.coreos.com/subscriptions/meteor-operator
   - ../../../../base/operators.coreos.com/subscriptions/nfd
@@ -136,7 +132,6 @@ patchesStrategicMerge:
   - oauths/cluster_patch.yaml
   - storageclasses/moc-nfs-csi_patch.yaml
   - subscriptions/cluster-logging-operator_patch.yaml
-  - subscriptions/kubernetes-nmstate-operator_patch.yaml
   - subscriptions/nfd_patch.yaml
   - subscriptions/vpa_patch.yaml
   - subscriptions/openshift-pipelines-operator-rh_patch.yaml

--- a/cluster-scope/overlays/prod/moc/smaug/subscriptions/kubernetes-nmstate-operator_patch.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/subscriptions/kubernetes-nmstate-operator_patch.yaml
@@ -1,7 +1,0 @@
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: kubernetes-nmstate-operator
-  namespace: openshift-nmstate
-spec:
-  channel: "4.8"


### PR DESCRIPTION
Since CNV is deployed to Smaug, we should remove nmstate operator to avoid both nmstate deployments fighting over it.


/cc @larsks @HumairAK 

/hold