### PR TITLE
Make ocs-external-storagecluster-ceph-rbd the default storage class

### DIFF
--- a/cluster-scope/base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd/kustomization.yaml
+++ b/cluster-scope/base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- storageclass.yaml

--- a/cluster-scope/base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd/storageclass.yaml
+++ b/cluster-scope/base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd/storageclass.yaml
@@ -1,0 +1,22 @@
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    description: Provides RWO Filesystem volumes, and RWO and RWX Block volumes
+  name: ocs-external-storagecluster-ceph-rbd
+parameters:
+  clusterID: openshift-storage
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: openshift-storage
+  csi.storage.k8s.io/fstype: ext4
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+  csi.storage.k8s.io/node-stage-secret-namespace: openshift-storage
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: openshift-storage
+  imageFeatures: layering
+  imageFormat: "2"
+  pool: moc_rbd_1
+provisioner: openshift-storage.rbd.csi.ceph.com
+reclaimPolicy: Delete
+volumeBindingMode: Immediate

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -120,6 +120,7 @@ resources:
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/tekton-dashboard
   - ../../../../base/storage.k8s.io/csidrivers/org.democratic-csi.nfs
   - ../../../../base/storage.k8s.io/storageclasses/moc-nfs-csi
+  - ../../../../base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd
   - ../../../../base/user.openshift.io/groups/cluster-admins
 
   - ingresscontrollers/default.yaml
@@ -134,7 +135,7 @@ patchesStrategicMerge:
   - configmaps/user-workload-monitoring-config.yaml
   - groups/cluster-admins.yaml
   - oauths/cluster_patch.yaml
-  - storageclasses/moc-nfs-csi_patch.yaml
+  - storageclasses/ocs-external-storagecluster-ceph-rbd.yaml
   - subscriptions/cluster-logging-operator_patch.yaml
   - subscriptions/kubernetes-nmstate-operator_patch.yaml
   - subscriptions/nfd_patch.yaml

--- a/cluster-scope/overlays/prod/moc/smaug/storageclasses/ocs-external-storagecluster-ceph-rbd.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/storageclasses/ocs-external-storagecluster-ceph-rbd.yaml
@@ -1,6 +1,6 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: moc-nfs-csi
+  name: ocs-external-storagecluster-ceph-rbd
   annotations:
     storageclass.kubernetes.io/is-default-class: 'true'


### PR DESCRIPTION
This adds the ocs-external-storagecluster-ceph-rbd storageclass to the
repository and makes it the default on smaug.

Part of operate-first/sre#416
