### PR TITLE
Include operate-first-sso-secret in generated manifests

### DIFF
--- a/cluster-scope/overlays/prod/moc/curator/secret-generator.yaml
+++ b/cluster-scope/overlays/prod/moc/curator/secret-generator.yaml
@@ -4,6 +4,8 @@ kind: ksops
 metadata:
   name: secret-generator
 files:
-  - oauths/moc-sso-client-secret.enc.yaml
-  - ingresscontrollers/default-ingress-certificate.enc.yaml
   - ../common/pull-secret.enc.yaml
+
+  - ingresscontrollers/default-ingress-certificate.enc.yaml
+  - oauths/moc-sso-client-secret.enc.yaml
+  - oauths/operate-first-sso-secret.enc.yaml


### PR DESCRIPTION
Operate First SSO on the Curator cluster is missing the necessary
client secret. This was erroneously omitted from 0bdc9bd.
