### PR TITLE
Configure VPA custom resource for opf-trino namespace's trino-worker

### DIFF
--- a/kfdefs/overlays/moc/smaug/opf-trino/kustomization.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-trino/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: opf-trino
@@ -6,6 +7,7 @@ resources:
   - hive-metastores
   - obcs
   - secrets
+  - vpa
 patchesJson6902:
   - patch: |
       - op: add

--- a/kfdefs/overlays/moc/smaug/opf-trino/vpa/kustomization.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-trino/vpa/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: opf-trino
+resources:
+  - vpa-custom-resource.yaml

--- a/kfdefs/overlays/moc/smaug/opf-trino/vpa/vpa-custom-resource.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-trino/vpa/vpa-custom-resource.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  namespace: opf-trino
+  name: vpa-trino
+  labels:
+    app: vpa-trino
+spec:
+  resourcePolicy:
+    containerPolicies:
+      - containerName: trino-worker
+        maxAllowed:
+          cpu: 8000m
+          memory: 16Gi
+        minAllowed:
+          cpu: 1000m
+          memory: 4Gi
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: trino-worker
+  updatePolicy:
+    updateMode: "Off"


### PR DESCRIPTION
@HumairAK / @4n4nd Current opf-trino (prod) request and limits are:
CPU: Request- 4 core, Limit- 8 core
Memory: Request: 9 GB, Limit: 16 GB

Based on this, min and max values that VPA can operate are configured in this PR. VPA UpdatePolicy will be set to Off for prod initially. Let me know if you think we should tune values differently.

```
maxAllowed:
          cpu: 8000m
          memory: 16Gi
        minAllowed:
          cpu: 1000m
          memory: 4Gi
```

These min/max values are per container of trino-worker. Ref: https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go#L165
