### PR TITLE
Add manual trigger for jbook action.

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -7,6 +7,7 @@ on:
       - 'docs/**'
     branches:
       - 'master'
+  workflow_dispatch:
 
 # This job installs dependencies, build the book, and pushes it to `gh-pages`
 jobs:


### PR DESCRIPTION
Yaml looks a bit weird, but seems it's valid, not specifically mentioned in the docs, but you can see it in use here: 
https://github.com/operate-first/operate-first.github.io/blob/master/.github/workflows/build_job.yaml#L6