### PR TITLE
fix: Forbidden to create project on ACM cluster import

### DIFF
--- a/cluster-scope/overlays/prod/moc/infra/clusterrolebindings/self-provisioners_patch.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/clusterrolebindings/self-provisioners_patch.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: self-provisioners
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: octo-ushift-dev

--- a/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
@@ -50,3 +50,4 @@ patchesStrategicMerge:
   - storageclasses/moc-nfs-csi_patch.yaml
   - subscriptions/kubernetes-nmstate-operator_patch.yaml
   - groups/cluster-admins.yaml
+  - clusterrolebindings/self-provisioners_patch.yaml


### PR DESCRIPTION
Possible fix to: https://github.com/operate-first/support/issues/436