### PR TITLE
Add role/rolebind for cluster-monitoring prom to see openshift-logging namespace

### DIFF
--- a/cluster-logging/base/kustomization.yaml
+++ b/cluster-logging/base/kustomization.yaml
@@ -6,3 +6,5 @@ namespace: openshift-logging
 
 resources:
   - clusterlogging.yaml
+  - rolebindings
+  - roles

--- a/cluster-logging/base/rolebindings/kustomization.yaml
+++ b/cluster-logging/base/rolebindings/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - prometheus-k8s.yaml

--- a/cluster-logging/base/rolebindings/prometheus-k8s.yaml
+++ b/cluster-logging/base/rolebindings/prometheus-k8s.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prometheus-k8s
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s

--- a/cluster-logging/base/roles/kustomization.yaml
+++ b/cluster-logging/base/roles/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - prometheus-k8s.yaml

--- a/cluster-logging/base/roles/prometheus-k8s.yaml
+++ b/cluster-logging/base/roles/prometheus-k8s.yaml
@@ -1,0 +1,31 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prometheus-k8s
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - services
+      - endpoints
+      - pods
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - extensions
+    resources:
+      - ingresses
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses


### PR DESCRIPTION
Resolves https://github.com/operate-first/apps/issues/1355

The role `prometheus-k8s` is a general role that has been copied from other namespaces which `openshift-monitoring` can monitor