### PR TITLE
Remove demo app of apps from argocd.

### DIFF
--- a/argocd/overlays/moc-infra/applications/app-of-apps/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/app-of-apps/kustomization.yaml
@@ -10,4 +10,6 @@ resources:
 - app-of-apps-rick.yaml
 - app-of-apps-smaug.yaml
 - workshops-app-of-apps.yaml
-- app-of-apps-demo.yaml
+
+# Used for demo clusters
+# - app-of-apps-demo.yaml


### PR DESCRIPTION
Keeping it around for future use, but removing it from the build so it doesn't show up in argocd. 