### PR TITLE
Patch the pulp instance with node affinity to allow RDX storage mode

### DIFF
--- a/pulp/overlays/moc/smaug/opf-pulp.yaml
+++ b/pulp/overlays/moc/smaug/opf-pulp.yaml
@@ -7,13 +7,13 @@ spec:
   route_tls_termination_mechanism: Edge
   ingress_type: Route
   loadbalancer_port: 80
-  file_storage_size: 50Gi
   image_pull_policy: IfNotPresent
-  file_storage_storage_class: ocs-external-storagecluster-ceph-rbd
   image_web: 'quay.io/pulp/pulp-web:stable'
+  file_storage_size: 50Gi
+  file_storage_storage_class: ocs-external-storagecluster-ceph-rbd
+  file_storage_access_mode: ReadWriteOnce
   web:
     replicas: 1
-  file_storage_access_mode: ReadWriteMany
   content:
     log_level: INFO
     replicas: 2
@@ -28,3 +28,12 @@ spec:
   storage_type: File
   worker:
     replicas: 2
+  affinity:
+    node_affinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: name
+            operator: In
+            values:
+            - oct-03-31-compute


### PR DESCRIPTION
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Related-to: https://github.com/operate-first/support/issues/456
Epic: https://github.com/operate-first/support/issues/176


The ceph storage in smaug doesn't allow volume mode: file system with the ReadWriteMany mode.
Alternative this was suggested to use ReadWriteOnce mode, to allow many pods to attach to this kinda storage the pods must be on the same node. Hence added the node affinity which the pulp operator allows
https://github.com/pulp/pulp-operator/blob/c3fb814aa6685e14d5b016830e680c908550b559/config/crd/bases/pulpproject_v1beta1_pulp_crd.yaml#L230