### PR TITLE
Adding Helm parameter to Fybrik ArgoCD application

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/fybrik/fybrik.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/fybrik/fybrik.yaml
@@ -14,4 +14,6 @@ spec:
       parameters:
         - name: clusterScoped
           value: "false"
+        - name: applicationNamespace
+          value: fybrik-applications
   project: fybrik


### PR DESCRIPTION
This PR adds the `applicationNamespace` Helm parameter to the Fybrik ArgoCD application

@ronenkat @HumairAK 