### PR TITLE
Add dev trino instance to osc-cl1.

### DIFF
--- a/cloudbeaver/overlays/osc/osc-cl1/configs/initial-data-sources.conf
+++ b/cloudbeaver/overlays/osc/osc-cl1/configs/initial-data-sources.conf
@@ -1,36 +1,6 @@
 {
     "folders": {},
     "connections": {
-        "sqlite_xerial-sample-database": {
-            "provider": "generic",
-            "driver": "sqlite_jdbc",
-            "name": "SQLite - Chinook (Sample)",
-            "save-password": true,
-            "read-only": false,
-            "configuration": {
-                "database": "${application.path}/../samples/db/Chinook.sqlitedb",
-                "type": "dev",
-                "auth-model": "native"
-            }
-        },
-        "postgresql-template-1": {
-            "provider": "postgresql",
-            "driver": "postgres-jdbc",
-            "name": "PostgreSQL (Template)",
-            "save-password": false,
-            "template": true,
-            "read-only": true,
-            "configuration": {
-                "host": "localhost",
-                "port": "5432",
-                "database": "postgres",
-                "url": "jdbc:postgresql://localhost:5432/postgres",
-                "type": "dev",
-                "provider-properties": {
-                    "@dbeaver-show-non-default-db@": "false"
-                }
-            }
-        },
         "trino_operate_first": {
             "provider": "generic",
             "driver": "trino_jdbc",
@@ -49,7 +19,26 @@
                 },
                 "auth-model": "native"
             }
+        },
+      "trino_operate_first_dev": {
+        "provider": "generic",
+        "driver": "trino_jdbc",
+        "name": "ODH Trino Dev",
+        "save-password": true,
+        "show-system-objects": true,
+        "read-only": false,
+        "configuration": {
+          "host": "trino-secure-odh-trino-dev.apps.odh-cl1.apps.os-climate.org",
+          "port": "443",
+          "url": "jdbc:trino://trino-secure-odh-trino-dev.apps.odh-cl1.apps.os-climate.org:443",
+          "type": "dev",
+          "properties": {
+            "SSLVerification": "FULL",
+            "SSL": "true"
+          },
+          "auth-model": "native"
         }
+      }
     },
     "connection-types": {
         "dev": {

--- a/cluster-scope/base/core/namespaces/odh-trino-dev/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/odh-trino-dev/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+components:
+  - ../../../../components/project-admin-rolebindings/odh-admin
+  - ../../../../components/limitranges/default
+namespace: odh-trino-dev

--- a/cluster-scope/base/core/namespaces/odh-trino-dev/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/odh-trino-dev/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: odh-trino-dev
+    annotations:
+        openshift.io/requester: odh-admin

--- a/cluster-scope/overlays/prod/osc/osc-cl1/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ../../../../base/core/namespaces/odh-seldon
   - ../../../../base/core/namespaces/odh-superset
   - ../../../../base/core/namespaces/odh-trino
+  - ../../../../base/core/namespaces/odh-trino-dev
   - ../../../../base/core/namespaces/sandbox
   - ../../../../base/operators.coreos.com/subscriptions/cert-manager
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator

--- a/dex/overlays/osc/osc-cl1/dex-clients.enc.yaml
+++ b/dex/overlays/osc/osc-cl1/dex-clients.enc.yaml
@@ -7,13 +7,14 @@ metadata:
 stringData:
     SUPERSET_SECRET: ENC[AES256_GCM,data:fSPCyYDsZpUQ6feMJJS84hfc9c1M1c4B8AWMkSlyDeo8zun7NW5kVZtVQhffRGicZtkKzTgPfOUS/5EEnZpHDw==,iv:kjDZu6tsifWW2GfDBmHiEdsiD8TfT7dtmeAtsTdqjls=,tag:Dsv4u9ayHgntNl5qADtBOw==,type:str]
     TRINO_SECRET: ENC[AES256_GCM,data:2NjyvL7O/TZcYJX0xBOCSCsoC5vlMZMPthu7rok6/xmlFO/p9sL/V51MZZgfnh/GUv1nj7lmuLWpGw0juqAesA==,iv:X1UTYquhIwSLFK3l3BRTE70qyaiKEB7m9SF407IRPbI=,tag:wNwyt4Bje0dx1VvnfJ2WxQ==,type:str]
+    TRINO_DEV_SECRET: ENC[AES256_GCM,data:drbA5u9fAHCVFPchAhGIGYhNjbHxcyML9nXY27Nv3adKqiAosGWuYyLv8LlhgZU7ZnpHpgywuL1AfLjhRASdOA==,iv:IPAhrVdd3YWcgXVFhS9vtIeorhZT1P2vKDVilbDO6Ao=,tag:6dBNgpdweqSozkWFK4Brwg==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2021-08-23T21:08:55Z'
-    mac: ENC[AES256_GCM,data:WueKJxXbPEpmKmpbvuDO0kgGUsNrPhpGl7UrKccQoNyAfo0Oa2rhySCUgXgoPfJ4nUHc7DZM3cQx9aflmqR7TIf6ke2e/hLkikOafqD7HYuUo6gIkAK71Rcr3tAPvzE7qd3RoY2uGUwndA9Qoye1oTgJ6XNLvz0ZEhHuHMY2Jmw=,iv:mshZjD2zRqafRnKFjplVoCJyoi0XVtkrIsRwEb7QweA=,tag:ACDTgNc/EaFcH2HwHYXHEQ==,type:str]
+    lastmodified: '2021-11-26T15:40:42Z'
+    mac: ENC[AES256_GCM,data:THdi37bEk8DKkS9+A/IHIviT4zuTo1ukV5UqZBW4BPCq4U+zVZ6nqjArXD3+h7tWFHt+AprFvdwZOadHKwgzHcgf3eDR8DEMErx7z/L43NBP1+Mhkm5yq7M/9rthCEgV8NSAb8QjPqjSJDuElY4a8yaRQRAGWcNdvW8vMZYSHf8=,iv:JZcd1qb6yVFP9120SL7+B0btcpTSPmzMqvZ6cLCfKEQ=,tag:Cic5xqD3+EMZfg7eBYuvkA==,type:str]
     pgp:
     -   created_at: '2021-08-23T21:08:55Z'
         enc: |-

--- a/dex/overlays/osc/osc-cl1/dex-cm.yaml
+++ b/dex/overlays/osc/osc-cl1/dex-cm.yaml
@@ -38,6 +38,13 @@ data:
           - https://trino-route-odh-trino.apps.odh-cl1.apps.os-climate.org
         secretEnv: TRINO_SECRET
 
+      - id: trino-dev
+        name: Trino
+        redirectURIs:
+          - https://trino-secure-odh-trino-dev.apps.odh-cl1.apps.os-climate.org/oauth2/callback
+          - https://trino-route-odh-trino-dev.apps.odh-cl1.apps.os-climate.org
+        secretEnv: TRINO_DEV_SECRET
+
       - id: das
         name: Dex Auth Service
         redirectURIs:

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/access-control.properties
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/access-control.properties
@@ -1,0 +1,2 @@
+access-control.name=file
+security.config-file=/etc/trino/rules.json

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/catalogs/osc_datacommons_dev.properties
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/catalogs/osc_datacommons_dev.properties
@@ -1,0 +1,14 @@
+connector.name=hive-hadoop2
+hive.metastore.uri=thrift://hive-metastore-osc-datacommons-dev:9083
+hive.s3.endpoint=${ENV:OSC_DATACOMMONS_DEV_S3_ENDPOINT_URL_PREFIX}${ENV:OSC_DATACOMMONS_DEV_S3_ENDPOINT}
+hive.s3.signer-type=S3SignerType
+hive.s3.path-style-access=true
+hive.s3.staging-directory=/tmp
+hive.s3.ssl.enabled=false
+hive.s3.sse.enabled=false
+hive.allow-drop-table=true
+hive.parquet.use-column-names=true
+hive.recursive-directories=true
+hive.non-managed-table-writes-enabled=true
+hive.s3.aws-access-key=${ENV:OSC_DATACOMMONS_DEV_AWS_ACCESS_KEY_ID}
+hive.s3.aws-secret-key=${ENV:OSC_DATACOMMONS_DEV_AWS_SECRET_ACCESS_KEY}

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/config-coordinator.properties
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/config-coordinator.properties
@@ -1,0 +1,17 @@
+coordinator=true
+node-scheduler.include-coordinator=false
+discovery.uri=http://localhost:8080
+web-ui.authentication.type=oauth2
+http-server.authentication.type=PASSWORD,oauth2
+http-server.process-forwarded=true
+http-server.http.port=8080
+http-server.authentication.oauth2.issuer=http://dex-dex.apps.odh-cl1.apps.os-climate.org
+http-server.authentication.oauth2.auth-url=http://dex-dex.apps.odh-cl1.apps.os-climate.org/auth
+http-server.authentication.oauth2.token-url=http://dex-dex.apps.odh-cl1.apps.os-climate.org/token
+http-server.authentication.oauth2.jwks-url=http://dex-dex.apps.odh-cl1.apps.os-climate.org/keys
+http-server.authentication.oauth2.userinfo-url=http://dex-dex.apps.odh-cl1.apps.os-climate.org/userinfo
+http-server.authentication.oauth2.client-id=trino-dev
+http-server.authentication.oauth2.client-secret=${ENV:TRINO_OAUTH_SECRET}
+http-server.authentication.oauth2.scopes=openid,groups,email
+http-server.authentication.oauth2.principal-field=email
+http-server.authentication.oauth2.additional-audiences=das

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/config-worker.properties
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/config-worker.properties
@@ -1,0 +1,3 @@
+coordinator=false
+http-server.http.port=8080
+discovery.uri=http://trino-service:8080

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/group-mapping.properties
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/group-mapping.properties
@@ -1,0 +1,1 @@
+admins:admin,erikerlandson,caldeirav,HumairAK,MichaelTiemannOSC

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/group-provider.properties
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/group-provider.properties
@@ -1,0 +1,2 @@
+group-provider.name=file
+file.group-file=/etc/trino/group-mapping.properties

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/jmx.properties
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/jmx.properties
@@ -1,0 +1,1 @@
+connector.name=jmx

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/jvm.config
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/jvm.config
@@ -1,0 +1,13 @@
+-server
+-Xmx16G
+-XX:-UseBiasedLocking
+-XX:+UseG1GC
+-XX:G1HeapRegionSize=32M
+-XX:+ExplicitGCInvokesConcurrent
+-XX:+ExitOnOutOfMemoryError
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:ReservedCodeCacheSize=512M
+-XX:PerMethodRecompilationCutoff=10000
+-XX:PerBytecodeRecompilationCutoff=10000
+-Djdk.attach.allowAttachSelf=true
+-Djdk.nio.maxCachedBufferSize=2000000

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/kustomization.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: trino-catalog
+    files:
+      - jmx.properties
+      - catalogs/osc_datacommons_dev.properties
+  - name: trino-config
+    files:
+      - config-coordinator.properties
+      - config-worker.properties
+      - jvm.config
+      - log.properties
+      - node.properties
+      - password-authenticator.properties
+      - password.db
+      - group-provider.properties
+      - group-mapping.properties
+      - access-control.properties
+      - rules.json

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/log.properties
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/log.properties
@@ -1,0 +1,1 @@
+io.trino=INFO

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/node.properties
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/node.properties
@@ -1,0 +1,2 @@
+node.environment=$(trino_environment)
+node.data-dir=/tmp/data/trino

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/password-authenticator.properties
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/password-authenticator.properties
@@ -1,0 +1,2 @@
+password-authenticator.name=file
+file.password-file=/etc/trino/password.db

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/password.db
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/password.db
@@ -1,0 +1,1 @@
+admin:$2y$10$mD/NvdrRynfW.gp6QvvAfe/49lF3F67LmeF9wp0a7vpByRclVnMrm

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/rules.json
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/rules.json
@@ -1,0 +1,20 @@
+{
+  "catalogs": [
+    {
+      "group": "admins",
+      "allow": "all"
+    }
+  ],
+  "schemas": [
+    {
+      "group": "admins",
+      "owner": true
+    }
+  ],
+  "tables": [
+    {
+      "group": "admins",
+      "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP"]
+    }
+  ]
+}

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/hive-metastores/OSC_DataCommons_Dev/kustomization.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/hive-metastores/OSC_DataCommons_Dev/kustomization.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../../../base/trino/hive-metastore-template
+patches:
+  - target:
+      kind: Service
+      name: catalog-name
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: hive-metastore-osc-datacommons-dev
+      - op: replace
+        path: /metadata/labels/trino-catalog
+        value: hive-metastore-osc-datacommons-dev
+      - op: replace
+        path: /spec/selector/trino-catalog
+        value: hive-metastore-osc-datacommons-dev
+  - target:
+      kind: StatefulSet
+      name: catalog-name
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: hive-metastore-osc-datacommons-dev
+      - op: replace
+        path: /metadata/labels/trino-catalog
+        value: hive-metastore-osc-datacommons-dev
+      - op: replace
+        path: /spec/selector/matchLabels/trino-catalog
+        value: hive-metastore-osc-datacommons-dev
+      - op: replace
+        path: /spec/serviceName
+        value: hive-metastore-osc-datacommons-dev
+      - op: replace
+        path: /spec/template/metadata/labels/trino-catalog
+        value: hive-metastore-osc-datacommons-dev
+      - op: replace
+        path: /spec/selector/matchLabels/trino-catalog
+        value: hive-metastore-osc-datacommons-dev
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: S3_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              key: OSC_DATACOMMONS_DEV_S3_ENDPOINT
+              name: s3buckets
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: S3_ENDPOINT_URL_PREFIX
+          valueFrom:
+            secretKeyRef:
+              key: OSC_DATACOMMONS_DEV_S3_ENDPOINT_URL_PREFIX
+              name: s3buckets
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: OSC_DATACOMMONS_DEV_AWS_ACCESS_KEY_ID
+              name: s3buckets
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: OSC_DATACOMMONS_DEV_AWS_SECRET_ACCESS_KEY
+              name: s3buckets
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: S3_BUCKET_NAME
+          valueFrom:
+            secretKeyRef:
+              key: OSC_DATACOMMONS_DEV_BUCKET
+              name: s3buckets
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: S3_DATA_DIR
+          value: "data"

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/hive-metastores/kustomization.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/hive-metastores/kustomization.yaml
@@ -1,9 +1,6 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: odh-trino-dev
 resources:
-  - jupyterhub
-  - seldon
-  - superset
-  - trino
-  - trino-dev
+  - OSC_DataCommons_Dev

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/kfdef.yaml
@@ -1,0 +1,38 @@
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  annotations:
+    kfctl.kubeflow.io/force-delete: "false"
+    kfdef-version: '2'
+  name: opendatahub
+  namespace: odh-trino-dev
+spec:
+  applications:
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-common
+      name: odh-common
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: trino
+      name: trino
+    - kustomizeConfig:
+        parameters:
+          - name: s3_endpoint_url
+            value: s3.us-east-1.amazonaws.com
+          - name: s3_credentials_secret
+            value: odh-datacatalog-bucket
+          - name: trino_image
+            value: quay.io/opendatahub/trino:362
+        repoRef:
+          name: opf
+          path: odh-manifests/osc-cl1/trino-dev
+      name: trino
+  repos:
+    - name: manifests
+      uri: https://github.com/opendatahub-io/odh-manifests/tarball/v1.1.0
+    - name: opf
+      uri: https://github.com/operate-first/apps/tarball/master
+  version: v1.1.0

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/kustomization.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: odh-trino-dev
+resources:
+  - kfdef.yaml
+  - secure-route.yaml
+  - secrets
+  - hive-metastores
+  - configs
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/secrets/kustomization.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - secret-generator.yaml

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/secrets/s3buckets.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/secrets/s3buckets.yaml
@@ -1,0 +1,44 @@
+kind: Secret
+apiVersion: v1
+metadata:
+    name: s3buckets
+    namespace: odh-trino
+stringData:
+    OSC_DATACOMMONS_DEV_BUCKET: ENC[AES256_GCM,data:qr9zcG+039fBzpFvoTDBV3+K,iv:x4sKlaASPGl59cmgxivXgsV1+kwuLY0eB2KJsuHsATM=,tag:tg29R0rJP7ljjbAM9txCLw==,type:str]
+    OSC_DATACOMMONS_DEV_AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:qtxGTP9TYKOY0Q5sU53+r7A9JyY=,iv:uRrBwn83XsKt8JtnieVY8B4v2oHTwWF2kYQ0p1adChQ=,tag:9MAg+NaPAJgd6JQSSHA45A==,type:str]
+    OSC_DATACOMMONS_DEV_AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:9GVRdfHScFFKrEdk8fxINWqDLYANME6rIwaY6HKJYTyO8O5VQZ55jQ==,iv:GGSw3Pg58i3yG+4e5c4/Rd6UZLf59iHek1mhNX/IULE=,tag:bqYPMZqPnP98M2X9PO5CYw==,type:str]
+    OSC_DATACOMMONS_DEV_REGION: ENC[AES256_GCM,data:O+RFiOEVqiS0,iv:eZ9WxkahNeppBkIS+6D6xDCrsfIOfbZL4XJzZ1oURFU=,tag:aahwDIcbe01egnc2ax/ejw==,type:str]
+    OSC_DATACOMMONS_DEV_S3_ENDPOINT: ENC[AES256_GCM,data:A1mjqovKgwYwgTctCNNUZpAJbeB0BWxNRcQ=,iv:6Pu6ynb/ZGV1wi1mQfC3o/KdD56IVEpHs5C/2w12yX4=,tag:yWIJKCOf7y5iLKzSzVxN+g==,type:str]
+    OSC_DATACOMMONS_DEV_S3_ENDPOINT_URL_PREFIX: ENC[AES256_GCM,data:FH9M7wzXS0Y=,iv:MfnC5xXC3eOvGsTnQjhX14qHrmhHCIcd53XhzmWd4ow=,tag:PBt8vPm4RCdlDayyqRnLIA==,type:str]
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-11-26T16:59:38Z'
+    mac: ENC[AES256_GCM,data:QJjYV0ZDEifx9FYKPQm4ybU+I4PjXo0OnYEYJoUoqdDPhlZxUEamw+mBIf1/UKglBy/DrG99fnWSwdTIuQaIEciD/8KwToFOvSvhR99w4CnxQ5Y7t9KcFWySfV1zvEk4MojestCzDBQMBH6VpX41ztvY7xhLEw2i69FEuyzixxo=,iv:h9+YVmfFK2C+SIX8UwHC+MeEHKfC/DgFyrPde9zRP3A=,tag:tz1nyFOb78BBX6gzWFwkxw==,type:str]
+    pgp:
+    -   created_at: '2021-11-26T16:59:37Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA9aKBcudqifiARAACQh6l+m+UkIpWVYXt3asSOlAUqBomeeLkQMDObpY3mi6
+            3TpOPpqdooJaiEM02npdSmUpjppUCBbM2PIxt3V+Y/SEY9bjZ7ju3geK+7MeSJRz
+            X5D8tcM9IdWkVXYmBc9Y/7C2ogDdMh+muLH+jJcOlGn40VnyPcrT01kD8caoAH8w
+            /kVEP4f6gKjiVhkytZxO7GngBsdJfOjWaYditswa3oPeDenCz7RdgbAHqiVT1UPO
+            +4Ag+28SOxsJ6WCU5cxrufreRSuwNzDmpXd/8HWMzp9MutUS1I+73FUFPY1ZeuCF
+            IsiOi+N2Qq7JEpR8g0SeXJZpCgOcH8qYj43FhlkplrODfPTSxMRPKIt6gTPcqj3C
+            /+w7VGLnHcTDwjhaD0of1MAKHHWkdPy+7Wj+cEAzY3KzPo8fk5qz42e41PIH8tcu
+            qYP3Oz35VgYP7I73BmBlT0jTA29KkH6XQhAYoAjW1hpEd4pEGmQnTFufGMo33fkq
+            LvKSeWCwrHOY0PsqECVPGkyHwrDf6TRccj6NwBedk9owxzMb1YoPf6Ql2zlQby8m
+            pUo0ZmF3A6QDSJf290EcB6f5W5KY+5Yebe/Bs/W8B+ej8ivLJSj2k6jafR+ZqKsO
+            lccvROc24UwpGNG/PCPoMZSEp2FJq2fq3626d8ojYwkogb6z7XvM55tMXoO/dTfS
+            4AHkxNzCn5KfyrgdChFBiqD7P+HbLOCW4IXhNGPg8+ITcG9s4Mzlp3xHm+T9Ij1N
+            f/hVo106ou3OTQbxSn1f6URZfi35eB/gauRuAr135jvr8btvZX8ZtDIf4lTs8jHh
+            tOEA
+            =zPtP
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^(data|stringData)$
+    version: 3.6.1

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/secrets/secret-generator.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/secrets/secret-generator.yaml
@@ -1,0 +1,8 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: secret-generator
+files:
+  - trino-oauth.yaml
+  - s3buckets.yaml
+  - trino_admin_act.yaml

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/secrets/trino-oauth.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/secrets/trino-oauth.yaml
@@ -1,0 +1,38 @@
+kind: Secret
+apiVersion: v1
+metadata:
+    name: trino-oauth
+stringData:
+    TRINO_OAUTH_SECRET: ENC[AES256_GCM,data:R6cgvdA8ajomGwdKrUYsYG44p205GFD2tqicKjphPqysMB/caTknU6v0rw38QOj517YEbDfX7rO8H6UOmKGugw==,iv:BENKSyBAXmIUHNBUST5sZ9d6tgXu/8qNcerOJDopcjk=,tag:LhUh/s6c4jYPlb6J6P4PsA==,type:str]
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-11-26T15:43:14Z'
+    mac: ENC[AES256_GCM,data:nE5X5uyuj9aNvgfI7XYc5wJZzjYMSj5734ZSDqc1Spg9wDWq8fFFSlnkKvIPYM6tIm9yyMCJkY+9EK0EfzK64eDKlqcx9Jb6ZTq9KYw6QaKXxvrxg/39ZnIwoD6VwWRiJkW+qeMZ+ySDNx5vPdlqocJYF6LGDEcFrsZjtxykQ0Y=,iv:q/mvZUdqdIW42QxxBNu7C0YonML2QwOlA6O2n4/47mc=,tag:XYvhMQhe+I2op10+tj7JHw==,type:str]
+    pgp:
+    -   created_at: '2021-11-26T15:43:13Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA9aKBcudqifiARAAVh0I9fNBlBSZRdnL1Rti9DIpz6RwknWZOzqjB5i1XHNX
+            o4oloXMv8MMgU6kABtDLBTW9esFge+86RD8oPmABf+FOGlYCq2s15m2H6rL8A5pG
+            NY+nHt14x6x/tBXZIA+2fLWO32Vyh01rD+eXqUgPjbdUnY81MxplCmxTejDYpPmR
+            cP3Y9NuYwT/282REj7ZluaPjGWxm+P7TzLW5jxePhMjkQMURQavLonzdg7+ZljsX
+            YeeertXYVsxo2Y56QGwy7iqm1dfsLGrh+fSirXYtKZ2VGeXfcea9Uxttj0T79/Md
+            0wqMH+1por6P03xsPXLudAYc3hgMQJYgBlqiS7cQoPOcws/8i+IaVjINY9tzuL0u
+            Ub78grWHd8Dw7uZw5JkS9oCINah1n3ZozthzN67BNKjFc52FOU+zS+mk97LMwort
+            NRKH/JACF2/rq28s+hSLPrgCKLi0BNuQ5v841KA0FQ+p9IINQodz5VrHowoKRhGu
+            KLk0IEnEWKDUhrjHd0UEOtoSnRf6N+yz/yN4bIeieXjMTve2d7KgUJ+tUnEYmaK5
+            nBHlULLe/m1Y2B18FKQ5PLGwux/gs0ke1ZQJ8/wIgavZVyyybzZHNVPwzjT+JtUT
+            785Qrx2F40wYe8HykS63ikIsPx+FuPToDGafEQn0U/5Lcux3JeIZC7soBFdoEsjS
+            4AHkumaRn6DYa+4/iEDanT+IQuFfyODi4BfheqrgteKKwNPC4BjlgQSNEg1VlON2
+            0/VbyoWwvc1tvmmHCGq07tBkGMOyDTngO+RT8BYN37nv7ZapM4AgcnxU4vMKv+Th
+            5I0A
+            =DlhM
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^(data|stringData)$
+    version: 3.6.1

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/secrets/trino_admin_act.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/secrets/trino_admin_act.yaml
@@ -1,0 +1,40 @@
+kind: Secret
+apiVersion: v1
+metadata:
+    name: trino-admin-acct
+    namespace: odh-trino
+stringData:
+    username: ENC[AES256_GCM,data:TH0Rrs0=,iv:IqN+Srp4jXSsoL6VCZLNeQhIYmbKum/UMuiYbjOJx2Q=,tag:rNACXpgSikl7QXGpgGn4ug==,type:str]
+    password: ENC[AES256_GCM,data:wf2ECBKV0V55s9SbCw==,iv:PeheynLzi67g+989J86HLV9ZkN3HEt8152Z3tlooUmI=,tag:xCy8Djx4JtlH0j54Tm7C6w==,type:str]
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2021-11-26T15:43:09Z'
+    mac: ENC[AES256_GCM,data:6djDIjycmSxjV/7veyZ9IxgAMbPtO6uk0Oczytj77Dst0OgN7JjJoIAxcuqgJqzTMlHbFkQh5Ta8VCgKjfydhOTE46XV1HQmX3ZsvU8lK7VNwIJph7/AQpBtDoNs770Xg5MDdZF7TIXPSzVaP/p4hA4eYEsMwRLDh/yK1olKuDo=,iv:EhvSkwvxyWUhZFsT2LN1FMtwUkwo29JJLhhRgvOowP4=,tag:YyeT6EHh8bkEm3TSTLEADg==,type:str]
+    pgp:
+    -   created_at: '2021-11-26T15:43:08Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA9aKBcudqifiARAAC3cej9pCgWZGHQXuqxefNTKvERITfCW1gizSF9SLKO/C
+            0HesCh5di6r4M7hQ94Y8LnuQ8DbIixunomtxRaquTPpqf4bhLu8kRtKh8X/KSA+p
+            3UNM2ZGnyKg2EEImGY9OlaBVhs9LS24IUo/v3N5ACKMnlpofrtcK5zt8dVx6UNSF
+            erSSJE0ACUVkn3p1vZFmxe9gI0bZRZu3sfMas1Il6glbgagGXG+ZIlnOj1CEHCdc
+            g2ohZMFk0RHzb24xa5pN4x2jkq6C0ewtE83Db9fcEPPyfdKU57UjNgwDq2VxpsST
+            zZNaUS7WwY7Ggh1hXqRxjLsN/yCLXhWGJmTlPWAJog59CbGqErfCTJUprvFiuHZ1
+            j4vYf0IoBOx0923Wm5eTSfkx89JUcycZgoH47frs/o2VBwcmnOvMPkBjntD1f1/9
+            W2SliKG8H8uRpoH8MqPKqzN5bF/1vyMwj69cldl495PhC2eEk0u9uH8oGgwIWBlx
+            mZG92Om2eCzgxiKEWo5JPwKd58lZcBUaDqHtJk7zCX9hTshqjaF8KkekoFFwQq1t
+            PH6QmmW5m3sY3DPT5xOlXZEVeoVfzDQtATJ6p9aVu3ysisRwp0v5HYksU4kG1MHH
+            gkzBTk+wpPeDsi6GmsOq4B0ApbRXlBjs/3jExEmeel/dCq0KUHVIcHY/C8P5jQDS
+            4AHk6SHOAKYzk+ZrH3Y1nUYIKuHi5OAD4HnhSyLgeeKM2PeK4O/lbZzhQ+GSvDNq
+            DQbPiYbtYvUmf+NqpJTehmaLC+kdZy7gqeTZnw4m8E69+okfFWXB1AAh4k5Q36Lh
+            wxwA
+            =0q3R
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^(data|stringData)$
+    version: 3.6.1

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/secure-route.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/secure-route.yaml
@@ -1,0 +1,12 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: trino-secure
+  annotations:
+    kubernetes.io/tls-acme: "true"
+spec:
+  to:
+    kind: Service
+    name: trino-service
+  port:
+    targetPort: 8080

--- a/odh-manifests/osc-cl1/trino-dev/base/hive-config.yaml
+++ b/odh-manifests/osc-cl1/trino-dev/base/hive-config.yaml
@@ -1,0 +1,250 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hive-config
+data:
+  hive-exec-log4j2.properties: 'status = INFO
+
+    name = HiveLog4j2
+
+    packages = org.apache.hadoop.hive.ql.log
+
+
+    # list of properties
+
+    property.hive.log.level = INFO
+
+    property.hive.root.logger = console
+
+    property.hive.log.dir = ${sys:java.io.tmpdir}/${sys:user.name}
+
+    property.hive.log.file = hive.log
+
+
+    # list of all appenders
+
+    appenders = console
+
+
+    # console appender
+
+    appender.console.type = Console
+
+    appender.console.name = console
+
+    appender.console.target = SYSTEM_ERR
+
+    appender.console.layout.type = PatternLayout
+
+    appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} [%t]: %p %c{2}: %m%n
+
+
+    # list of all loggers
+
+    loggers = NIOServerCnxn, ClientCnxnSocketNIO, DataNucleus, Datastore, JPOX
+
+
+    logger.NIOServerCnxn.name = org.apache.zookeeper.server.NIOServerCnxn
+
+    logger.NIOServerCnxn.level = WARN
+
+
+    logger.ClientCnxnSocketNIO.name = org.apache.zookeeper.ClientCnxnSocketNIO
+
+    logger.ClientCnxnSocketNIO.level = WARN
+
+
+    logger.DataNucleus.name = DataNucleus
+
+    logger.DataNucleus.level = ERROR
+
+
+    logger.Datastore.name = Datastore
+
+    logger.Datastore.level = ERROR
+
+
+    logger.JPOX.name = JPOX
+
+    logger.JPOX.level = ERROR
+
+
+    # root logger
+
+    rootLogger.level = ${sys:hive.log.level}
+
+    rootLogger.appenderRefs = root
+
+    rootLogger.appenderRef.root.ref = ${sys:hive.root.logger}
+
+    '
+  hive-log4j2.properties: 'status = INFO
+
+    name = HiveLog4j2
+
+    packages = org.apache.hadoop.hive.ql.log
+
+
+    # list of properties
+
+    property.hive.log.level = INFO
+
+    property.hive.root.logger = console
+
+    property.hive.log.dir = ${sys:java.io.tmpdir}/${sys:user.name}
+
+    property.hive.log.file = hive.log
+
+
+    # list of all appenders
+
+    appenders = console
+
+
+    # console appender
+
+    appender.console.type = Console
+
+    appender.console.name = console
+
+    appender.console.target = SYSTEM_ERR
+
+    appender.console.layout.type = PatternLayout
+
+    appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} [%t]: %p %c{2}: %m%n
+
+
+    # list of all loggers
+
+    loggers = NIOServerCnxn, ClientCnxnSocketNIO, DataNucleus, Datastore, JPOX
+
+
+    logger.NIOServerCnxn.name = org.apache.zookeeper.server.NIOServerCnxn
+
+    logger.NIOServerCnxn.level = WARN
+
+
+    logger.ClientCnxnSocketNIO.name = org.apache.zookeeper.ClientCnxnSocketNIO
+
+    logger.ClientCnxnSocketNIO.level = WARN
+
+
+    logger.DataNucleus.name = DataNucleus
+
+    logger.DataNucleus.level = ERROR
+
+
+    logger.Datastore.name = Datastore
+
+    logger.Datastore.level = ERROR
+
+
+    logger.JPOX.name = JPOX
+
+    logger.JPOX.level = ERROR
+
+
+    # root logger
+
+    rootLogger.level = ${sys:hive.log.level}
+
+    rootLogger.appenderRefs = root
+
+    rootLogger.appenderRef.root.ref = ${sys:hive.root.logger}
+
+    '
+  hive-site.xml: |
+    <configuration>
+      <property>
+        <name>hive.server2.enable.doAs</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>hive.server2.use.SSL</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>hive.server2.authentication</name>
+        <value>NOSASL</value>
+      </property>
+      <property>
+        <name>hive.metastore.metrics.enabled</name>
+        <value>true</value>
+      </property>
+      <property>
+        <name>hive.server2.metrics.enabled</name>
+        <value>true</value>
+      </property>
+      <property>
+        <name>hive.service.metrics.reporter</name>
+        <value>JMX</value>
+      </property>
+      <property>
+        <name>hive.server2.thrift.bind.host</name>
+        <value>0.0.0.0</value>
+      </property>
+      <property>
+        <name>hive.metastore.thrift.bind.host</name>
+        <value>0.0.0.0</value>
+      </property>
+      <property>
+        <name>hive.metastore.uris</name>
+        <value>thrift://hive-metastore-0:9083,thrift://hive-metastore-1:9083,thrift://hive-metastore-2:9083</value>
+      </property>
+      <property>
+        <name>datanucleus.schema.autoCreateAll</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>hive.metastore.schema.verification</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>hive.default.fileformat</name>
+        <value>Parquet</value>
+      </property>
+      <property>
+        <name>hive.metastore.warehouse.dir</name>
+        <value>s3a://XXX_S3ENDPOINT_XXX/</value>
+      </property>
+      <property>
+        <name>fs.s3a.endpoint</name>
+        <value>XXX_S3ENDPOINT_URL_PREFIX_XXXXXX_S3LOCATION_XXX/</value>
+      </property>
+     <property>
+      <name>hive.metastore.db.type</name>
+      <value>POSTGRES</value>
+      <description>
+        Expects one of [derby, oracle, mysql, mssql, postgres].
+        Type of database used by the metastore. Information schema &amp; JDBCStorageHandler depend on it.
+      </description>
+      </property>
+      <property>
+        <name>javax.jdo.option.ConnectionUserName</name>
+        <value>XXX_DATABASE_USER_XXX</value>
+        <description>Username to use against metastore database</description>
+      </property>
+      <property>
+        <name>javax.jdo.option.ConnectionPassword</name>
+        <value>XXX_DATABASE_PASSWORD_XXX</value>
+        <description>password to use against metastore database</description>
+      </property>
+      <property>
+        <name>javax.jdo.option.ConnectionURL</name>
+        <value>jdbc:XXX_DATABASE_CONNECT_URL_XXX</value>
+        <description>
+          JDBC connect string for a JDBC metastore.
+          To use SSL to encrypt/authenticate the connection, provide database-specific SSL flag in the connection URL.
+          For example, jdbc:postgresql://myhost/db?ssl=true for postgres database.
+        </description>
+      </property>
+      <property>
+        <name>javax.jdo.option.ConnectionDriverName</name>
+        <value>org.postgresql.Driver</value>
+        <description>Driver class name for a JDBC metastore</description>
+      </property>
+      <property>
+        <name>hive.cluster.delegation.token.store.class</name>
+        <value>org.apache.hadoop.hive.thrift.DBTokenStore</value>
+      </property>
+    </configuration>

--- a/odh-manifests/osc-cl1/trino-dev/base/kustomization.yaml
+++ b/odh-manifests/osc-cl1/trino-dev/base/kustomization.yaml
@@ -1,0 +1,145 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- aws-secret.yaml
+- trino-db-secret.yaml
+- trino-db-pvc.yaml
+- trino-db-dc.yaml
+- trino-db-service.yaml
+- hive-metastore-entrypoint.yaml
+- hive-db-secret.yaml
+- hadoop-config.yaml
+- hive-config.yaml
+- hive-jmx-config.yaml
+- trino-coordinator-dc.yaml
+- trino-service.yaml
+- trino-route.yaml
+- trino-worker-dc.yaml
+
+commonLabels:
+  opendatahub.io/component: "true"
+  component.opendatahub.io/name: "trino"
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: trino-config
+    envs:
+      - params.env
+
+vars:
+  - name: s3_endpoint_url
+    objref:
+      name: trino-config
+      kind: ConfigMap
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.s3_endpoint_url
+  - name: s3_endpoint_url_prefix
+    objref:
+      name: trino-config
+      kind: ConfigMap
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.s3_endpoint_url_prefix
+  - name: s3_credentials_secret
+    objref:
+      kind: ConfigMap
+      apiVersion: v1
+      name: trino-config
+    fieldref:
+      fieldpath: data.s3_credentials_secret
+  - name: trino_environment
+    objref:
+      kind: ConfigMap
+      apiVersion: v1
+      name: trino-config
+    fieldref:
+      fieldpath: data.trino_environment
+  - name: trino_db_secret
+    objref:
+      name: trino-config
+      apiVersion: v1
+      kind: ConfigMap
+    fieldref:
+      fieldpath: data.trino_db_secret
+  - name: hive_metastore_cpu_request
+    objref:
+      name: trino-config
+      apiVersion: v1
+      kind: ConfigMap
+    fieldref:
+      fieldpath: data.hive_metastore_cpu_request
+  - name: hive_metastore_cpu_limit
+    objref:
+      name: trino-config
+      apiVersion: v1
+      kind: ConfigMap
+    fieldref:
+      fieldpath: data.hive_metastore_cpu_limit
+  - name: hive_metastore_memory_request
+    objref:
+      name: trino-config
+      apiVersion: v1
+      kind: ConfigMap
+    fieldref:
+      fieldpath: data.hive_metastore_memory_request
+  - name: hive_metastore_memory_limit
+    objref:
+      name: trino-config
+      apiVersion: v1
+      kind: ConfigMap
+    fieldref:
+      fieldpath: data.hive_metastore_memory_limit
+  - name: trino_cpu_request
+    objref:
+      name: trino-config
+      apiVersion: v1
+      kind: ConfigMap
+    fieldref:
+      fieldpath: data.trino_cpu_request
+  - name: trino_cpu_limit
+    objref:
+      name: trino-config
+      apiVersion: v1
+      kind: ConfigMap
+    fieldref:
+      fieldpath: data.trino_cpu_limit
+  - name: trino_memory_request
+    objref:
+      name: trino-config
+      apiVersion: v1
+      kind: ConfigMap
+    fieldref:
+      fieldpath: data.trino_memory_request
+  - name: trino_memory_limit
+    objref:
+      name: trino-config
+      apiVersion: v1
+      kind: ConfigMap
+    fieldref:
+      fieldpath: data.trino_memory_limit
+  - name: trino_image
+    objref:
+      name: trino-config
+      apiVersion: v1
+      kind: ConfigMap
+    fieldref:
+      fieldpath: data.trino_image
+
+configurations:
+  - params.yaml
+
+images:
+  - name: postgresql
+    newName: registry.redhat.io/rhel8/postgresql-96
+    newTag: latest
+  - name: hive-metastore
+    newName: quay.io/cloudservices/ubi-hive
+    newTag: 2.3.3-002
+  - name: trino
+    newName: quay.io/opendatahub/trino
+    newTag: latest

--- a/odh-manifests/osc-cl1/trino-dev/base/trino-coordinator-dc.yaml
+++ b/odh-manifests/osc-cl1/trino-dev/base/trino-coordinator-dc.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trino-coordinator
+  labels:
+    instance: trino
+    role: trino-coordinator
+spec:
+  selector:
+    matchLabels:
+      instance: trino
+      role: trino-coordinator
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        instance: trino
+        role: trino-coordinator
+    spec:
+      volumes:
+        - name: trino-config-volume
+          configMap:
+            name: trino-config
+            defaultMode: 420
+        - name: trino-catalogs-volume
+          configMap:
+            name: trino-catalog
+            defaultMode: 420
+      containers:
+        - resources:
+            requests:
+              cpu: $(trino_cpu_request)
+              memory: $(trino_memory_request)
+            limits:
+              cpu: $(trino_cpu_limit)
+              memory: $(trino_memory_limit)
+          name: trino-coordinator
+          command:
+            - /usr/lib/trino/bin/run-trino
+          env:
+            - name: POD_ID
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.uid
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: trino-config-volume
+              mountPath: /etc/trino
+            - name: trino-catalogs-volume
+              mountPath: /etc/trino/catalog
+          image: $(trino_image)
+          envFrom:
+            - secretRef:
+                name: trino-oauth
+            - secretRef:
+                name: s3buckets
+          args:
+            - --config=/etc/trino/config-coordinator.properties

--- a/odh-manifests/osc-cl1/trino-dev/base/trino-worker-dc.yaml
+++ b/odh-manifests/osc-cl1/trino-dev/base/trino-worker-dc.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trino-worker
+  labels:
+    instance: trino
+    role: trino-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      instance: trino
+      role: trino-worker
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        instance: trino
+        role: trino-worker
+    spec:
+      volumes:
+        - name: trino-config-volume
+          configMap:
+            name: trino-config
+            defaultMode: 420
+        - name: trino-catalogs-volume
+          configMap:
+            name: trino-catalog
+            defaultMode: 420
+      containers:
+        - resources:
+            requests:
+              cpu: $(trino_cpu_request)
+              memory: $(trino_memory_request)
+            limits:
+              cpu: $(trino_cpu_limit)
+              memory: $(trino_memory_limit)
+          name: trino-worker
+          command:
+            - /usr/lib/trino/bin/run-trino
+          env:
+            - name: POD_ID
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.uid
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: trino-config-volume
+              mountPath: /etc/trino
+            - name: trino-catalogs-volume
+              mountPath: /etc/trino/catalog
+          image: $(trino_image)
+          envFrom:
+            - secretRef:
+                name: s3buckets
+          args:
+            - --config=/etc/trino/config-worker.properties


### PR DESCRIPTION
Resolves: https://github.com/os-climate/os_c_data_commons/issues/99 

This PR does the following: 
- Creates `odh-trino-dev` namespace on osc cluster
- Deploys a dev trino instance on the osc cluster in namespace `odh-trino-dev` 
- The bucket used as starting catalog is: `ocp-odh-os-demo-s3` (I.e. `OSC_DATACOMMONS_DEV`, which is also configured for the non-dev trino instance currently running, so I'm not sure if this poses as an issue) 


I'm also doing a trial run of pulling the configmaps out of `odh-manifests` and putting them in the `kfdefs` directory as separate files, I think this would make it easier to add validation in the future for files like `rules.json`, and if you have syntax highlighting/validation etc. in your ide, editing these files becomes easier. If it works without issues, I'll bring these changes to the non-dev instance currently on live. 