### PR TITLE
enabling prometheus rule to argocd in moc-infra overlay

### DIFF
--- a/argocd/overlays/moc-infra/projects/global_project.yaml
+++ b/argocd/overlays/moc-infra/projects/global_project.yaml
@@ -127,6 +127,8 @@ spec:
     - group: metrics.k8s.io
       kind: PodMetrics
     - group: monitoring.coreos.com
+      kind: PrometheusRule
+    - group: monitoring.coreos.com
       kind: ServiceMonitor
     - group: networking.k8s.io
       kind: Ingress


### PR DESCRIPTION
## Related Issues and Dependencies

Addresses part 3 of [thoth-station/thoth-application issue 2029](https://github.com/thoth-station/thoth-application/issues/2029#issuecomment-961310030)

## Does this require new deployment ?

no

## Description

Enabling prometheus rule in argocd in the global_project for the MOC-infra overlay.