### PR TITLE
Add multi-cluster support to graf overview dashboards.

### DIFF
--- a/grafana/overlays/moc/smaug/dashboards/cluster-management/cluster-cpu-overview.yaml
+++ b/grafana/overlays/moc/smaug/dashboards/cluster-management/cluster-cpu-overview.yaml
@@ -33,8 +33,8 @@ spec:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 5,
-      "iteration": 1633725003409,
+      "id": 30,
+      "iteration": 1637097691324,
       "links": [],
       "panels": [
         {
@@ -76,7 +76,7 @@ spec:
           },
           "gridPos": {
             "h": 6,
-            "w": 6,
+            "w": 3,
             "x": 0,
             "y": 1
           },
@@ -137,8 +137,8 @@ spec:
           },
           "gridPos": {
             "h": 6,
-            "w": 6,
-            "x": 6,
+            "w": 3,
+            "x": 3,
             "y": 1
           },
           "id": 2,
@@ -174,8 +174,8 @@ spec:
           "type": "stat"
         },
         {
-          "datasource": "openshift-monitoring",
-          "description": "The total amount of cpu requests that have been requested by ResourceQuotas currently active.\n\nMax value is total cores available on cluster.",
+          "datasource": "${datasource}",
+          "description": "CPU Requests alotted via Resource Quotas out of Available Cores on the cluster.\n\nMax value is the total cpu cores on worker nodes (if the cluster has only master nodes, then masters are taken into account instead).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -208,14 +208,15 @@ spec:
             "overrides": []
           },
           "gridPos": {
-            "h": 6,
+            "h": 3,
             "w": 6,
-            "x": 12,
+            "x": 6,
             "y": 1
           },
-          "id": 26,
+          "id": 29,
           "options": {
-            "orientation": "auto",
+            "displayMode": "gradient",
+            "orientation": "horizontal",
             "reduceOptions": {
               "calcs": [
                 "mean"
@@ -223,8 +224,7 @@ spec:
               "fields": "",
               "values": false
             },
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true,
+            "showUnfilled": true,
             "text": {}
           },
           "pluginVersion": "8.1.1",
@@ -239,7 +239,7 @@ spec:
             },
             {
               "exemplar": true,
-              "expr": "cluster:capacity_cpu_cores:sum{cluster=~\"$cluster\", label_node_role_kubernetes_io!~\".+\"}",
+              "expr": "cluster:capacity_cpu_cores:sum{cluster=~\"$cluster\", label_node_role_kubernetes_io!~\".+\"} OR on() cluster:capacity_cpu_cores:sum{cluster=\"$cluster\", label_node_role_kubernetes_io=\"master\"} ",
               "hide": false,
               "instant": true,
               "interval": "",
@@ -249,7 +249,7 @@ spec:
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Total CPU ResourceQuota",
+          "title": "Total ResourceQuota CPU Requests",
           "transformations": [
             {
               "id": "configFromData",
@@ -268,11 +268,11 @@ spec:
               }
             }
           ],
-          "type": "gauge"
+          "type": "bargauge"
         },
         {
-          "datasource": "openshift-monitoring",
-          "description": "Cores currently not in use. This does not take into account ResourceQuotas, rather -- it takes into account cores available for the scheduler to reserve for pods.",
+          "datasource": "${datasource}",
+          "description": "Cores currently not in use on Master nodes. This does not take into account ResourceQuotas, rather -- it takes into account cores available for the scheduler to reserve for pods.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -305,14 +305,15 @@ spec:
             "overrides": []
           },
           "gridPos": {
-            "h": 6,
+            "h": 3,
             "w": 6,
-            "x": 18,
+            "x": 12,
             "y": 1
           },
-          "id": 6,
+          "id": 34,
           "options": {
-            "orientation": "auto",
+            "displayMode": "gradient",
+            "orientation": "horizontal",
             "reduceOptions": {
               "calcs": [
                 "mean"
@@ -320,15 +321,14 @@ spec:
               "fields": "",
               "values": false
             },
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true,
+            "showUnfilled": true,
             "text": {}
           },
           "pluginVersion": "8.1.1",
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(cluster:capacity_cpu_cores:sum{cluster=\"$cluster\", label_node_role_kubernetes_io!~\".+\"}) - (sum(kube_pod_resource_request{cluster=\"$cluster\", resource=\"cpu\"} * on (node) group_left kube_node_role{cluster=\"$cluster\", role=\"worker\"}))",
+              "expr": "sum(cluster:capacity_cpu_cores:sum{cluster=\"$cluster\", label_node_role_kubernetes_io=\"master\"}) - (sum(kube_pod_resource_request{cluster=\"$cluster\", resource=\"cpu\"} * on (node) group_left kube_node_role{cluster=\"$cluster\", role=\"master\"}))",
               "instant": true,
               "interval": "",
               "legendFormat": "Free Cores",
@@ -336,7 +336,7 @@ spec:
             },
             {
               "exemplar": true,
-              "expr": "cluster:capacity_cpu_cores:sum{cluster=~\"$cluster\", label_node_role_kubernetes_io!~\".+\"}",
+              "expr": "cluster:capacity_cpu_cores:sum{cluster=~\"$cluster\", label_node_role_kubernetes_io=\"master\"}",
               "hide": false,
               "interval": "",
               "legendFormat": "Total Cores",
@@ -345,7 +345,7 @@ spec:
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Free Cores (Approx)",
+          "title": "Actual Free Cores (Master Nodes)",
           "transformations": [
             {
               "id": "configFromData",
@@ -364,56 +364,394 @@ spec:
               }
             }
           ],
-          "type": "gauge"
+          "type": "bargauge"
         },
         {
-          "aliasColors": {},
-          "breakPoint": "50%",
-          "cacheTimeout": null,
-          "combine": {
-            "label": "Others",
-            "threshold": ".01"
+          "datasource": "${datasource}",
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 60
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 90
+                  }
+                ]
+              }
+            },
+            "overrides": []
           },
-          "datasource": "$datasource",
-          "description": "This graph shows the sum of cpu being requested by pods per namespace. ",
-          "fontSize": "80%",
-          "format": "short",
           "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 7
+            "h": 3,
+            "w": 6,
+            "x": 18,
+            "y": 1
           },
-          "id": 10,
-          "interval": null,
-          "legend": {
-            "percentage": true,
-            "show": true,
-            "sort": null,
-            "sortDesc": null,
-            "values": true
+          "id": 37,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
           },
-          "legendType": "Right side",
-          "links": [],
-          "nullPointMode": "connected",
-          "pieType": "pie",
-          "pluginVersion": "7.1.1",
-          "strokeWidth": ".05",
+          "pluginVersion": "8.1.1",
           "targets": [
             {
               "exemplar": true,
-              "expr": "sort_desc(sum(kube_pod_resource_request{cluster=\"$cluster\", resource=\"cpu\"}) by (namespace))",
+              "expr": "sum(kube_pod_resource_limit{cluster=\"$cluster\", resource=\"cpu\"})",
               "instant": true,
               "interval": "",
-              "legendFormat": "{{namespace}}",
+              "legendFormat": "",
               "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(cluster:capacity_cpu_cores:sum{cluster=\"$cluster\"})",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total Cores",
+              "refId": "B"
             }
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Pod CPU Requests by Namespace",
-          "type": "grafana-piechart-panel",
-          "valueName": "current"
+          "title": "Total CPU Limits on Cluster",
+          "transformations": [
+            {
+              "id": "configFromData",
+              "options": {
+                "applyTo": {
+                  "id": "byName",
+                  "options": "Value"
+                },
+                "configRefId": "B",
+                "mappings": [
+                  {
+                    "fieldName": "Total Cores",
+                    "handlerKey": "max"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "bargauge"
+        },
+        {
+          "datasource": "${datasource}",
+          "description": "CPU Limits alotted via Resource Quotas out of Available Cores on the cluster.\n\nMax value is the total cpu cores on worker nodes (if the cluster has only master nodes, then masters are taken into account instead).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 60
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 90
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 6,
+            "y": 4
+          },
+          "id": 30,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
+          },
+          "pluginVersion": "8.1.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kube_resourcequota{cluster=\"$cluster\", type=\"hard\", resource=\"limits.cpu\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "cluster:capacity_cpu_cores:sum{cluster=~\"$cluster\", label_node_role_kubernetes_io!~\".+\"} OR on() cluster:capacity_cpu_cores:sum{cluster=\"$cluster\", label_node_role_kubernetes_io=\"master\"} ",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total Cores",
+              "refId": "B"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Total ResourceQuota CPU Limits",
+          "transformations": [
+            {
+              "id": "configFromData",
+              "options": {
+                "applyTo": {
+                  "id": "byName",
+                  "options": "Value"
+                },
+                "configRefId": "B",
+                "mappings": [
+                  {
+                    "fieldName": "Total Cores",
+                    "handlerKey": "max"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "bargauge"
+        },
+        {
+          "datasource": "${datasource}",
+          "description": "Cores currently not in use on Worker nodes. This does not take into account ResourceQuotas, rather -- it takes into account cores available for the scheduler to reserve for pods.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "dark-red",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 10
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 20
+                  },
+                  {
+                    "color": "green",
+                    "value": 30
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 12,
+            "y": 4
+          },
+          "id": 6,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
+          },
+          "pluginVersion": "8.1.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(cluster:capacity_cpu_cores:sum{cluster=\"$cluster\", label_node_role_kubernetes_io!~\".+\"}) - \n\n(sum(\n    kube_pod_resource_request{cluster=\"$cluster\", resource=\"cpu\"} \n    * on (node) group_left kube_node_role{cluster=\"$cluster\", role=\"worker\"})\n    )",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Free Cores",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "cluster:capacity_cpu_cores:sum{cluster=~\"$cluster\", label_node_role_kubernetes_io!~\".+\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total Cores",
+              "refId": "B"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Actual Free Cores (Workers)",
+          "transformations": [
+            {
+              "id": "configFromData",
+              "options": {
+                "applyTo": {
+                  "id": "byName",
+                  "options": "Free Cores"
+                },
+                "configRefId": "B",
+                "mappings": [
+                  {
+                    "fieldName": "Total Cores",
+                    "handlerKey": "max"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "bargauge"
+        },
+        {
+          "datasource": "${datasource}",
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 60
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 90
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 18,
+            "y": 4
+          },
+          "id": 36,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
+          },
+          "pluginVersion": "8.1.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kube_pod_resource_request{cluster=\"$cluster\", resource=\"cpu\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(cluster:capacity_cpu_cores:sum{cluster=\"$cluster\"})",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total Cores",
+              "refId": "B"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Total CPU Requests on Cluster",
+          "transformations": [
+            {
+              "id": "configFromData",
+              "options": {
+                "applyTo": {
+                  "id": "byName",
+                  "options": "Value"
+                },
+                "configRefId": "B",
+                "mappings": [
+                  {
+                    "fieldName": "Total Cores",
+                    "handlerKey": "max"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "bargauge"
         },
         {
           "aliasColors": {},
@@ -425,7 +763,101 @@ spec:
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
-            "h": 8,
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 7
+          },
+          "hiddenSeries": false,
+          "id": 38,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.1.1",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(cluster:capacity_cpu_cores:sum{cluster=\"$cluster\", label_node_role_kubernetes_io=\"master\"}) - (sum(kube_pod_resource_request{cluster=\"$cluster\", resource=\"cpu\"} * on (node) group_left kube_node_role{cluster=\"$cluster\", role=\"master\"}))",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "Free Cores",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Free Cores (Master)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:205",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:206",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${datasource}",
+          "description": "Cores currently not in use. This does not take into account ResourceQuotas, rather -- it takes into account cores available for the scheduler to reserve for pods.",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
             "w": 12,
             "x": 12,
             "y": 7
@@ -470,7 +902,7 @@ spec:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Free Cores (Approx)",
+          "title": "Free Cores (Workers)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -486,6 +918,7 @@ spec:
           },
           "yaxes": [
             {
+              "$$hashKey": "object:205",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -494,6 +927,7 @@ spec:
               "show": true
             },
             {
+              "$$hashKey": "object:206",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -516,6 +950,106 @@ spec:
             "threshold": ".01"
           },
           "datasource": "$datasource",
+          "description": "This graph shows the sum of cpu limits scheduled by pods per namespace. ",
+          "fontSize": "80%",
+          "format": "short",
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "id": 31,
+          "interval": null,
+          "legend": {
+            "percentage": true,
+            "show": true,
+            "sideWidth": 400,
+            "sort": null,
+            "sortDesc": null,
+            "values": true
+          },
+          "legendType": "Right side",
+          "links": [],
+          "nullPointMode": "connected",
+          "pieType": "pie",
+          "pluginVersion": "7.1.1",
+          "strokeWidth": ".05",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sort_desc(sum(kube_pod_resource_limit{cluster=\"$cluster\", resource=\"cpu\"}) by (namespace))",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{namespace}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Pod CPU Limits by Namespace",
+          "type": "grafana-piechart-panel",
+          "valueName": "current"
+        },
+        {
+          "aliasColors": {},
+          "breakPoint": "50%",
+          "cacheTimeout": null,
+          "combine": {
+            "label": "Others",
+            "threshold": ".01"
+          },
+          "datasource": "$datasource",
+          "description": "This graph shows the sum of cpu being requested by pods per namespace. ",
+          "fontSize": "80%",
+          "format": "short",
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "id": 10,
+          "interval": null,
+          "legend": {
+            "percentage": true,
+            "show": true,
+            "sideWidth": 400,
+            "sort": null,
+            "sortDesc": null,
+            "values": true
+          },
+          "legendType": "Right side",
+          "links": [],
+          "nullPointMode": "connected",
+          "pieType": "pie",
+          "pluginVersion": "7.1.1",
+          "strokeWidth": ".05",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sort_desc(sum(kube_pod_resource_request{cluster=\"$cluster\", resource=\"cpu\"}) by (namespace))",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{namespace}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Pod CPU Requests by Namespace",
+          "type": "grafana-piechart-panel",
+          "valueName": "current"
+        },
+        {
+          "aliasColors": {},
+          "breakPoint": "50%",
+          "cacheTimeout": null,
+          "combine": {
+            "label": "Others",
+            "threshold": ".01"
+          },
+          "datasource": "$datasource",
           "description": "This graph shows the sum of cpu being requested by resourcequotas. I.e. how much CPU can be requested per namespace in total.",
           "fontSize": "80%",
           "format": "short",
@@ -523,13 +1057,14 @@ spec:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 15
+            "y": 24
           },
           "id": 12,
           "interval": null,
           "legend": {
             "percentage": true,
             "show": true,
+            "sideWidth": 400,
             "sort": "current",
             "sortDesc": true,
             "values": true
@@ -543,7 +1078,7 @@ spec:
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(kube_resourcequota{cluster=\"$cluster\", type=\"hard\", resource=\"requests.cpu\", prometheus_replica=\"prometheus-k8s-1\"}) by (namespace)",
+              "expr": "sum(kube_resourcequota{cluster=\"$cluster\", type=\"hard\", resource=\"requests.cpu\"}) by (namespace)",
               "instant": true,
               "interval": "",
               "legendFormat": "{{namespace}}",
@@ -553,6 +1088,56 @@ spec:
           "timeFrom": null,
           "timeShift": null,
           "title": "CPU ResourceQuota (Requests) By Namespace",
+          "type": "grafana-piechart-panel",
+          "valueName": "current"
+        },
+        {
+          "aliasColors": {},
+          "breakPoint": "50%",
+          "cacheTimeout": null,
+          "combine": {
+            "label": "Others",
+            "threshold": ".01"
+          },
+          "datasource": "$datasource",
+          "description": "This graph shows the sum of cpu limits scheduled by resourcequotas. I.e. how much CPU Limits are alotted per namespace in total.",
+          "fontSize": "80%",
+          "format": "short",
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 24
+          },
+          "id": 32,
+          "interval": null,
+          "legend": {
+            "percentage": true,
+            "show": true,
+            "sideWidth": 400,
+            "sort": "current",
+            "sortDesc": true,
+            "values": true
+          },
+          "legendType": "Right side",
+          "links": [],
+          "nullPointMode": "connected",
+          "pieType": "pie",
+          "pluginVersion": "7.1.1",
+          "strokeWidth": ".05",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kube_resourcequota{cluster=\"$cluster\", type=\"hard\", resource=\"limits.cpu\"}) by (namespace)",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{namespace}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPU ResourceQuota (Limits) By Namespace",
           "type": "grafana-piechart-panel",
           "valueName": "current"
         },
@@ -588,8 +1173,8 @@ spec:
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 12,
-            "y": 15
+            "x": 0,
+            "y": 32
           },
           "id": 14,
           "options": {
@@ -633,13 +1218,89 @@ spec:
           "type": "table"
         },
         {
+          "datasource": "$datasource",
+          "description": "Approximate CPU Limits on each node by summing CPU limits on all PENDING and RUNNING pods.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 32
+          },
+          "id": 33,
+          "options": {
+            "frameIndex": 3,
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Value"
+              }
+            ]
+          },
+          "pluginVersion": "8.1.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sort(sum(sum(kube_pod_container_resource_limits{cluster=\"$cluster\", resource=\"cpu\"}) by (namespace, pod, node) * on (pod, namespace) group_left() (sum(kube_pod_status_phase{cluster=\"$cluster\", phase=~\"Pending|Running\"}) by (pod, namespace) == 1)) by (node))",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{node}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Total CPU Limits",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "names": [
+                    "node",
+                    "Value"
+                  ]
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
           "collapsed": true,
           "datasource": null,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 23
+            "y": 40
           },
           "id": 24,
           "panels": [
@@ -655,7 +1316,7 @@ spec:
                 "h": 8,
                 "w": 24,
                 "x": 0,
-                "y": 24
+                "y": 32
               },
               "hiddenSeries": false,
               "id": 16,
@@ -749,7 +1410,7 @@ spec:
                 "h": 8,
                 "w": 24,
                 "x": 0,
-                "y": 32
+                "y": 40
               },
               "hiddenSeries": false,
               "id": 18,
@@ -843,7 +1504,7 @@ spec:
                 "h": 8,
                 "w": 24,
                 "x": 0,
-                "y": 40
+                "y": 48
               },
               "hiddenSeries": false,
               "id": 20,
@@ -930,7 +1591,7 @@ spec:
           "type": "row"
         }
       ],
-      "refresh": "",
+      "refresh": false,
       "schemaVersion": 30,
       "style": "dark",
       "tags": [],
@@ -951,6 +1612,7 @@ spec:
             "name": "datasource",
             "options": [],
             "query": "prometheus",
+            "queryValue": "",
             "refresh": 1,
             "regex": "",
             "skipUrlSync": false,
@@ -986,12 +1648,12 @@ spec:
         ]
       },
       "time": {
-        "from": "now-6h",
-        "to": "now"
+        "from": "2021-11-16T21:13:55.693Z",
+        "to": "2021-11-16T21:23:55.693Z"
       },
       "timepicker": {},
       "timezone": "",
       "title": "Cluster CPU overview",
-      "uid": "nA4fwtvnz",
-      "version": 41
+      "uid": "nA4fwtvnzzdf3e",
+      "version": 9
     }

--- a/grafana/overlays/moc/smaug/dashboards/cluster-management/cluster-memory-overview.yaml
+++ b/grafana/overlays/moc/smaug/dashboards/cluster-management/cluster-memory-overview.yaml
@@ -33,8 +33,8 @@ spec:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 3,
-      "iteration": 1635277629445,
+      "id": 22,
+      "iteration": 1637097715045,
       "links": [],
       "panels": [
         {
@@ -46,14 +46,14 @@ spec:
             "x": 0,
             "y": 0
           },
-          "id": 22,
+          "id": 32,
           "panels": [],
           "title": "General",
           "type": "row"
         },
         {
           "datasource": "$datasource",
-          "description": "Total memory available on master nodes.",
+          "description": "Total Memory available on master nodes.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -77,11 +77,11 @@ spec:
           },
           "gridPos": {
             "h": 6,
-            "w": 6,
+            "w": 3,
             "x": 0,
             "y": 1
           },
-          "id": 28,
+          "id": 30,
           "options": {
             "colorMode": "value",
             "graphMode": "none",
@@ -139,11 +139,11 @@ spec:
           },
           "gridPos": {
             "h": 6,
-            "w": 6,
-            "x": 6,
+            "w": 3,
+            "x": 3,
             "y": 1
           },
-          "id": 2,
+          "id": 34,
           "options": {
             "colorMode": "value",
             "graphMode": "none",
@@ -176,8 +176,8 @@ spec:
           "type": "stat"
         },
         {
-          "datasource": "openshift-monitoring",
-          "description": "The total amount of memory requests that have been requested by ResourceQuotas currently active.\n\nMax value is total cores available on cluster.",
+          "datasource": "${datasource}",
+          "description": "Memory Requests alotted via Resource Quotas out of Available memory on the cluster.\n\nMax value is the total Memory on worker nodes (if the cluster has only master nodes, then masters are taken into account instead).",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -211,14 +211,15 @@ spec:
             "overrides": []
           },
           "gridPos": {
-            "h": 6,
+            "h": 3,
             "w": 6,
-            "x": 12,
+            "x": 6,
             "y": 1
           },
-          "id": 26,
+          "id": 36,
           "options": {
-            "orientation": "auto",
+            "displayMode": "gradient",
+            "orientation": "horizontal",
             "reduceOptions": {
               "calcs": [
                 "mean"
@@ -226,8 +227,7 @@ spec:
               "fields": "",
               "values": false
             },
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true,
+            "showUnfilled": true,
             "text": {}
           },
           "pluginVersion": "8.1.1",
@@ -242,7 +242,7 @@ spec:
             },
             {
               "exemplar": true,
-              "expr": "cluster:capacity_memory_bytes:sum{cluster=~\"$cluster\", label_node_role_kubernetes_io!~\".+\"}",
+              "expr": "cluster:capacity_memory_bytes:sum{cluster=~\"$cluster\", label_node_role_kubernetes_io!~\".+\"} OR on() cluster:capacity_memory_bytes:sum{cluster=\"$cluster\", label_node_role_kubernetes_io=\"master\"} ",
               "hide": false,
               "instant": true,
               "interval": "",
@@ -252,7 +252,7 @@ spec:
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Total Memory ResourceQuota",
+          "title": "Total ResourceQuota Memory Requests",
           "transformations": [
             {
               "id": "configFromData",
@@ -271,11 +271,11 @@ spec:
               }
             }
           ],
-          "type": "gauge"
+          "type": "bargauge"
         },
         {
-          "datasource": "openshift-monitoring",
-          "description": "Memory currently not in use. This does not take into account ResourceQuotas, rather -- it takes into account memory available for the scheduler to reserve for pods.",
+          "datasource": "${datasource}",
+          "description": "Memory currently not in use on Master nodes. This does not take into account ResourceQuotas, rather -- it takes into account memory available for the scheduler to reserve for pods.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -309,14 +309,15 @@ spec:
             "overrides": []
           },
           "gridPos": {
-            "h": 6,
+            "h": 3,
             "w": 6,
-            "x": 18,
+            "x": 12,
             "y": 1
           },
-          "id": 6,
+          "id": 40,
           "options": {
-            "orientation": "auto",
+            "displayMode": "gradient",
+            "orientation": "horizontal",
             "reduceOptions": {
               "calcs": [
                 "mean"
@@ -324,15 +325,14 @@ spec:
               "fields": "",
               "values": false
             },
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true,
+            "showUnfilled": true,
             "text": {}
           },
           "pluginVersion": "8.1.1",
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(cluster:capacity_memory_bytes:sum{cluster=\"$cluster\", label_node_role_kubernetes_io!~\".+\"}) - (sum(kube_pod_resource_request{cluster=\"$cluster\", resource=\"memory\"} * on (node) group_left kube_node_role{cluster=\"$cluster\", role=\"worker\"}))",
+              "expr": "sum(cluster:capacity_memory_bytes:sum{cluster=\"$cluster\", label_node_role_kubernetes_io=\"master\"}) - (sum(kube_pod_resource_request{cluster=\"$cluster\", resource=\"memory\"} * on (node) group_left kube_node_role{cluster=\"$cluster\", role=\"master\"}))",
               "instant": true,
               "interval": "",
               "legendFormat": "Free Cores",
@@ -340,7 +340,7 @@ spec:
             },
             {
               "exemplar": true,
-              "expr": "cluster:capacity_memory_bytes:sum{cluster=~\"$cluster\", label_node_role_kubernetes_io!~\".+\"}",
+              "expr": "cluster:capacity_memory_bytes:sum{cluster=~\"$cluster\", label_node_role_kubernetes_io=\"master\"}",
               "hide": false,
               "interval": "",
               "legendFormat": "Total Cores",
@@ -349,7 +349,7 @@ spec:
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Free Memory (Approx)",
+          "title": "Actual Free Memory (Master Nodes)",
           "transformations": [
             {
               "id": "configFromData",
@@ -368,7 +368,586 @@ spec:
               }
             }
           ],
-          "type": "gauge"
+          "type": "bargauge"
+        },
+        {
+          "datasource": "${datasource}",
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 60
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 18,
+            "y": 1
+          },
+          "id": 46,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
+          },
+          "pluginVersion": "8.1.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kube_pod_resource_request{cluster=\"$cluster\", resource=\"memory\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(cluster:capacity_memory_bytes:sum{cluster=\"$cluster\"})",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total Cores",
+              "refId": "B"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Total Memory Requests on Cluster",
+          "transformations": [
+            {
+              "id": "configFromData",
+              "options": {
+                "applyTo": {
+                  "id": "byName",
+                  "options": "Value"
+                },
+                "configRefId": "B",
+                "mappings": [
+                  {
+                    "fieldName": "Total Cores",
+                    "handlerKey": "max"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "bargauge"
+        },
+        {
+          "datasource": "${datasource}",
+          "description": "Memory Limits alotted via Resource Quotas out of Available Memory on the cluster.\n\nMax value is the total Memory on worker nodes (if the cluster has only master nodes, then masters are taken into account instead).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 60
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 6,
+            "y": 4
+          },
+          "id": 38,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
+          },
+          "pluginVersion": "8.1.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kube_resourcequota{cluster=\"$cluster\", type=\"hard\", resource=\"limits.memory\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "cluster:capacity_memory_bytes:sum{cluster=~\"$cluster\", label_node_role_kubernetes_io!~\".+\"} OR on() cluster:capacity_memory_bytes:sum{cluster=\"$cluster\", label_node_role_kubernetes_io=\"master\"} ",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total Cores",
+              "refId": "B"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Total ResourceQuota Memory Limits",
+          "transformations": [
+            {
+              "id": "configFromData",
+              "options": {
+                "applyTo": {
+                  "id": "byName",
+                  "options": "Value"
+                },
+                "configRefId": "B",
+                "mappings": [
+                  {
+                    "fieldName": "Total Cores",
+                    "handlerKey": "max"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "bargauge"
+        },
+        {
+          "datasource": "${datasource}",
+          "description": "Memory currently not in use on Worker nodes. This does not take into account ResourceQuotas, rather -- it takes into account memory available for the scheduler to reserve for pods.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "dark-red",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 10
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 20
+                  },
+                  {
+                    "color": "green",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 12,
+            "y": 4
+          },
+          "id": 42,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
+          },
+          "pluginVersion": "8.1.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(cluster:capacity_memory_bytes:sum{cluster=\"$cluster\", label_node_role_kubernetes_io!~\".+\"}) - \n(sum(kube_pod_resource_request{cluster=\"$cluster\", resource=\"memory\"} * on (node) group_left kube_node_role{cluster=\"$cluster\", role=\"worker\"}))",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Free Cores",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "cluster:capacity_memory_bytes:sum{cluster=~\"$cluster\", label_node_role_kubernetes_io!~\".+\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total Cores",
+              "refId": "B"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Actual Free Memory (Workers)",
+          "transformations": [
+            {
+              "id": "configFromData",
+              "options": {
+                "applyTo": {
+                  "id": "byName",
+                  "options": "Free Cores"
+                },
+                "configRefId": "B",
+                "mappings": [
+                  {
+                    "fieldName": "Total Cores",
+                    "handlerKey": "max"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "bargauge"
+        },
+        {
+          "datasource": "${datasource}",
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 60
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 90
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 18,
+            "y": 4
+          },
+          "id": 44,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
+          },
+          "pluginVersion": "8.1.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kube_pod_resource_limit{cluster=\"$cluster\", resource=\"memory\"})",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(cluster:capacity_memory_bytes:sum{cluster=\"$cluster\"})",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total Cores",
+              "refId": "B"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Total Memory Limits on Cluster",
+          "transformations": [
+            {
+              "id": "configFromData",
+              "options": {
+                "applyTo": {
+                  "id": "byName",
+                  "options": "Value"
+                },
+                "configRefId": "B",
+                "mappings": [
+                  {
+                    "fieldName": "Total Cores",
+                    "handlerKey": "max"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "bargauge"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${datasource}",
+          "description": "Memory currently not in use. This does not take into account ResourceQuotas, rather -- it takes into account cores available for the scheduler to reserve for pods.",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 7
+          },
+          "hiddenSeries": false,
+          "id": 48,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.1.1",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(cluster:capacity_memory_bytes:sum{cluster=\"$cluster\", label_node_role_kubernetes_io=\"master\"}) - (sum(kube_pod_resource_request{cluster=\"$cluster\", resource=\"memory\"} * on (node) group_left kube_node_role{cluster=\"$cluster\", role=\"master\"}))",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "Free Cores",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Free Memory (Master)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:205",
+              "format": "decbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:206",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${datasource}",
+          "description": "Memory currently not in use. This does not take into account ResourceQuotas, rather -- it takes into account cores available for the scheduler to reserve for pods.",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 7
+          },
+          "hiddenSeries": false,
+          "id": 50,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.1.1",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(cluster:capacity_memory_bytes:sum{cluster=\"$cluster\", label_node_role_kubernetes_io!~\".+\"}) - (sum(kube_pod_resource_request{cluster=\"$cluster\", resource=\"memory\"} * on (node) group_left kube_node_role{cluster=\"$cluster\", role=\"worker\"}))",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "Free Cores",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Free Memory (Workers)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:205",
+              "format": "decbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:206",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},
@@ -379,20 +958,71 @@ spec:
             "threshold": ".01"
           },
           "datasource": "$datasource",
-          "description": "This graph shows the sum of memory being requested by pods per namespace. ",
+          "description": "This graph shows the sum of Memory limits scheduled by pods per namespace. ",
           "fontSize": "80%",
           "format": "decbytes",
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 7
+            "y": 16
           },
-          "id": 10,
+          "id": 52,
           "interval": null,
           "legend": {
             "percentage": true,
             "show": true,
+            "sideWidth": 400,
+            "sort": null,
+            "sortDesc": null,
+            "values": true
+          },
+          "legendType": "Right side",
+          "links": [],
+          "nullPointMode": "connected",
+          "pieType": "pie",
+          "pluginVersion": "7.1.1",
+          "strokeWidth": ".05",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sort_desc(sum(kube_pod_resource_limit{cluster=\"$cluster\", resource=\"memory\"}) by (namespace))",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{namespace}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Pod Memory Limits by Namespace",
+          "type": "grafana-piechart-panel",
+          "valueName": "current"
+        },
+        {
+          "aliasColors": {},
+          "breakPoint": "50%",
+          "cacheTimeout": null,
+          "combine": {
+            "label": "Others",
+            "threshold": ".01"
+          },
+          "datasource": "$datasource",
+          "description": "This graph shows the sum of Memory being requested by pods per namespace. ",
+          "fontSize": "80%",
+          "format": "decbytes",
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "id": 54,
+          "interval": null,
+          "legend": {
+            "percentage": true,
+            "show": true,
+            "sideWidth": 400,
             "sort": null,
             "sortDesc": null,
             "values": true
@@ -420,93 +1050,6 @@ spec:
           "valueName": "current"
         },
         {
-          "datasource": "${datasource}",
-          "description": "Memory currently not in use. This does not take into account ResourceQuotas, rather -- it takes into account memory available for the scheduler to reserve for pods.",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": true,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "decbytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 7
-          },
-          "id": 8,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "single"
-            }
-          },
-          "pluginVersion": "8.1.1",
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "sum(cluster:capacity_memory_bytes:sum{cluster=\"$cluster\", label_node_role_kubernetes_io!~\".+\"}) - (sum(kube_pod_resource_request{cluster=\"$cluster\", resource=\"memory\"} * on (node) group_left kube_node_role{cluster=\"$cluster\", role=\"worker\"}))",
-              "instant": false,
-              "interval": "",
-              "legendFormat": "Free Cores",
-              "refId": "A"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Free Memory (Approx)",
-          "type": "timeseries"
-        },
-        {
           "aliasColors": {},
           "breakPoint": "50%",
           "cacheTimeout": null,
@@ -515,20 +1058,21 @@ spec:
             "threshold": ".01"
           },
           "datasource": "$datasource",
-          "description": "This graph shows the sum of memory being requested by resourcequotas. I.e. how much memory can be requested per namespace in total.",
+          "description": "This graph shows the sum of Memory being requested by resourcequotas. I.e. how much Memory can be requested per namespace in total.",
           "fontSize": "80%",
           "format": "decbytes",
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 15
+            "y": 24
           },
-          "id": 12,
+          "id": 56,
           "interval": null,
           "legend": {
             "percentage": true,
             "show": true,
+            "sideWidth": 400,
             "sort": "current",
             "sortDesc": true,
             "values": true
@@ -556,8 +1100,135 @@ spec:
           "valueName": "current"
         },
         {
+          "aliasColors": {},
+          "breakPoint": "50%",
+          "cacheTimeout": null,
+          "combine": {
+            "label": "Others",
+            "threshold": ".01"
+          },
           "datasource": "$datasource",
-          "description": "Approximate memory requests on each node by summing memory requests on all PENDING and RUNNING pods.",
+          "description": "This graph shows the sum of Memory limits scheduled by resourcequotas. I.e. how much Memory Limits are alotted per namespace in total.",
+          "fontSize": "80%",
+          "format": "decbytes",
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 24
+          },
+          "id": 58,
+          "interval": null,
+          "legend": {
+            "percentage": true,
+            "show": true,
+            "sideWidth": 400,
+            "sort": "current",
+            "sortDesc": true,
+            "values": true
+          },
+          "legendType": "Right side",
+          "links": [],
+          "nullPointMode": "connected",
+          "pieType": "pie",
+          "pluginVersion": "7.1.1",
+          "strokeWidth": ".05",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kube_resourcequota{cluster=\"$cluster\", type=\"hard\", resource=\"limits.memory\"}) by (namespace)",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{namespace}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Memory ResourceQuota (Limits) By Namespace",
+          "type": "grafana-piechart-panel",
+          "valueName": "current"
+        },
+        {
+          "datasource": "$datasource",
+          "description": "Approximate Memory requests on each node by summing Memory requests on all PENDING and RUNNING pods.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 32
+          },
+          "id": 60,
+          "options": {
+            "frameIndex": 3,
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Value"
+              }
+            ]
+          },
+          "pluginVersion": "8.1.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sort(sum(sum(kube_pod_container_resource_requests{cluster=\"$cluster\", resource=\"memory\"}) by (namespace, pod, node) * on (pod, namespace) group_left() (sum(kube_pod_status_phase{cluster=\"$cluster\", phase=~\"Pending|Running\"}) by (pod, namespace) == 1)) by (node))",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{node}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Total Memory Requests",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "names": [
+                    "node",
+                    "Value"
+                  ]
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": "$datasource",
+          "description": "Approximate Memory Limits on each node by summing Memory limits on all PENDING and RUNNING pods.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -589,9 +1260,9 @@ spec:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 15
+            "y": 32
           },
-          "id": 14,
+          "id": 62,
           "options": {
             "frameIndex": 3,
             "showHeader": true,
@@ -606,7 +1277,7 @@ spec:
           "targets": [
             {
               "exemplar": true,
-              "expr": "sort(sum(sum(kube_pod_container_resource_requests{cluster=\"$cluster\", resource=\"memory\"}) by (namespace, pod, node) * on (pod, namespace) group_left() (sum(kube_pod_status_phase{cluster=\"$cluster\", phase=~\"Pending|Running\"}) by (pod, namespace) == 1)) by (node))",
+              "expr": "sort(sum(sum(kube_pod_container_resource_limits{cluster=\"$cluster\", resource=\"memory\"}) by (namespace, pod, node) * on (pod, namespace) group_left() (sum(kube_pod_status_phase{cluster=\"$cluster\", phase=~\"Pending|Running\"}) by (pod, namespace) == 1)) by (node))",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -616,7 +1287,7 @@ spec:
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Total CPU Requests",
+          "title": "Total Memory Limits",
           "transformations": [
             {
               "id": "filterFieldsByName",
@@ -641,9 +1312,9 @@ spec:
         "list": [
           {
             "current": {
-              "selected": false,
-              "text": "openshift-monitoring",
-              "value": "openshift-monitoring"
+              "selected": true,
+              "text": "aws-balrog-monitoring",
+              "value": "aws-balrog-monitoring"
             },
             "description": null,
             "error": null,
@@ -654,6 +1325,7 @@ spec:
             "name": "datasource",
             "options": [],
             "query": "prometheus",
+            "queryValue": "",
             "refresh": 1,
             "regex": "",
             "skipUrlSync": false,
@@ -663,8 +1335,8 @@ spec:
             "allValue": null,
             "current": {
               "selected": false,
-              "text": "moc/smaug",
-              "value": "moc/smaug"
+              "text": "emea/balrog",
+              "value": "emea/balrog"
             },
             "datasource": "${datasource}",
             "definition": "label_values(kubelet_node_name, cluster)",
@@ -696,5 +1368,5 @@ spec:
       "timezone": "",
       "title": "Cluster Memory overview",
       "uid": "ucHWsaF7i",
-      "version": 6
+      "version": 3
     }


### PR DESCRIPTION
This updates the charts here: 
https://grafana.operate-first.cloud/d/ucHWsaF7i/cluster-memory-overview?orgId=1
https://grafana.operate-first.cloud/d/nA4fwtvnzzdf3e/cluster-cpu-overview?orgId=1