### PR TITLE
updating routes for grafana smaug grafana in kfdefs

### DIFF
--- a/kfdefs/overlays/moc/smaug/opf-monitoring/dashboards/thoth-station/thoth-kafka-argo-metrics.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-monitoring/dashboards/thoth-station/thoth-kafka-argo-metrics.yaml
@@ -7,4 +7,4 @@ metadata:
     app: grafana
     component: thoth-station
 spec:
-  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/cnv-prod/thoth-kafka-argo-metrics.json
+  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/moc-prod/thoth-kafka-argo-metrics.json

--- a/kfdefs/overlays/moc/smaug/opf-monitoring/dashboards/thoth-station/thoth-knowledge-graph-content-metrics.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-monitoring/dashboards/thoth-station/thoth-knowledge-graph-content-metrics.yaml
@@ -7,4 +7,4 @@ metadata:
     app: grafana
     component: thoth-station
 spec:
-  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/cnv-prod/thoth-knowledge-graph-content-metrics.json
+  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/moc-prod/thoth-knowledge-graph-content-metrics.json

--- a/kfdefs/overlays/moc/smaug/opf-monitoring/dashboards/thoth-station/thoth-postgresql-metrics.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-monitoring/dashboards/thoth-station/thoth-postgresql-metrics.yaml
@@ -7,4 +7,4 @@ metadata:
     app: grafana
     component: thoth-station
 spec:
-  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/cnv-prod/thoth-postgresql-metrics.json
+  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/moc-prod/thoth-postgresql-metrics.json

--- a/kfdefs/overlays/moc/smaug/opf-monitoring/dashboards/thoth-station/thoth-service-metrics.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-monitoring/dashboards/thoth-station/thoth-service-metrics.yaml
@@ -7,4 +7,4 @@ metadata:
     app: grafana
     component: thoth-station
 spec:
-  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/cnv-prod/thoth-service-metrics.json
+  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/moc-prod/thoth-service-metrics.json

--- a/kfdefs/overlays/moc/smaug/opf-monitoring/dashboards/thoth-station/thoth-sli-slo.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-monitoring/dashboards/thoth-station/thoth-sli-slo.yaml
@@ -7,4 +7,4 @@ metadata:
     app: grafana
     component: thoth-station
 spec:
-  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/cnv-prod/thoth-sli-slo.json
+  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/moc-prod/thoth-sli-slo.json

--- a/kfdefs/overlays/moc/smaug/opf-monitoring/dashboards/thoth-station/thoth-user-api-metrics.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-monitoring/dashboards/thoth-station/thoth-user-api-metrics.yaml
@@ -7,4 +7,4 @@ metadata:
     app: grafana
     component: thoth-station
 spec:
-  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/cnv-prod/thoth-user-api-metrics.json
+  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/moc-prod/thoth-user-api-metrics.json

--- a/kfdefs/overlays/moc/smaug/opf-monitoring/dashboards/thoth-station/thoth-workflow-controllers-metrics.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-monitoring/dashboards/thoth-station/thoth-workflow-controllers-metrics.yaml
@@ -7,4 +7,4 @@ metadata:
     app: grafana
     component: thoth-station
 spec:
-  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/cnv-prod/thoth-workflow-controllers-metrics.json
+  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/overlays/moc-prod/thoth-workflow-controllers-metrics.json


### PR DESCRIPTION
Updates the URL routes within kfdefs for grafana dashboards. Partially addresses [Thoth-station/thoth-application issue 2029](https://github.com/thoth-station/thoth-application/issues/2029).

Related changes for thoth-application merged into master from [thoth-station/thoth-application pr 2097](https://github.com/thoth-station/thoth-application/pull/2097/)