### PR TITLE
updating the alerting rules with prometheus standard and thoth rules

### DIFF
--- a/cluster-scope/overlays/prod/common/alertmanager-main-secret.yaml
+++ b/cluster-scope/overlays/prod/common/alertmanager-main-secret.yaml
@@ -67,6 +67,9 @@ stringData:
       - name: Github
         webhook_configs:
           - url: 'http://github-receiver-service.opf-alertreceiver.svc.cluster.local:9393/v1/receiver'
+      - name: Thoth-Github
+        webhook_configs:
+          - url: 'http://github-receiver.thoth-infra-prod.svc.cluster.local:9393/v1/receiver'
     route:
       receiver: "null"
       group_by:
@@ -221,6 +224,9 @@ stringData:
                 namespace: opf-.*                     # Alerts for opf-.* namespaces
               match:
                 prometheus: openshift-monitoring/k8s
+            - receiver: Thoth-Github
+              match_re:
+                alertname: Thoth.*
         - receiver: Watchdog
           match:
             alertname: Watchdog


### PR DESCRIPTION
Addresses Operate-first/apps pr 3 for alerting rules for [Thoth issue 2029](https://github.com/thoth-station/thoth-application/issues/2029)
- [x] defined new thoth-github reciever
- [x] wrote alerting rule to target all thoth related alerts 

Prometheus alerting rule updates:
  - inhibit_rules.source_match, inhibit_rules.source_match_re and inhibit_rules.target_match and inhibit_rules.target_match_re have been depricated, use source_matchers and target_matchers, [see docs](https://prometheus.io/docs/alerting/latest/configuration/#inhibit_rule)
  - route.match and route.match_re have been depricated, use route.matchers, [see docs](https://prometheus.io/docs/alerting/latest/configuration/#route)
  - matches configuration defined, [see docs](https://prometheus.io/docs/alerting/latest/configuration/#matcher)