### PR TITLE
Give `prometheus-ai` group access to thanos metrics

### DIFF
--- a/observatorium/overlays/moc/smaug/thanos/rolebindings/opf-observatorium-view.yaml
+++ b/observatorium/overlays/moc/smaug/thanos/rolebindings/opf-observatorium-view.yaml
@@ -20,3 +20,6 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: logs-insights
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: prometheus-ai


### PR DESCRIPTION
This PR can be used as an example PR in the docs

Related https://github.com/operate-first/support/issues/454#issuecomment-981831163