### PR TITLE
Fix opf-datactalog objectbucketName to match auto generated name.

### DIFF
--- a/kfdefs/overlays/moc/smaug/opf-trino/obcs/opf-datacatalog.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-trino/obcs/opf-datacatalog.yaml
@@ -6,5 +6,5 @@ spec:
   additionalConfig:
     maxSize: 15G
   bucketName: opf-datacatalog
-  objectBucketName: opf-datacatalog
+  objectBucketName: obc-opf-trino-opf-datacatalog
   storageClassName: openshift-storage.noobaa.io


### PR DESCRIPTION
Seems like this gets replaced by ocs, not sure if it's auto-generated but matching it with what's on live all the same. 