### PR TITLE
Curator team access

### DIFF
--- a/cluster-scope/overlays/prod/moc/curator/groups/cluster-admins.yaml
+++ b/cluster-scope/overlays/prod/moc/curator/groups/cluster-admins.yaml
@@ -8,3 +8,6 @@ users:
   - naved001
   - ipolonsk
   - skanthed
+  - gagansk
+  - hpdempsey
+  - leihchen

--- a/grafana/overlays/moc/smaug/grafana-oauth.yaml
+++ b/grafana/overlays/moc/smaug/grafana-oauth.yaml
@@ -33,5 +33,6 @@ spec:
         contains(groups[*], 'sre')            && 'Editor' ||
         contains(groups[*], 'logs-insights')  && 'Editor' ||
         contains(groups[*], 'data-science')   && 'Viewer' ||
+        contains(groups[*], 'curator')        && 'Viewer' ||
         'Deny'
       role_attribute_strict: true


### PR DESCRIPTION
Permission to access Grafana dashboard for curator team.
Add the rest of this curator team members to the cluster-admin list of curator cluster.
