### PR TITLE
Configure curator cluster to allow 4.8 -> 4.9 upgrade

### DIFF
--- a/cluster-scope/overlays/prod/moc/curator/configmaps/admin-acks.yaml
+++ b/cluster-scope/overlays/prod/moc/curator/configmaps/admin-acks.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: admin-acks
+  namespace: openshift-config
+data:
+  ack-4.8-kube-1.22-api-removals-in-4.9: "true"

--- a/cluster-scope/overlays/prod/moc/curator/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/curator/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - ../../../../base/user.openshift.io/groups/cluster-admins
 
   - machineconfigs/50-ipmi-route.yaml
+  - configmaps/admin-acks.yaml
 
 generators:
   - secret-generator.yaml


### PR DESCRIPTION
This adds the necessary admin-ack for the 4.8 -> 4.9 upgrade
described in KB 6329921 [1].

[1]: https://access.redhat.com/articles/6329921
