### PR TITLE
Add Vector deployment for multiple clusters

### DIFF
--- a/cluster-scope/base/core/namespaces/opf-observatorium/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/opf-observatorium/resourcequota.yaml
@@ -4,8 +4,8 @@ metadata:
   name: opf-observatorium-custom
 spec:
   hard:
-    limits.cpu: '32'
-    limits.memory: 64Gi
+    limits.cpu: '48'
+    limits.memory: 100Gi
     requests.cpu: '32'
     requests.memory: 64Gi
     requests.storage: 500Gi

--- a/docs/observatorium/vector/README.md
+++ b/docs/observatorium/vector/README.md
@@ -1,6 +1,6 @@
 ## Vector on Operate First
 
-We deploy and manage an instance of [Vector][Vector] on the Operate First `Smaug` cluster.
+We deploy and manage instances of [Vector][Vector] on the Operate First `Smaug` cluster.
 
 Currently we use Vector for forwarding [CLO][CLO] logs from our [Kafka instance][Kafka] to our [Loki][Loki] instance.
 
@@ -10,4 +10,4 @@ You can find our Vector configurations [here][config]. If you would like to make
 [CLO]: https://docs.openshift.com/container-platform/4.9/logging/cluster-logging-external.html
 [Kafka]: https://github.com/operate-first/apps/tree/master/docs/odh/kafka
 [Loki]: https://github.com/operate-first/apps/tree/master/docs/observatorium/loki
-[config]: https://github.com/operate-first/apps/tree/master/observatorium/overlays/moc/smaug/vector/configmap.yaml
+[config]: https://github.com/operate-first/apps/tree/master/observatorium/overlays/moc/smaug/vector/smaug/configmap.yaml

--- a/observatorium/overlays/moc/smaug/vector/balrog/configmap.yaml
+++ b/observatorium/overlays/moc/smaug/vector/balrog/configmap.yaml
@@ -1,0 +1,154 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vector-config-balrog
+data:
+  vector-config.yaml: |
+    ---
+    api:
+      enabled: true
+      address: 0.0.0.0:8686
+      playground: false
+
+    sources:
+      balrog-app-logs-kafka:
+        type: kafka
+        bootstrap_servers: odh-message-bus-kafka-bootstrap.opf-kafka.svc.cluster.local:9093
+        group_id: cluster-logs-consumer
+        key_field: message_key
+        topics:
+        - balrog-prod.cluster-logs.application
+        tls:
+          enabled: true
+          ca_file: "/mnt/ca-bundle.crt"
+          crt_file: "/mnt/tls.crt"
+          key_file: "/mnt/tls.key"
+
+      balrog-infra-logs-kafka:
+        type: kafka
+        bootstrap_servers: odh-message-bus-kafka-bootstrap.opf-kafka.svc.cluster.local:9093
+        group_id: cluster-logs-consumer
+        key_field: message_key
+        topics:
+        - balrog-prod.cluster-logs.infrastructure
+        tls:
+          enabled: true
+          ca_file: "/mnt/ca-bundle.crt"
+          crt_file: "/mnt/tls.crt"
+          key_file: "/mnt/tls.key"
+
+      balrog-audit-logs-kafka:
+        type: kafka
+        bootstrap_servers: odh-message-bus-kafka-bootstrap.opf-kafka.svc.cluster.local:9093
+        group_id: cluster-logs-consumer
+        key_field: message_key
+        topics:
+        - balrog-prod.cluster-logs.audit
+        tls:
+          enabled: true
+          ca_file: "/mnt/ca-bundle.crt"
+          crt_file: "/mnt/tls.crt"
+          key_file: "/mnt/tls.key"
+
+      vector_metrics_source:
+        type: internal_metrics
+        scrape_interval_secs: 60
+
+    transforms:
+      loki_parser_app:
+        type: remap
+        inputs:
+        - balrog-app-logs-kafka
+        source: "
+          message = parse_json!(.message) \n
+          .message = message.message \n
+          .docker = message.docker \n
+          .kubernetes = message.kubernetes \n "
+
+      loki_parser_infra:
+        type: remap
+        inputs:
+        - balrog-infra-logs-kafka
+        source: "
+          message = parse_json!(.message) \n
+          .message = message.message \n
+          .docker = message.docker \n
+          .kubernetes = message.kubernetes \n "
+
+      loki_parser_audit:
+        type: remap
+        inputs:
+        - balrog-audit-logs-kafka
+        source: ". = parse_json!(.message)"
+
+    sinks:
+      loki_sink_app:
+        type: loki
+        inputs:
+        - loki_parser_app
+        endpoint: http://observatorium-loki-distributor-http.opf-observatorium.svc.cluster.local:3100
+        out_of_order_action: rewrite_timestamp
+        tenant_id: cluster-app-logs
+        request:
+          concurrency: adaptive
+        batch:
+          max_bytes: 10240000 # 10MB
+          max_events: 10000000
+        encoding:
+          codec: json
+        healthcheck:
+          enabled: true
+        labels:
+          openshift_cluster: emea/balrog
+          cluster_log_level: app-logs
+          k8s_namespace_name: "{{ kubernetes.namespace_name }}"
+
+      loki_sink_infra:
+        type: loki
+        inputs:
+        - loki_parser_infra
+        endpoint: http://observatorium-loki-distributor-http.opf-observatorium.svc.cluster.local:3100
+        out_of_order_action: rewrite_timestamp
+        request:
+          concurrency: adaptive
+        tenant_id: cluster-infra-logs
+        batch:
+          max_bytes: 1024000 # 1MB
+          max_events: 1000000
+        encoding:
+          codec: json
+        healthcheck:
+          enabled: true
+        labels:
+          openshift_cluster: emea/balrog
+          cluster_log_level: infra-logs
+          k8s_namespace_name: "{{ kubernetes.namespace_name }}"
+
+      loki_sink_audit:
+        type: loki
+        inputs:
+        - loki_parser_audit
+        endpoint: http://observatorium-loki-distributor-http.opf-observatorium.svc.cluster.local:3100
+        out_of_order_action: rewrite_timestamp
+        request:
+          concurrency: adaptive
+        tenant_id: cluster-audit-logs
+        batch:
+          max_bytes: 1024000 # 1MB
+          max_events: 1000000
+        encoding:
+          codec: json
+        healthcheck:
+          enabled: true
+        labels:
+          openshift_cluster: emea/balrog
+          cluster_log_level: audit-logs
+          k8s_namespace_name: "{{ objectRef.namespace }}"
+
+      vector_metrics_prom_exporter:
+        type: prometheus_exporter
+        inputs:
+        - vector_metrics_source
+        address: 0.0.0.0:9598
+        default_namespace: service

--- a/observatorium/overlays/moc/smaug/vector/balrog/deployment.yaml
+++ b/observatorium/overlays/moc/smaug/vector/balrog/deployment.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vector-balrog
+  labels:
+    app: vector-balrog
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vector-balrog
+  template:
+    metadata:
+      labels:
+        app: vector-balrog
+    spec:
+      containers:
+        - name: vector
+          image: quay.io/operate-first/vector:0.14.X-alpine
+          command: ["vector", "-c", "/home/config/vector-config.yaml"]
+          resources:
+            limits:
+              cpu: "2"
+              memory: 2Gi
+            requests:
+              cpu: 1500m
+              memory: 500Mi
+          ports:
+            - containerPort: 8686
+              name: graphql-api
+            - containerPort: 9598
+              name: metrics
+          volumeMounts:
+            - name: config-volume
+              mountPath: /home/config
+              readOnly: true
+            - name: clo-kafka
+              readOnly: true
+              mountPath: /mnt
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+      volumes:
+        - name: config-volume
+          configMap:
+            name: vector-config-balrog
+        - name: clo-kafka
+          secret:
+            secretName: clo-kafka
+            defaultMode: 420

--- a/observatorium/overlays/moc/smaug/vector/balrog/kustomization.yaml
+++ b/observatorium/overlays/moc/smaug/vector/balrog/kustomization.yaml
@@ -2,12 +2,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: opf-observatorium
-
+commonLabels:
+  app: vector-balrog
 resources:
-  - balrog
-  - infra
-  - rick
-  - smaug
-
-generators:
-  - ./secret-generator.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml

--- a/observatorium/overlays/moc/smaug/vector/balrog/service.yaml
+++ b/observatorium/overlays/moc/smaug/vector/balrog/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vector-balrog-metrics
+spec:
+  selector:
+    app: vector-balrog
+  ports:
+    - name: metrics
+      protocol: TCP
+      port: 9598
+      targetPort: metrics
+    - name: graphql-api
+      protocol: TCP
+      port: 8686
+      targetPort: graphql-api

--- a/observatorium/overlays/moc/smaug/vector/infra/configmap.yaml
+++ b/observatorium/overlays/moc/smaug/vector/infra/configmap.yaml
@@ -1,0 +1,154 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vector-config-infra
+data:
+  vector-config.yaml: |
+    ---
+    api:
+      enabled: true
+      address: 0.0.0.0:8686
+      playground: false
+
+    sources:
+      infra-app-logs-kafka:
+        type: kafka
+        bootstrap_servers: odh-message-bus-kafka-bootstrap.opf-kafka.svc.cluster.local:9093
+        group_id: cluster-logs-consumer
+        key_field: message_key
+        topics:
+        - infra-prod.cluster-logs.application
+        tls:
+          enabled: true
+          ca_file: "/mnt/ca-bundle.crt"
+          crt_file: "/mnt/tls.crt"
+          key_file: "/mnt/tls.key"
+
+      infra-infra-logs-kafka:
+        type: kafka
+        bootstrap_servers: odh-message-bus-kafka-bootstrap.opf-kafka.svc.cluster.local:9093
+        group_id: cluster-logs-consumer
+        key_field: message_key
+        topics:
+        - infra-prod.cluster-logs.infrastructure
+        tls:
+          enabled: true
+          ca_file: "/mnt/ca-bundle.crt"
+          crt_file: "/mnt/tls.crt"
+          key_file: "/mnt/tls.key"
+
+      infra-audit-logs-kafka:
+        type: kafka
+        bootstrap_servers: odh-message-bus-kafka-bootstrap.opf-kafka.svc.cluster.local:9093
+        group_id: cluster-logs-consumer
+        key_field: message_key
+        topics:
+        - infra-prod.cluster-logs.audit
+        tls:
+          enabled: true
+          ca_file: "/mnt/ca-bundle.crt"
+          crt_file: "/mnt/tls.crt"
+          key_file: "/mnt/tls.key"
+
+      vector_metrics_source:
+        type: internal_metrics
+        scrape_interval_secs: 60
+
+    transforms:
+      loki_parser_app:
+        type: remap
+        inputs:
+        - infra-app-logs-kafka
+        source: "
+          message = parse_json!(.message) \n
+          .message = message.message \n
+          .docker = message.docker \n
+          .kubernetes = message.kubernetes \n "
+
+      loki_parser_infra:
+        type: remap
+        inputs:
+        - infra-infra-logs-kafka
+        source: "
+          message = parse_json!(.message) \n
+          .message = message.message \n
+          .docker = message.docker \n
+          .kubernetes = message.kubernetes \n "
+
+      loki_parser_audit:
+        type: remap
+        inputs:
+        - infra-audit-logs-kafka
+        source: ". = parse_json!(.message)"
+
+    sinks:
+      loki_sink_app:
+        type: loki
+        inputs:
+        - loki_parser_app
+        endpoint: http://observatorium-loki-distributor-http.opf-observatorium.svc.cluster.local:3100
+        out_of_order_action: rewrite_timestamp
+        tenant_id: cluster-app-logs
+        request:
+          concurrency: adaptive
+        batch:
+          max_bytes: 10240000 # 10MB
+          max_events: 10000000
+        encoding:
+          codec: json
+        healthcheck:
+          enabled: true
+        labels:
+          openshift_cluster: moc/infra
+          cluster_log_level: app-logs
+          k8s_namespace_name: "{{ kubernetes.namespace_name }}"
+
+      loki_sink_infra:
+        type: loki
+        inputs:
+        - loki_parser_infra
+        endpoint: http://observatorium-loki-distributor-http.opf-observatorium.svc.cluster.local:3100
+        out_of_order_action: rewrite_timestamp
+        request:
+          concurrency: adaptive
+        tenant_id: cluster-infra-logs
+        batch:
+          max_bytes: 1024000 # 1MB
+          max_events: 1000000
+        encoding:
+          codec: json
+        healthcheck:
+          enabled: true
+        labels:
+          openshift_cluster: moc/infra
+          cluster_log_level: infra-logs
+          k8s_namespace_name: "{{ kubernetes.namespace_name }}"
+
+      loki_sink_audit:
+        type: loki
+        inputs:
+        - loki_parser_audit
+        endpoint: http://observatorium-loki-distributor-http.opf-observatorium.svc.cluster.local:3100
+        out_of_order_action: rewrite_timestamp
+        request:
+          concurrency: adaptive
+        tenant_id: cluster-audit-logs
+        batch:
+          max_bytes: 1024000 # 1MB
+          max_events: 1000000
+        encoding:
+          codec: json
+        healthcheck:
+          enabled: true
+        labels:
+          openshift_cluster: moc/infra
+          cluster_log_level: audit-logs
+          k8s_namespace_name: "{{ objectRef.namespace }}"
+
+      vector_metrics_prom_exporter:
+        type: prometheus_exporter
+        inputs:
+        - vector_metrics_source
+        address: 0.0.0.0:9598
+        default_namespace: service

--- a/observatorium/overlays/moc/smaug/vector/infra/deployment.yaml
+++ b/observatorium/overlays/moc/smaug/vector/infra/deployment.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vector-infra
+  labels:
+    app: vector-infra
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vector-infra
+  template:
+    metadata:
+      labels:
+        app: vector-infra
+    spec:
+      containers:
+        - name: vector
+          image: quay.io/operate-first/vector:0.14.X-alpine
+          command: ["vector", "-c", "/home/config/vector-config.yaml"]
+          resources:
+            limits:
+              cpu: "2"
+              memory: 2Gi
+            requests:
+              cpu: 1500m
+              memory: 500Mi
+          ports:
+            - containerPort: 8686
+              name: graphql-api
+            - containerPort: 9598
+              name: metrics
+          volumeMounts:
+            - name: config-volume
+              mountPath: /home/config
+              readOnly: true
+            - name: clo-kafka
+              readOnly: true
+              mountPath: /mnt
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+      volumes:
+        - name: config-volume
+          configMap:
+            name: vector-config-infra
+        - name: clo-kafka
+          secret:
+            secretName: clo-kafka
+            defaultMode: 420

--- a/observatorium/overlays/moc/smaug/vector/infra/kustomization.yaml
+++ b/observatorium/overlays/moc/smaug/vector/infra/kustomization.yaml
@@ -2,12 +2,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: opf-observatorium
-
+commonLabels:
+  app: vector-infra
 resources:
-  - balrog
-  - infra
-  - rick
-  - smaug
-
-generators:
-  - ./secret-generator.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml

--- a/observatorium/overlays/moc/smaug/vector/infra/service.yaml
+++ b/observatorium/overlays/moc/smaug/vector/infra/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vector-infra-metrics
+spec:
+  selector:
+    app: vector-infra
+  ports:
+    - name: metrics
+      protocol: TCP
+      port: 9598
+      targetPort: metrics
+    - name: graphql-api
+      protocol: TCP
+      port: 8686
+      targetPort: graphql-api

--- a/observatorium/overlays/moc/smaug/vector/rick/configmap.yaml
+++ b/observatorium/overlays/moc/smaug/vector/rick/configmap.yaml
@@ -1,0 +1,154 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vector-config-rick
+data:
+  vector-config.yaml: |
+    ---
+    api:
+      enabled: true
+      address: 0.0.0.0:8686
+      playground: false
+
+    sources:
+      rick-app-logs-kafka:
+        type: kafka
+        bootstrap_servers: odh-message-bus-kafka-bootstrap.opf-kafka.svc.cluster.local:9093
+        group_id: cluster-logs-consumer
+        key_field: message_key
+        topics:
+        - rick-prod.cluster-logs.application
+        tls:
+          enabled: true
+          ca_file: "/mnt/ca-bundle.crt"
+          crt_file: "/mnt/tls.crt"
+          key_file: "/mnt/tls.key"
+
+      rick-infra-logs-kafka:
+        type: kafka
+        bootstrap_servers: odh-message-bus-kafka-bootstrap.opf-kafka.svc.cluster.local:9093
+        group_id: cluster-logs-consumer
+        key_field: message_key
+        topics:
+        - rick-prod.cluster-logs.infrastructure
+        tls:
+          enabled: true
+          ca_file: "/mnt/ca-bundle.crt"
+          crt_file: "/mnt/tls.crt"
+          key_file: "/mnt/tls.key"
+
+      rick-audit-logs-kafka:
+        type: kafka
+        bootstrap_servers: odh-message-bus-kafka-bootstrap.opf-kafka.svc.cluster.local:9093
+        group_id: cluster-logs-consumer
+        key_field: message_key
+        topics:
+        - rick-prod.cluster-logs.audit
+        tls:
+          enabled: true
+          ca_file: "/mnt/ca-bundle.crt"
+          crt_file: "/mnt/tls.crt"
+          key_file: "/mnt/tls.key"
+
+      vector_metrics_source:
+        type: internal_metrics
+        scrape_interval_secs: 60
+
+    transforms:
+      loki_parser_app:
+        type: remap
+        inputs:
+        - rick-app-logs-kafka
+        source: "
+          message = parse_json!(.message) \n
+          .message = message.message \n
+          .docker = message.docker \n
+          .kubernetes = message.kubernetes \n "
+
+      loki_parser_infra:
+        type: remap
+        inputs:
+        - rick-infra-logs-kafka
+        source: "
+          message = parse_json!(.message) \n
+          .message = message.message \n
+          .docker = message.docker \n
+          .kubernetes = message.kubernetes \n "
+
+      loki_parser_audit:
+        type: remap
+        inputs:
+        - rick-audit-logs-kafka
+        source: ". = parse_json!(.message)"
+
+    sinks:
+      loki_sink_app:
+        type: loki
+        inputs:
+        - loki_parser_app
+        endpoint: http://observatorium-loki-distributor-http.opf-observatorium.svc.cluster.local:3100
+        out_of_order_action: rewrite_timestamp
+        tenant_id: cluster-app-logs
+        request:
+          concurrency: adaptive
+        batch:
+          max_bytes: 10240000 # 10MB
+          max_events: 10000000
+        encoding:
+          codec: json
+        healthcheck:
+          enabled: true
+        labels:
+          openshift_cluster: emea/rick
+          cluster_log_level: app-logs
+          k8s_namespace_name: "{{ kubernetes.namespace_name }}"
+
+      loki_sink_infra:
+        type: loki
+        inputs:
+        - loki_parser_infra
+        endpoint: http://observatorium-loki-distributor-http.opf-observatorium.svc.cluster.local:3100
+        out_of_order_action: rewrite_timestamp
+        request:
+          concurrency: adaptive
+        tenant_id: cluster-infra-logs
+        batch:
+          max_bytes: 1024000 # 1MB
+          max_events: 1000000
+        encoding:
+          codec: json
+        healthcheck:
+          enabled: true
+        labels:
+          openshift_cluster: emea/rick
+          cluster_log_level: infra-logs
+          k8s_namespace_name: "{{ kubernetes.namespace_name }}"
+
+      loki_sink_audit:
+        type: loki
+        inputs:
+        - loki_parser_audit
+        endpoint: http://observatorium-loki-distributor-http.opf-observatorium.svc.cluster.local:3100
+        out_of_order_action: rewrite_timestamp
+        request:
+          concurrency: adaptive
+        tenant_id: cluster-audit-logs
+        batch:
+          max_bytes: 1024000 # 1MB
+          max_events: 1000000
+        encoding:
+          codec: json
+        healthcheck:
+          enabled: true
+        labels:
+          openshift_cluster: emea/rick
+          cluster_log_level: audit-logs
+          k8s_namespace_name: "{{ objectRef.namespace }}"
+
+      vector_metrics_prom_exporter:
+        type: prometheus_exporter
+        inputs:
+        - vector_metrics_source
+        address: 0.0.0.0:9598
+        default_namespace: service

--- a/observatorium/overlays/moc/smaug/vector/rick/deployment.yaml
+++ b/observatorium/overlays/moc/smaug/vector/rick/deployment.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vector-rick
+  labels:
+    app: vector-rick
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vector-rick
+  template:
+    metadata:
+      labels:
+        app: vector-rick
+    spec:
+      containers:
+        - name: vector
+          image: quay.io/operate-first/vector:0.14.X-alpine
+          command: ["vector", "-c", "/home/config/vector-config.yaml"]
+          resources:
+            limits:
+              cpu: "2"
+              memory: 2Gi
+            requests:
+              cpu: 1500m
+              memory: 500Mi
+          ports:
+            - containerPort: 8686
+              name: graphql-api
+            - containerPort: 9598
+              name: metrics
+          volumeMounts:
+            - name: config-volume
+              mountPath: /home/config
+              readOnly: true
+            - name: clo-kafka
+              readOnly: true
+              mountPath: /mnt
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+      volumes:
+        - name: config-volume
+          configMap:
+            name: vector-config-rick
+        - name: clo-kafka
+          secret:
+            secretName: clo-kafka
+            defaultMode: 420

--- a/observatorium/overlays/moc/smaug/vector/rick/kustomization.yaml
+++ b/observatorium/overlays/moc/smaug/vector/rick/kustomization.yaml
@@ -2,12 +2,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: opf-observatorium
-
+commonLabels:
+  app: vector-rick
 resources:
-  - balrog
-  - infra
-  - rick
-  - smaug
-
-generators:
-  - ./secret-generator.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml

--- a/observatorium/overlays/moc/smaug/vector/rick/service.yaml
+++ b/observatorium/overlays/moc/smaug/vector/rick/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vector-rick-metrics
+spec:
+  selector:
+    app: vector-rick
+  ports:
+    - name: metrics
+      protocol: TCP
+      port: 9598
+      targetPort: metrics
+    - name: graphql-api
+      protocol: TCP
+      port: 8686
+      targetPort: graphql-api

--- a/observatorium/overlays/moc/smaug/vector/smaug/configmap.yaml
+++ b/observatorium/overlays/moc/smaug/vector/smaug/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vector-config
+  name: vector-config-smaug
 data:
   vector-config.yaml: |
     ---

--- a/observatorium/overlays/moc/smaug/vector/smaug/deployment.yaml
+++ b/observatorium/overlays/moc/smaug/vector/smaug/deployment.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vector-smaug
+  labels:
+    app: vector-smaug
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vector-smaug
+  template:
+    metadata:
+      labels:
+        app: vector-smaug
+    spec:
+      containers:
+        - name: vector
+          image: quay.io/operate-first/vector:0.14.X-alpine
+          command: ["vector", "-c", "/home/config/vector-config.yaml"]
+          resources:
+            limits:
+              cpu: "2"
+              memory: 2Gi
+            requests:
+              cpu: 1500m
+              memory: 500Mi
+          ports:
+            - containerPort: 8686
+              name: graphql-api
+            - containerPort: 9598
+              name: metrics
+          volumeMounts:
+            - name: config-volume
+              mountPath: /home/config
+              readOnly: true
+            - name: clo-kafka
+              readOnly: true
+              mountPath: /mnt
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+      volumes:
+        - name: config-volume
+          configMap:
+            name: vector-config-smaug
+        - name: clo-kafka
+          secret:
+            secretName: clo-kafka
+            defaultMode: 420

--- a/observatorium/overlays/moc/smaug/vector/smaug/kustomization.yaml
+++ b/observatorium/overlays/moc/smaug/vector/smaug/kustomization.yaml
@@ -2,12 +2,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: opf-observatorium
-
+commonLabels:
+  app: vector-smaug
 resources:
-  - balrog
-  - infra
-  - rick
-  - smaug
-
-generators:
-  - ./secret-generator.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml

--- a/observatorium/overlays/moc/smaug/vector/smaug/service.yaml
+++ b/observatorium/overlays/moc/smaug/vector/smaug/service.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: vector-metrics
+  name: vector-smaug-metrics
 spec:
   selector:
-    app: vector
+    app: vector-smaug
   ports:
     - name: metrics
       protocol: TCP


### PR DESCRIPTION
Related https://github.com/operate-first/apps/issues/1210

Deploy Vector in Smaug to forward logs from Rick/Infra/Balrog/Smaug clusters to the Smaug Loki instance.