### PR TITLE
setup the argocd app to deploy the tekton chains

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/kustomization.yaml
@@ -14,4 +14,5 @@ resources:
   - prod-aicoe-ci.yaml
   - pulp.yaml
   - slack-first.yaml
+  - tekton-chains.yaml
   - triage-party.yaml

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/tekton-chains.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/tekton-chains.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: opf-tekton-chains
+spec:
+  project: operate-first
+  source:
+    repoURL: https://github.com/operate-first/continuous-delivery.git
+    path: tekton-chains/overlays/moc
+    targetRevision: HEAD
+  destination:
+    name: smaug
+    namespace: tekton-chains
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false


### PR DESCRIPTION
setup the argocd app to deploy the tekton chains
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Related-to: https://github.com/operate-first/support/issues/438
