### PR TITLE
Fybrik - adding cluster role binding for Vault

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/vault-server-binding/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/vault-server-binding/clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: vault
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: vault
+    helm.sh/chart: vault-0.9.1
+  name: vault-server-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: vault
+  namespace: fybrik-system

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/vault-server-binding/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/vault-server-binding/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrolebinding.yaml

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -110,6 +110,7 @@ resources:
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/node-labeler
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/scc-privileged-opf-ci-pipelines-aicoe-ci
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/tekton-dashboard
+  - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/vault-server-binding
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/acme-operator
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/curator-auth-proxy-role
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/curator-report-editor-role


### PR DESCRIPTION
This PR adds the cluster role binding required to deploy Vault on the Smaug cluster. 

See reasoning below:
`vault-server-binding` is part of the Helm deployment of vault when using Kubernetes auth method https://wanwenli.com/kubernetes/2019/08/28/k8s-tokenreview-api-vault.html 

The Vault Kubernetes auth method (https://www.vaultproject.io/docs/auth/kubernetes#kubernetes-auth-method) is used to authenticate Kubernetes services against Vault using their Service Account Token. To enable it Vault needs to access Kubernetes TokenReview API to validate the service JWT.

For this reason Vault Service Account should be granted permissions to access this API with this cluster role binding.

@roee88 @ronenkat @HumairAK 