### PR TITLE
Add action to sync hitchiker docs between repos.

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,0 +1,3 @@
+operate-first/hitchhikers-guide:
+  - source: docs/
+    dest: docs/

--- a/.github/workflows/sync-action.yaml
+++ b/.github/workflows/sync-action.yaml
@@ -1,0 +1,17 @@
+name: Sync Files
+on:
+  push:
+    paths:
+      - 'docs/**'
+    branches:
+      - 'master'
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@main
+      - name: Run GitHub File Sync
+        uses: BetaHuhn/repo-file-sync-action@v1
+        with:
+          GH_PAT: ${{ secrets.OP1ST_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ---
-exclude: scripts|argocd/overlays/dev/configs|argocd/overlays/moc-infra/configs
+exclude: scripts|argocd/overlays/dev/configs|argocd/overlays/moc-infra/configs|.github/workflows
 
 repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks


### PR DESCRIPTION
This is a suggestion to sync docs from apps to hitchhiker's guide automatically. It uses github actions, but ideally we would use thoth tooling to do this, this should serve as an interim solution.

Basically everytime any change is pushed to `docs` the bot account will push these changes to the `docs` folder in `hitchhiker's` galaxy. 

WDYT?

side note: ignoring workflows in pre-commit as part of this change due to [this issue](https://github.com/adrienverge/yamllint/issues/158), the pr is merged, but I tried it against latest yamllint 1.26.3 and it still failed. 