### PR TITLE
setup namespace, rbac and roles for the tekton chains

### DIFF
--- a/cluster-scope/base/core/namespaces/tekton-chains/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/tekton-chains/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: tekton-chains
+components:
+  - ../../../../components/project-admin-rolebindings/operate-first
+  - ../../../../components/monitoring-rbac
+  - ../../../../components/resourcequotas/small
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/tekton-chains/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/tekton-chains/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tekton-chains
+  labels:
+    app.kubernetes.io/component: chains
+    app.kubernetes.io/part-of: tekton-pipelines
+spec: {}

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/tekton-chains/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/tekton-chains/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- tekton-chains-controller-cluster-access.yaml
+- tekton-chains-controller-tenant-access.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/tekton-chains/tekton-chains-controller-cluster-access.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/tekton-chains/tekton-chains-controller-cluster-access.yaml
@@ -1,0 +1,31 @@
+---
+# Copyright 2021 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-chains-controller-cluster-access
+  labels:
+    app.kubernetes.io/component: chains
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+subjects:
+  - kind: ServiceAccount
+    name: tekton-chains-controller
+    namespace: tekton-chains
+roleRef:
+  kind: ClusterRole
+  name: tekton-chains-controller-cluster-access
+  apiGroup: rbac.authorization.k8s.io

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/tekton-chains/tekton-chains-controller-tenant-access.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/tekton-chains/tekton-chains-controller-tenant-access.yaml
@@ -1,0 +1,21 @@
+---
+# If this ClusterRoleBinding is replaced with a RoleBinding
+# then the ClusterRole would be namespaced. The access described by
+# the tekton-pipelines-controller-tenant-access ClusterRole would
+# be scoped to individual tenant namespaces.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-chains-controller-tenant-access
+  labels:
+    app.kubernetes.io/component: chains
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+subjects:
+  - kind: ServiceAccount
+    name: tekton-chains-controller
+    namespace: tekton-chains
+roleRef:
+  kind: ClusterRole
+  name: tekton-chains-controller-tenant-access
+  apiGroup: rbac.authorization.k8s.io

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/tekton-chains/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/tekton-chains/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- tekton-chains-controller-cluster-access.yaml
+- tekton-chains-controller-tenant-access.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/tekton-chains/tekton-chains-controller-cluster-access.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/tekton-chains/tekton-chains-controller-cluster-access.yaml
@@ -1,0 +1,71 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-chains-controller-cluster-access
+  labels:
+    app.kubernetes.io/component: chains
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+rules:
+  - apiGroups:
+      - ""
+      # Controller needs to watch Pods created by TaskRuns to see them progress.
+    resources:
+      - "pods"
+    verbs:
+      - "list"
+      - "watch"
+      # Controller needs cluster access to all of the CRDs that it is responsible for
+      # managing.
+  - apiGroups:
+      - "tekton.dev"
+    resources:
+      - "tasks"
+      - "clustertasks"
+      - "taskruns"
+      - "pipelines"
+      - "pipelineruns"
+      - "pipelineresources"
+      - "conditions"
+      - "runs"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
+  - apiGroups:
+      - "tekton.dev"
+    resources:
+      - "taskruns/finalizers"
+      - "pipelineruns/finalizers"
+      - "runs/finalizers"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
+  - apiGroups:
+      - "tekton.dev"
+    resources:
+      - "tasks/status"
+      - "clustertasks/status"
+      - "taskruns/status"
+      - "pipelines/status"
+      - "pipelineruns/status"
+      - "pipelineresources/status"
+      - "runs/status"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/tekton-chains/tekton-chains-controller-tenant-access.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/tekton-chains/tekton-chains-controller-tenant-access.yaml
@@ -1,0 +1,52 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # This is the access that the controller needs on a per-namespace basis.
+  name: tekton-chains-controller-tenant-access
+  labels:
+    app.kubernetes.io/component: chains
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-chains
+rules:
+  # Read-write access to create Pods, K8s Events and PVCs (for Workspaces)
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+      - "pods/log"
+      - "events"
+      - "persistentvolumeclaims"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"
+  # Read-only access to these.
+  - apiGroups:
+      - ""
+    resources:
+      - "configmaps"
+      - "limitranges"
+      - "secrets"
+      - "serviceaccounts"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+  # Read-write access to StatefulSets for Affinity Assistant.
+  - apiGroups:
+      - "apps"
+    resources:
+      - "statefulsets"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -64,6 +64,7 @@ resources:
   - ../../../../base/core/namespaces/report-system
   - ../../../../base/core/namespaces/seraph-ingress
   - ../../../../base/core/namespaces/seraph-platform-mq
+  - ../../../../base/core/namespaces/tekton-chains
   - ../../../../base/core/namespaces/tekton-pipelines
   - ../../../../base/core/namespaces/thoth-amun-api-prod
   - ../../../../base/core/namespaces/thoth-amun-inspection-prod
@@ -109,6 +110,7 @@ resources:
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/moc-nfs-democratic-csi-node-rb
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/node-labeler
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/scc-privileged-opf-ci-pipelines-aicoe-ci
+  - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/tekton-chains
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/tekton-dashboard
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/vault-server-binding
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/acme-operator
@@ -120,6 +122,7 @@ resources:
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/moc-nfs-democratic-csi-controller-cr
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/moc-nfs-democratic-csi-node-cr
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/node-labeler
+  - ../../../../base/rbac.authorization.k8s.io/clusterroles/tekton-chains
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/tekton-dashboard
   - ../../../../base/storage.k8s.io/csidrivers/org.democratic-csi.nfs
   - ../../../../base/storage.k8s.io/storageclasses/moc-nfs-csi


### PR DESCRIPTION
setup namespace, rbac and roles for the tekton chains
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Related-to: https://github.com/operate-first/support/issues/438

Tekton chains provide security to our pipeline supply chains.
It would sign the images based on the secrets. 
https://github.com/tektoncd/chains#installation