### PR TITLE
re-sync trino user groups with github teams

### DIFF
--- a/odh-manifests/osc-cl1/trino/base/trino-config-secret.yaml
+++ b/odh-manifests/osc-cl1/trino/base/trino-config-secret.yaml
@@ -60,46 +60,24 @@ stringData:
     mikhail:$2y$10$kk/XazcoKmZGRvUwiM6kgex5QUEOTnVCmk5mU290gXTkArmEdAvLC
     ricardo:$2y$10$aLK8b1tH0bvXGk8GjU2EteokQQ4xH3e29PgyUTtiVsDUmCV2nHVpO
     vincent:$2y$10$93Lnt4vXk1sbhftl3fVE8euqyaCHPWmUrEdP99SRmrXK/XJ6UToDG
-    oindrillac:$2y$10$kk1Q4Ls03PxXersv5V/Ew.DjccTBx5QzNIPGBrS3F0aJUHLHVnJkC
-    aakankshaduggal:$2y$10$7r00EoU.aiZWg.ZHOQarSusVM9nGEdqq.jjdeX0ATw2i5MWN2SPSe
-    shreyanand:$2y$10$/YeIADI8wv31rym/S/yTfOrH3Au2A7A9zgM0Q5JNSqXQ8y1IRF3di
-    michaelclifford:$2y$10$/LaXqAuUWoc7PyXyHz1...jV5cNJ5DvSuTGLvYo6FEctmbyYLomi.
-    chauhankaranraj:$2y$10$S4i3gvYGeX3YHAgD3AO3d.FHxa9vOY8PyS86O5zN0CdBW6/x7OVv2
-    sankbad:$2y$10$yFqgZoaVSSca94pXZql6ue1LbKdfPz0u0Ye9zweU/4DC6ldiqOfIS
-    isabelizimm:$2y$10$0FyAEaXQiMSOScG7AeJMaOjgSER3NqPcVxhG8YjfwvEMtIx415KhK
-    harshad16:$2y$10$EesX21D8mDR8taJDf.4KrOIp91WSfqe0ZRuU8gxvcOYE3aVPVaqL2
-    durandom:$2y$10$PR8Fh0.rH3N2pka/yg2bqelqWUzchjVLaX6Wgyd.FcUlMmU8ZDXB6
-    erikerlandson:$2y$10$MbsyvrFh5Trfjk1bVnplKeVzIKollUrKNYJMDZbRXlb05W/UrVQle
-    ludans:$2y$10$rpZqi6LmO4rdk/A5jmOpQO90UW1fYahIJLUdUdmSyetayzISbje6m
-    caldeirav:$2y$10$IUWQcTQktuCw3dgOX.bRbuAoRbgNSG83.1Wcs6pNBxMxZHPtQ5kf2
-    DavWinkel:$2y$10$IAJ8qhSMc43FQ0JZjzmifel7pvPTCP0KiCjJw1v6F.iINKDKsAgxK
-    rmorais1:$2y$10$rgAZD0wy57YVf/QWKG.n9OZ83hJWmv0X9xFKvMTyDVrHTAkURqe0m
-    andraNew:$2y$10$RItbALxc413zx5p7CG32jOTPRcLSqrD7QOGTAMzmZyVZC.kdrnuBa
-    ChristianMeyndt:$2y$10$OMBcZLhySMGhUBSsmWtzx.oT8evygkvrMjCH76q5NiabeOtKBYlV6
-    ttschmucker:$2y$10$mMEMRKzJ5sfB.RzreWxmcuTLezLG3WWHkqXIMS5y.2sQkims9TZrm
-    toki8:$2y$10$BWWlcU1/G/GxQ8iDDm0qUunO0mjoJvy/bauMZffsXMNQE9qySNGPO
-    LeaADeleris:$2y$10$LOldV7LHWidmwRyz9e.EPuuGgafex35iZSR1IIRoSo8CfQ.WG2wcO
-    JeremyGohBNP:$2y$10$WwP3cILJ.zVIXRnk1NeDee6fz7sagb/SwNwfGq8JPiGvzDgt461wm
-    amirqamar:$2y$10$fDaxttz.y3VBOW8zOtKROecf9bDUa9DCYYMKtyINortQfS.2gIRgK
-    joriscram:$2y$10$uf8O4z6Jdfpk5EQ7oAyEJ.3rcV5vT7iJmeNQZ/6OfgrjSe1XiJQOm
-    alexanu:$2y$10$SZW472b78i68JDB97fqgWOQ4o9.xLtXqu59Hhe5yv5IM3hS.FREs2
-    hbaltzell:$2y$10$/t/k9aG39B0LCiA8ONI5mutKPvjNVmvZG9MLli32LHOxbP4DyLoLS
-    LeylaJavadova:$2y$10$QYaaMtycy6qwFm/hgjchEeKiVSTcBduvJyuTWCsNm775eAOnzAw7e
-    christian-schellnegger:$2y$10$z8f5FUsgAklvhVfiw320Ge/tnJdOVddPYhrkpkydue3iJp/joykLi
-    roland-mf:$2y$10$aURf0czAuWzVo8EHWmsTD.9u.I7gYcyPBZ74obQQHLgmYdCIcqeVW
-    franz-mf:$2y$10$VLhCo8gRJMIIoZr.WGf09.X6vzaa4Y/dn6zWbPpVUifswzi2480nC
-    EWinter21:$2y$10$LCHzLJCIqZL2X4genVuQVO7crLtaL9btNlqUNttls058PRUnO7GOG
-    MichaelTiemannOSC:$2y$10$xRzsTjBgwG2Rf5zIwFlBHefHBlmk80MP0DDFeZrepp7Gt/zTLQS3u
-
   group-provider.properties: |-
     group-provider.name=file
     file.group-file=/etc/trino/group-mapping.properties
   group-mapping.properties: |-
     admins:admin,erikerlandson,caldeirav,HumairAK,redmikhail
     aicoe_osc_demo:oindrillac,aakankshaduggal,shreyanand,michaelclifford,chauhankaranraj,sankbad,isabelizimm,harshad16,durandom,erikerlandson
-    os_climate_corporate_data_project:ludans,caldeirav,DavWinkel,rmorais1,andraNew,ChristianMeyndt,ttschmucker,toki8,LeaADeleris,JeremyGohBNP,amirqamar
-    climate_itr_tool_project:joriscram,alexanu,caldeirav,DavWinkel,ChristianMeyndt,hbaltzell,ttschmucker,toki8,LeylaJavadova,christian-schellnegger,roland-mf,franz-mf,EWinter21
-    physical_risk_project:NikolaosDimakis,MichaelTiemannOSC,joemoorhouse,mariestephanieprevot,dbferri
+    corporate_data:ludans,caldeirav,DavWinkel,rmorais1,andraNew,ChristianMeyndt,ttschmucker,toki8,LeaADeleris,JeremyGohBNP,amirqamar
+    corporate_data_pipeline_developers:ludans,caldeirav,rmorais1,mriefer,idemir-ids,ChristianMeyndt,JeremyGohBNP
+    corporate_data_pipeline_admin:ChristianMeyndt
+    itr:joriscram,alexanu,caldeirav,DavWinkel,ChristianMeyndt,hbaltzell,ttschmucker,toki8,LeylaJavadova,christian-schellnegger,roland-mf,franz-mf,EWinter21
+    itr_pipeline_developers:DavWinkel,alexanu
+    itr_pipeline_admin:DavWinkel,alexanu
+    physical_risk:NikolaosDimakis,MichaelTiemannOSC,joemoorhouse,mariestephanieprevot,dbferri
+    physical_risk_pipeline_developers:joemoorhouse,Floflow,MichaelTiemannOSC,NikolaosDimakis,mariestephanieprevot,floriangallo,dbferri,aliebadi2
+    physical_risk_pipeline_admin:MichaelTiemannOSC
+    entity_matching:DavWinkel,ludans
+    entity_matching_pipeline_developers:DavWinkel,ludans
+    entity_matching_pipeline_admin:DavWinkel,ludans
     data_commons_project:caldeirav,MichaelTiemannOSC,erikerlandson
     demo_group_a:demo_user_a,demo_user_c
     demo_group_b:demo_user_b,demo_user_c
@@ -115,12 +93,12 @@ stringData:
         "allow": "all"
       },
       {
-        "group": "aicoe_osc_demo|os_climate_corporate_data_project|climate_itr_tool_project|physical_risk_project",
+        "group": "aicoe_osc_demo|corporate_data.*|itr.*|physical_risk.*",
         "catalog": "osc_datacommons_dev",
         "allow": "all"
       },
       {
-        "group": "demo_group_*",
+        "group": "demo_group_.*",
         "catalog": "osc_datacommons_dev",
         "allow": "all"
       },
@@ -139,21 +117,27 @@ stringData:
         "owner": true
       },
       {
-        "group": "os_climate_corporate_data_project",
+        "group": "corporate_data.*",
         "catalog": "osc_datacommons_dev",
-        "schema": "os_climate_corporate_data_project",
+        "schema": "corporate_data",
         "owner": true
       },
       {
-        "group": "climate_itr_tool_project",
+        "group": "itr.*",
         "catalog": "osc_datacommons_dev",
-        "schema": "climate_itr_tool_project",
+        "schema": "itr",
         "owner": true
       },
       {
-        "group": "physical_risk_project",
+        "group": "physical_risk.*",
         "catalog": "osc_datacommons_dev",
-        "schema": "physical_risk_project",
+        "schema": "physical_risk",
+        "owner": true
+      },
+      {
+        "group": "entity_matching.*",
+        "catalog": "osc_datacommons_dev",
+        "schema": "gleif",
         "owner": true
       },
       {
@@ -164,7 +148,7 @@ stringData:
       },
       {
         "catalog": "osc_datacommons_dev",
-        "schema": "demo",
+        "schema": "demo|sandbox",
         "owner": true
       },
       {
@@ -183,29 +167,35 @@ stringData:
       },
       {
         "catalog": "osc_datacommons_dev",
-        "schema": "demo",
+        "schema": "demo|sandbox",
         "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP"]
       },
       {
-        "group": "demo_group_*",
+        "group": "demo_group_.*",
         "privileges": []
       },
       {
-        "group": "os_climate_corporate_data_project",
+        "group": "corporate_data_pipeline_.*",
         "catalog": "osc_datacommons_dev",
-        "schema": "os_climate_corporate_data_project",
+        "schema": "corporate_data",
         "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP"]
       },
       {
-        "group": "climate_itr_tool_project",
+        "group": "itr_pipeline_.*",
         "catalog": "osc_datacommons_dev",
-        "schema": "climate_itr_tool_project",
+        "schema": "itr",
         "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP"]
       },
       {
-        "group": "physical_risk_project",
+        "group": "physical_risk_pipeline_.*",
         "catalog": "osc_datacommons_dev",
-        "schema": "physical_risk_project",
+        "schema": "physical_risk",
+        "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP"]
+      },
+      {
+        "group": "entity_matching_pipeline_.*",
+        "catalog": "osc_datacommons_dev",
+        "schema": "gleif",
         "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP"]
       },
       {
@@ -216,6 +206,7 @@ stringData:
       },
       {
         "catalog": "osc_datacommons_dev",
+        "schema": "gleif",
         "privileges": ["SELECT"]
       },
       {


### PR DESCRIPTION
Original goal: define a group to confine lseg data access to users known to be covered under NDA
New Goal: resync user groups with github teams, which will include `..._developer` user groups for each project. These `developer` groups should have access to LSEG data.

cc @caldeirav @MichaelTiemannOSC