### PR TITLE
Adding permissions to create Fybrik CRD and adding CRD to Smaug kustomization

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/fybrik-admin-cr/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/fybrik-admin-cr/clusterrole.yaml
@@ -119,6 +119,19 @@ rules:
   - update
   - watch
 - apiGroups:
+  - katalog.fybrik.io
+  resources:
+  - assets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+- apiGroups:
   - com.ie.ibm.hpsys
   resources:
   - datasets

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/fybrikmodules.app.fybrik.io
   - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/fybrikstorageaccounts.app.fybrik.io
   - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/streamtransfers.motion.fybrik.io
+  - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/plotters.app.fybrik.io
   - ../../../../base/config.openshift.io/oauths/cluster
   - ../../../../base/core/configmaps/cluster-monitoring-config
   - ../../../../base/core/configmaps/user-workload-monitoring-config


### PR DESCRIPTION
This PR makes the following changes:

- modifies the Fybrik cluster role to add permissions for the `assets` CRD
- adds the `Plotters` CRD to the Smaug kustomization file

@HumairAK @ronenkat