### PR TITLE
Update configmap

### DIFF
--- a/kfdefs/base/jupyterhub/kfdef.yaml
+++ b/kfdefs/base/jupyterhub/kfdef.yaml
@@ -24,7 +24,7 @@ spec:
             value: s3.odh.com
         repoRef:
           name: opf-manifests
-          path: odh-manifests/zero/jupyterhub
+          path: odh-manifests/smaug/jupyterhub
       name: jupyterhub
     - kustomizeConfig:
         overlays:


### PR DESCRIPTION
To make sure that the changes of this [PR](https://github.com/operate-first/apps/pull/1311) are reflected in the Jupyterhub spawner page, we have to update the config map to point at "smaug" instead of "zero".