### PR TITLE
setup pulp instance and track it in git

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - grafana.yaml
   - jh-idle-culler.yaml
   - prod-aicoe-ci.yaml
+  - pulp.yaml
   - slack-first.yaml
   - triage-party.yaml
   - meteor-shower.yaml

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/pulp.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/pulp.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: pulp
+spec:
+  destination:
+    name: smaug
+    namespace: opf-pulp
+  project: operate-first
+  source:
+    path: pulp/overlays/moc/smaug
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false

--- a/argocd/overlays/moc-infra/projects/global_project.yaml
+++ b/argocd/overlays/moc-infra/projects/global_project.yaml
@@ -160,6 +160,8 @@ spec:
       kind: PackageManifest
     - group: policy
       kind: PodDisruptionBudget
+    - group: pulp.pulpproject.org
+      kind: Pulp
     - group: quota.openshift.io
       kind: AppliedClusterResourceQuota
     - group: rbac.authorization.k8s.io

--- a/cluster-scope/base/core/namespaces/opf-pulp/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/opf-pulp/kustomization.yaml
@@ -5,7 +5,7 @@ components:
 - ../../../../components/monitoring-rbac
 - ../../../../components/limitranges/default
 kind: Kustomization
-namespace: thoth-pulp-experiments
+namespace: opf-pulp
 resources:
 - namespace.yaml
 - resourcequota.yaml

--- a/cluster-scope/base/core/namespaces/opf-pulp/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/opf-pulp/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "opf-Pulp: Instance of the pulp (http://pulpproject.org)"
+    openshift.io/requester: thoth-devops
+  name: opf-pulp
+spec: {}

--- a/cluster-scope/base/core/namespaces/opf-pulp/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/opf-pulp/resourcequota.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ResourceQuota
 metadata:
-  name: thoth-pulp-experiments-custom
+  name: opf-pulp-custom
 spec:
   hard:
     requests.cpu: "8"

--- a/cluster-scope/base/core/namespaces/thoth-pulp-experiments/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/thoth-pulp-experiments/namespace.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    openshift.io/display-name: "Pulp+Thoth-Station: Experimenting with Pulp"
-    openshift.io/requester: thoth-devops
-  name: thoth-pulp-experiments
-spec: {}

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/opf-pulp/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/opf-pulp/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: thoth-pulp-experiments
+namespace: opf-pulp
 resources:
 - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/opf-pulp/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/opf-pulp/operatorgroup.yaml
@@ -2,7 +2,7 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: thoth-pulp-experiments
+  name: opf-pulp
 spec:
   targetNamespaces:
-    - thoth-pulp-experiments
+    - opf-pulp

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -52,6 +52,7 @@ resources:
   - ../../../../base/core/namespaces/opf-jupyterhub-stage
   - ../../../../base/core/namespaces/opf-kafka
   - ../../../../base/core/namespaces/opf-monitoring
+  - ../../../../base/core/namespaces/opf-pulp
   - ../../../../base/core/namespaces/opf-seldon
   - ../../../../base/core/namespaces/opf-dashboard
   - ../../../../base/core/namespaces/opf-slack-first
@@ -70,7 +71,6 @@ resources:
   - ../../../../base/core/namespaces/thoth-graph-prod
   - ../../../../base/core/namespaces/thoth-infra-prod
   - ../../../../base/core/namespaces/thoth-middletier-prod
-  - ../../../../base/core/namespaces/thoth-pulp-experiments
   - ../../../../base/core/namespaces/ushift-dev
   - ../../../../base/core/persistentvolumeclaims/image-registry-storage
   - ../../../../base/nmstate.io/nmstates/nmstate
@@ -84,7 +84,7 @@ resources:
   - ../../../../base/operators.coreos.com/operatorgroups/openshift-nfd
   - ../../../../base/operators.coreos.com/operatorgroups/openshift-vertical-pod-autoscaler
   - ../../../../base/operators.coreos.com/operatorgroups/opf-monitoring
-  - ../../../../base/operators.coreos.com/operatorgroups/thoth-pulp-experiments
+  - ../../../../base/operators.coreos.com/operatorgroups/opf-pulp
   - ../../../../base/operators.coreos.com/subscriptions/cert-manager
   - ../../../../base/operators.coreos.com/subscriptions/cluster-logging
   - ../../../../base/operators.coreos.com/subscriptions/koku-metrics-operator

--- a/cluster-scope/overlays/prod/moc/zero/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/zero/kustomization.yaml
@@ -90,7 +90,6 @@ resources:
   - ../../../../base/core/namespaces/thoth-graph-prod
   - ../../../../base/core/namespaces/thoth-infra-prod
   - ../../../../base/core/namespaces/thoth-middletier-prod
-  - ../../../../base/core/namespaces/thoth-pulp-experiments
   - ../../../../base/core/namespaces/uky-hpc-workload-generator
   - ../../../../base/core/namespaces/ws-ml-prague
   - ../../../../base/core/persistentvolumeclaims/image-registry-storage

--- a/pulp/base/kustomization.yaml
+++ b/pulp/base/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: opf-pulp
 resources:
-- subscription.yaml
+  - opf-pulp.yaml

--- a/pulp/base/opf-pulp.yaml
+++ b/pulp/base/opf-pulp.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: pulp.pulpproject.org/v1beta1
+kind: Pulp
+metadata:
+  name: pulp
+spec: {}

--- a/pulp/overlays/moc/smaug/kustomization.yaml
+++ b/pulp/overlays/moc/smaug/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base
+  - opf-pulp-route.yaml
+patchesStrategicMerge:
+  - opf-pulp.yaml

--- a/pulp/overlays/moc/smaug/opf-pulp-route.yaml
+++ b/pulp/overlays/moc/smaug/opf-pulp-route.yaml
@@ -1,0 +1,15 @@
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+    name: pulp-external
+    annotations:
+        kubernetes.io/tls-acme: "true"
+spec:
+    host: pulp.operate-first.cloud
+    to:
+        kind: Service
+        name: pulp-web-svc
+        weight: 100
+    port:
+        targetPort: web-8080

--- a/pulp/overlays/moc/smaug/opf-pulp.yaml
+++ b/pulp/overlays/moc/smaug/opf-pulp.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: pulp.pulpproject.org/v1beta1
+kind: Pulp
+metadata:
+  name: pulp
+spec:
+  route_tls_termination_mechanism: Edge
+  ingress_type: Route
+  loadbalancer_port: 80
+  file_storage_size: 50Gi
+  image_pull_policy: IfNotPresent
+  file_storage_storage_class: ocs-external-storagecluster-ceph-rbd
+  image_web: 'quay.io/pulp/pulp-web:stable'
+  web:
+    replicas: 1
+  file_storage_access_mode: ReadWriteMany
+  content:
+    log_level: INFO
+    replicas: 2
+  api:
+    log_level: INFO
+    replicas: 1
+  image: 'quay.io/pulp/pulp:stable'
+  loadbalancer_protocol: http
+  resource_manager:
+    replicas: 1
+  route_host: pulp.operate-first.cloud
+  storage_type: File
+  worker:
+    replicas: 2


### PR DESCRIPTION
setup pulp instance and track it in git
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Fixes: https://github.com/operate-first/support/issues/437
Related-to: https://github.com/operate-first/support/issues/176


Details:

Manage pulp instance via git.

- [x] Add pulp instance manifest in opf/apps dir [pulp](./pulp)
- [x]  set the pulp instance to use the ceph based PV.
- [x] Adjust the namespace name to `opf-pulp`. As this is no longer an experiment and can be opened for users to use.
- [x] Created argo-cd app for the pulp instance deployment.

Post Merge:
- [ ] Delete the namespace thoth-pulp-experiment. 
