### PR TITLE
apicurio: fix AppProject

### DIFF
--- a/argocd/overlays/moc-infra/projects/apicurio-registry.yaml
+++ b/argocd/overlays/moc-infra/projects/apicurio-registry.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   destinations:
     - namespace: 'apicurio-*'
-      server: 'https://api.zero.massopen.cloud:6443'
+      server: 'smaug'
   sourceRepos:
     - '*'
   roles:


### PR DESCRIPTION
Apicurio is still not being deployed, I checked argocd
https://argocd.operate-first.cloud/applications/opf-app-of-apps-smaug?resource=&node=argoproj.io%2FApplication%2Fargocd%2Fregistry-smaug%2F0

and found the error 
```
message: >-
        application destination {https://api.smaug.na.operate-first.cloud:6443
        apicurio-apicurio-registry} is not permitted in project 'apicurio'
```

Then I noticed the apicurio AppProject must point to the same destination as the Application. This PR changes that, however, is the value `smaug` correct? or should I use the api url? 

In this docs https://github.com/operate-first/apps/blob/master/docs/argocd-gitops/onboarding_to_argocd.md#create-the-argocd-project it says to use the cluster `metadata.name` value