### PR TITLE
Fix the image tags for the pulp instance

### DIFF
--- a/pulp/overlays/moc/smaug/opf-pulp.yaml
+++ b/pulp/overlays/moc/smaug/opf-pulp.yaml
@@ -8,7 +8,7 @@ spec:
   ingress_type: Route
   loadbalancer_port: 80
   image_pull_policy: IfNotPresent
-  image_web: 'quay.io/pulp/pulp-web:stable'
+  image_web: 'quay.io/pulp/pulp-web'
   file_storage_size: 50Gi
   file_storage_storage_class: ocs-external-storagecluster-ceph-rbd
   file_storage_access_mode: ReadWriteOnce
@@ -20,7 +20,7 @@ spec:
   api:
     log_level: INFO
     replicas: 1
-  image: 'quay.io/pulp/pulp:stable'
+  image: 'quay.io/pulp/pulp'
   loadbalancer_protocol: http
   resource_manager:
     replicas: 1


### PR DESCRIPTION
Fix the image tags for the pulp instance
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Epic: https://github.com/operate-first/support/issues/176

stable tag is added automatically by pulp-operator
![pulp-image](https://user-images.githubusercontent.com/14028058/143920006-44ce5ecd-412a-4871-be0e-5cf9181ed6b8.png)
![pulp](https://user-images.githubusercontent.com/14028058/143920018-821a68ba-ac33-4921-883d-d2d4dd0b95f3.png)
