### PR TITLE
Add routes for ipmi access to curator cluster

### DIFF
--- a/cluster-scope/overlays/prod/moc/curator/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/curator/kustomization.yaml
@@ -18,6 +18,8 @@ resources:
   - ../../../../base/storage.k8s.io/storageclasses/hostpath-provisioner
   - ../../../../base/user.openshift.io/groups/cluster-admins
 
+  - machineconfigs/50-ipmi-route.yaml
+
 generators:
   - secret-generator.yaml
 

--- a/cluster-scope/overlays/prod/moc/curator/machineconfigs/50-ipmi-route.yaml
+++ b/cluster-scope/overlays/prod/moc/curator/machineconfigs/50-ipmi-route.yaml
@@ -1,0 +1,28 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 50-ipmi-route
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    systemd:
+      units:
+      - contents: |
+          [Unit]
+          Description=Configure routes for IPMI access
+          Before=kubelet.service
+          After=network-online.target
+          Wants=network-online.target
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          ExecStart=/sbin/ip route add 10.0.0.0/19 via 192.12.185.101
+
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: ipmi-routes.service


### PR DESCRIPTION
The baremetal operator was complaining because it was unable to reach
the ipmi addresses of the cluster nodes. This adds the necessary
routes for access to the ipmi network.
