### PR TITLE
Use odh admin group for superset admins over cluster admins group.

### DIFF
--- a/cluster-scope/overlays/prod/osc/osc-cl1/groups/odh-admin.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/groups/odh-admin.yaml
@@ -7,8 +7,6 @@ users:
   - HumairAK
   - erikerlandson
   - 4n4nd
-  - tumido
-  - guimou
   - rimolive
   - caldeirav
   - myeung18

--- a/cluster-scope/overlays/prod/osc/osc-cl1/groups/odh-users.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/groups/odh-users.yaml
@@ -10,3 +10,4 @@ users:
   - aakankshaduggal
   - hemajv
   - MichaelTiemannOSC
+  - guimou

--- a/odh-manifests/osc-cl1/superset/base/secret.yaml
+++ b/odh-manifests/osc-cl1/superset/base/secret.yaml
@@ -29,7 +29,7 @@ stringData:
     AUTH_ROLES_MAPPING = {
         "odh-users": ["Admin"],
         "system:authenticated": ["Alpha"],
-        "odh-cluster-admins": ["Admin"],
+        "odh-admin": ["Admin"],
     }
     # if we should replace ALL the user's roles each login, or only on registration
     AUTH_ROLES_SYNC_AT_LOGIN = True


### PR DESCRIPTION
This will allow issues [like this](https://github.com/os-climate/os_c_data_commons/issues/103?notification_referrer_id=NT_kwDOAKZlh7MyNzM5MDc2NjA4OjEwOTA0OTY3#event-5676223043) to be self serviced by those in the `odh-admin` group. 