### PR TITLE
Remove web-terminal operator from curator cluster

### DIFF
--- a/cluster-scope/overlays/prod/moc/curator/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/curator/kustomization.yaml
@@ -13,7 +13,6 @@ resources:
   - ../../../../base/operators.coreos.com/operatorgroups/openshift-storage
   - ../../../../base/operators.coreos.com/subscriptions/kubevirt-hyperconverged
   - ../../../../base/operators.coreos.com/subscriptions/ocs-operator
-  - ../../../../base/operators.coreos.com/subscriptions/web-terminal
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-rb
   - ../../../../base/storage.k8s.io/storageclasses/hostpath-provisioner
   - ../../../../base/user.openshift.io/groups/cluster-admins
@@ -28,6 +27,5 @@ patchesStrategicMerge:
   - oauths/cluster_patch.yaml
   - subscriptions/kubevirt-hyperconverged_patch.yaml
   - subscriptions/ocs-operator_patch.yaml
-  - subscriptions/web-terminal.yaml
   - storageclasses/hostpath-provisioner_patch.yaml
   - groups/cluster-admins.yaml


### PR DESCRIPTION
This operator wasn't being used and was causing problems.

Closes operate-first/curator#165
