### PR TITLE
Add Jupyterhub resource tiers based on usage analysis

### DIFF
--- a/odh-manifests/smaug/jupyterhub/base/jupyterhub-singleuser-profiles-sizes-configmap.yaml
+++ b/odh-manifests/smaug/jupyterhub/base/jupyterhub-singleuser-profiles-sizes-configmap.yaml
@@ -7,35 +7,27 @@ metadata:
 data:
   jupyterhub-singleuser-profiles.yaml: |
       sizes:
+      - name: Small
+        resources:
+          requests:
+            memory: 512Mi
+            cpu: 100m
+          limits:
+            memory: 512Mi
+            cpu: 100m
       - name: Medium
         resources:
           requests:
-            memory: 2Gi
-            cpu: 100m
+            memory: 512Mi
+            cpu: 120m
           limits:
-            memory: 4Gi
-            cpu: 2
-      - name: Large - CPU intensive
+            memory: 6300Mi
+            cpu: 3
+      - name: Large
         resources:
           requests:
-            memory: 4Gi
-            cpu: 1
+            memory: 5Gi
+            cpu: 500m
           limits:
-            memory: 8Gi
-            cpu: 4
-      - name: Large - Memory intensive
-        resources:
-          requests:
-            memory: 16Gi
-            cpu: 100m
-          limits:
-            memory: 32Gi
-            cpu: 4
-      - name: Extra Large - Memory intensive
-        resources:
-          requests:
-            memory: 16Gi
-            cpu: 100m
-          limits:
-            memory: 48Gi
-            cpu: 4
+            memory: 34Gi
+            cpu: 9


### PR DESCRIPTION
This PR updates the tiers for single user profiles using result from usage analysis in [notebooks](https://github.com/aicoe-aiops/operate-first-jupyterhub-analysis/blob/master/notebooks/resource_allocation/) here. 
We found three triers: Small, Medium, and Large based on clustering of user consumption. 

Based on observation of just spawned pods, the minimum CPU and memory were set to 100m and 0.5gi respectively. 

Related Issue https://github.com/aicoe-aiops/operate-first-jupyterhub-analysis/issues/12

Continuation of this [PR](https://github.com/operate-first/apps/pull/1156)