### PR TITLE
Updating ArgoCD dex config with Fybrik

### DIFF
--- a/argocd/overlays/moc-infra/configs/argo_cm/dex.config
+++ b/argocd/overlays/moc-infra/configs/argo_cm/dex.config
@@ -18,5 +18,5 @@ connectors:
         - data-science
         - rekor
         - lab-cicd
-        - mesh-for-data
+        - fybrik
         - workshops


### PR DESCRIPTION
This PR removes `mesh-for-data` and adds `fybrik` to the ArgoCD Dex Config
 @HumairAK @4n4nd 