### PR TITLE
Fix various outdated links and link formatting in docs.

### DIFF
--- a/docs/content/README.md
+++ b/docs/content/README.md
@@ -79,7 +79,7 @@ Operate First manages various applications and services in the environments list
 [10]: https://github.com/operate-first/support/issues/new?assignees=first-operator&labels=kind%2Fonboarding%2Carea%2Fbucket&template=ceph_bucket_request.yaml&title=BUCKET%3A+%3Cname%3E
 [11]: https://github.com/operate-first/apps/tree/master/dex
 [12]: https://rook.io/
-[13]: https://www.operate-first.cloud/users/support/docs/claiming_object_store.md
+[13]: ocs/claiming_object_store.md
 [14]: https://massopen.cloud/
 [15]: https://opendatahub.io/
 [17]: https://argoproj.github.io/argo-cd/
@@ -88,11 +88,9 @@ Operate First manages various applications and services in the environments list
 [21]: https://github.com/dexidp/dex
 [23]: https://www.hetzner.com/
 [24]: https://github.com/os-climate/os_c_data_commons
-
 [smaug]: https://console-openshift-console.apps.smaug.na.operate-first.cloud/
 [infra]: https://console-openshift-console.apps.moc-infra.massopen.cloud/
 [rick]: https://console-openshift-console.apps.rick.emea.operate-first.cloud/
 [osc-cl]: https://console-openshift-console.apps.odh-cl1.apps.os-climate.org/dashboards
-
-[odh1]: https://github.com/operate-first/apps/tree/master/docs/odh
+[odh1]: odh/README.md
 [odh2]: https://odh.operate-first.cloud/

--- a/docs/content/about/intro.md
+++ b/docs/content/about/intro.md
@@ -31,7 +31,7 @@ Next step is bringing the discussion to the “Operate First Project Coordinatio
 
 There is another bi-weekly meeting an the alternate Wednesdays at 8:30 AM US Eastern time, called “MOC/ODH sprint planning” and it is primarily focused on the Ops team planning. (Odd numbered weeks for 2021) Meeting url: https://meet.google.com/oki-drge-wuc?authuser=0&hs=122
 
-More detailed information on onboarding to a cluster can be found here: https://www.operate-first.cloud/users/support/docs/onboarding_to_cluster.md
+More detailed information on onboarding to a cluster can be found here: https://www.operate-first.cloud/apps/content/cluster-scope/onboarding_to_cluster.html
 
 
 ## Understanding the environment

--- a/docs/content/acm/adding_managed_cluster_to_argocd.md
+++ b/docs/content/acm/adding_managed_cluster_to_argocd.md
@@ -16,5 +16,4 @@ metadata:
 
 Add this file to the `kustomization.yaml` found [here][kustomization].
 
-
 [kustomization]: https://github.com/operate-first/apps/blob/master/acm/overlays/moc/infra/managedclusters/kustomization.yaml

--- a/docs/content/acme/issuing_certificates.md
+++ b/docs/content/acme/issuing_certificates.md
@@ -2,7 +2,7 @@
 
 ## Securing OpenShift `Route`s with ACME (Let's Encrypt)
 
-We manage and deploy cluster wide deployment of [OpenShift ACME](https://github.com/tnozicka/openshift-acme) controller. This operator facilitates [Let's Encrypt](https://letsencrypt.org/) certificate provisioning in any `namespace` on the cluster. Any `route` resource is eligible, please use the following annotation to mark the route as managed by this operator:
+We manage and deploy cluster wide deployment of [OpenShift ACME][1] controller. This operator facilitates [Let's Encrypt][2] certificate provisioning in any `namespace` on the cluster. Any `route` resource is eligible, please use the following annotation to mark the route as managed by this operator:
 
 ```yaml
 apiVersion: route.openshift.io/v1
@@ -17,3 +17,6 @@ Annotating a route will result with an additional temporary route and 2 pods bei
 ## Issuing certificates via Cert Manager
 
 For other workloads that rely on SSL/TLS certificates, we will be able to provision certificates via Cert Manager shortly. This is currently work in progress.
+
+[1]: https://github.com/tnozicka/openshift-acme
+[2]: https://letsencrypt.org/

--- a/docs/content/argocd-gitops/encrypting_applications.md
+++ b/docs/content/argocd-gitops/encrypting_applications.md
@@ -1,8 +1,17 @@
 # How to encrypt apps in this repo
 
-We use SOPS to encrypt our secrets and other k8s/openshift resources in vcs. We use a Kustomize plugin called KSOPs to allow us to use sops with kustomize builds. We include KSOPs with ArgoCD and import our keys so that we can also have ArgoCD deploy manifests that are encrypted via sops in vcs. Read more about how to install and use KSOPs and SOPS [here](https://github.com/operate-first/continuous-deployment/blob/master/docs/manage_your_app_secrets.md)
+We use SOPS to encrypt our secrets and other k8s/openshift resources in vcs. We use a Kustomize plugin called KSOPs to
+allow us to use Sops with kustomize builds. We include KSOPs with ArgoCD and import our keys so that we can also have
+ArgoCD deploy manifests that are encrypted via sops in vcs. Read more about how to install and use KSOPs and SOPS
+[here][ksopsreadme]
 
 # GPG Key
-In the link above you will require a public fingerprint to include in your sops.yaml, this comes from a gpg key we use for all our apps in this repo and can be found [here](https://keys.openpgp.org/search?q=aicoe-operate-first%40redhat.com).
+In the link above you will require a public fingerprint to include in your sops.yaml, this comes from a gpg key we use
+for all our apps in this repo and can be found [here][op1stkey].
 
-If you are an active contributor and require the private key, please make an issue or reach out to another active contributor/maintainer for it. Be prepared to provide your own public key so that we may send it to you securely.
+If you are an active contributor and require the private key, please make an issue or reach out to another active
+contributor/maintainer for it. Be prepared to provide your own public key so that we may send it to you securely.
+
+
+[ksopsreadme]: https://github.com/viaduct-ai/kustomize-sops#installation
+[op1stkey]: https://keys.openpgp.org/search?q=aicoe-operate-first%40redhat.com

--- a/docs/content/argocd-gitops/onboarding_to_argocd.md
+++ b/docs/content/argocd-gitops/onboarding_to_argocd.md
@@ -164,14 +164,14 @@ these namespaces using ArgoCD Applications that are part of the `thoth` project.
 [2]: https://argoproj.github.io/argo-cd/user-guide/projects/
 [3]: https://github.com/operate-first/apps/tree/master/argocd/overlays/moc-infra/projects
 [4]: https://github.com/operate-first/apps/blob/master/argocd/overlays/moc-infra/projects/global_project.yaml
-[5]: https://github.com/operate-first/hitchhikers-guide/blob/main/pages/onboarding_project.ipynb
+[5]: ../cluster-scope/onboarding_to_cluster.md
 [6]: https://github.com/operate-first/apps
 [7]: https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#applications
 [8]: https://github.com/operate-first/apps/tree/master/argocd/overlays/moc-infra/applications/envs
-[9]: https://github.com/operate-first/apps/blob/master/docs/argocd/add_application.md
+[9]: add_application.md
 [10]: https://github.com/operate-first/apps/tree/master/argocd/overlays/moc-infra/secrets/clusters
 [11]: https://github.com/operate-first/apps/blob/master/argocd/overlays/moc-infra/projects/kustomization.yaml
-[12]: https://argocd-server-argocd.apps.moc-infra.massopen.cloud
+[12]: https://argocd.operate-first.cloud
 [13]: https://github.com/operate-first/apps/blob/master/argocd/overlays/moc-infra/configs/argo_cm/dex.config#L11
 [14]: https://github.com/operate-first/apps/blob/master/argocd/overlays/moc-infra/configs/argo_rbac_cm/policy.csv
 [15]: https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/

--- a/docs/content/argocd-gitops/secret_management.md
+++ b/docs/content/argocd-gitops/secret_management.md
@@ -4,12 +4,12 @@ This onboarding guide will help you set up your application's secrets in a way t
 
 ## Prerequisites
 
-1. Install GPG and [SOPS](https://github.com/mozilla/sops)
+1. Install GPG and [SOPS][sops]
 2. Have ready your own/team-owned secret GPG key that you want to access the encrypted data with
 
 ## Obtain OperateFirst GPG public key
 
-Fetch [`0508677DD04952D06A943D5B4DC4116D360E3276` GPG key](http://keys.gnupg.net/pks/lookup?op=vindex&fingerprint=on&search=0x4DC4116D360E3276):
+Fetch [`0508677DD04952D06A943D5B4DC4116D360E3276` GPG key][gpgkey]:
 
 ```sh
 gpg --keyserver keys.gnupg.net --recv 0508677DD04952D06A943D5B4DC4116D360E3276
@@ -30,7 +30,7 @@ This creation rule specifies:
 - `encrypted_regex` instructs SOPS to (by default) encrypt only the `data` or `stringData` properties of resources
 - `pgp` specifies which GPG keys to be used for the encryption. Multiple key fingerprints can be specified here separated by a comma. Each of the private GPG key holders to fingerprints specified in this list will be able to decrypt and re-encrypt the resource.
 
-For more details on the SOPS configuration, please consult the [SOPS documentation](https://github.com/mozilla/sops).
+For more details on the SOPS configuration, please consult the [SOPS documentation][sops].
 
 ## Encrypting a resource
 
@@ -60,5 +60,10 @@ sops path/to/resource.enc.yaml
 
 Based on the toolkit you use to structure your manifests with, please follow these guides:
 
-1. For Kustomize manifests, please use `ksops`. Please follow [the upstream documentation for ksops](https://github.com/viaduct-ai/kustomize-sops).
-2. For Helm manifests, please use `helm-secrets`. Please follow [the upstream documentation for helm-secrets](https://github.com/jkroepke/helm-secrets).
+1. For Kustomize manifests, please use `ksops`. Please follow [the upstream documentation for ksops][ksops].
+2. For Helm manifests, please use `helm-secrets`. Please follow [the upstream documentation for helm-secrets][hsecrets].
+
+[sops]: https://github.com/mozilla/sops
+[gpgkey]: https://keys.openpgp.org/search?q=aicoe-operate-first%40redhat.com
+[ksops]: https://github.com/viaduct-ai/kustomize-sops
+[hsecrets]: https://github.com/jkroepke/helm-secrets

--- a/docs/content/cluster-scope/onboarding_to_cluster.md
+++ b/docs/content/cluster-scope/onboarding_to_cluster.md
@@ -1,10 +1,10 @@
 # Onboarding to a cluster
 
-This document serves as a guide for adding cluster scoped resources of `Namespace` and `Group` kinds. Following steps in this guide should result in a PR against the [operate-first/apps](https://github.com/operate-first/apps) repository.
+This document serves as a guide for adding cluster scoped resources of `Namespace` and `Group` kinds. Following steps in this guide should result in a PR against the [operate-first/apps][1] repository.
 
 Currently we support 2 ways to request/perform onboarding to any supported clusters:
 
-1. Make an Onboarding issue request. Use the **Onboarding to Cluster** issue template in [operate-first/support](https://github.com/operate-first/support) repository.
+1. Make an Onboarding issue request. Use the **Onboarding to Cluster** issue template in [operate-first/support][2] repository.
 2. Opening a PR with the desired changes. The rest of this doc focuses on this second option. We'd gladly welcome your contributions.
 
 > NOTE: Choosing option 2 requires a PR to be made for onboarding after completing the steps outlined below. The actual
@@ -14,29 +14,29 @@ Currently we support 2 ways to request/perform onboarding to any supported clust
 
 You will need pre-requisite tools to follow along with this doc, please do one of the following:
 
-- Install our [toolbox](https://github.com/operate-first/toolbox) to have the developer setup ready automatically for you.
-- Install the tools manually. You'll need [kustomize](https://kustomize.io/), [sops](https://github.com/mozilla/sops) and [ksops](https://github.com/viaduct-ai/kustomize-sops).
+- Install our [toolbox][3] to have the developer setup ready automatically for you.
+- Install the tools manually. You'll need [kustomize][4], [sops][5] and [ksops][6].
 
-You will also need the `opfcli` install the latest version from [here](https://github.com/operate-first/opfcli/releases).
+You will also need the `opfcli` install the latest version from [here][7].
 
-Please fork/clone the [operate-first/apps](https://github.com/operate-first/apps) repository. **During this whole setup, we'll be working within this repository.**
+Please fork/clone the [operate-first/apps][1] repository. **During this whole setup, we'll be working within this repository.**
 
 For successful completion of this guide you need to understand what the aim is. Please have prepared following data:
 
 - Name of the onboarded team.
-- Desired namespace name. Please use your team name as a prefix. This will make it easier for you to [onboard to ArgoCD](../argocd-gitops/onboarding_to_argocd.md) later on.
+- Desired namespace name. Please use your team name as a prefix. This will make it easier for you to [onboard to ArgoCD][8] later on.
 - List of users you'd like to add to your team.
 - An optional team GPG key, in case you would like to modify the encrypted list of users of your team later on.
 
 ## Recipe
 
-If you want to know more about the overall design please consult the ADR documentation at [operate-first/blueprint](https://github.com/operate-first/blueprint).
+If you want to know more about the overall design please consult the ADR documentation at [operate-first/blueprint][9].
 
 In general we store all the cluster-scoped resources in a `cluster-scope` kustomize application within this repository.
 
 ## Adding namespaces
 
-For easier [onboard to ArgoCD](../argocd-gitops/onboarding_to_argocd.md) later on, we prefer to follow a name pattern for all our namespaces. Please use your team name as a prefix to the namespace name like so: `$OWNER_TEAM-example-project`.
+For easier [onboard to ArgoCD][8] later on, we prefer to follow a name pattern for all our namespaces. Please use your team name as a prefix to the namespace name like so: `$OWNER_TEAM-example-project`.
 
 ### Base resources
 
@@ -76,7 +76,7 @@ resources:
 ### Authenticate via OpenShift
 Users are automatically created upon login to the appropriate cluster. This is done by logging in via your GitHub account.
 
-Follow the link on the website at [operate-first.cloud](https://www.operate-first.cloud/), and click the grid icon at the top right, you will see a list of clusters. Clicking a cluster will redirect you to a login page, select `operate-first` and login using your GitHub account.
+Follow the link on the website at [operate-first.cloud][10], and click the grid icon at the top right, you will see a list of clusters. Clicking a cluster will redirect you to a login page, select `operate-first` and login using your GitHub account.
 
 With the user now created, we will need to provide them with appropriate rbac access to this namespace.
 
@@ -105,7 +105,7 @@ users:
 
 > Note that the USER_n value is the email used to login via SSO in the preceeding steps.
 
-Encrypt the file with sops. You can find the key to import from [here](https://github.com/operate-first/apps/tree/master/cluster-scope/overlays/prod/moc#secret-management):
+Encrypt the file with sops. You can find the key to import from [here][11]:
 
 ```sh
 $ sops --encrypt --encrypted-regex="^users$" --pgp="0508677DD04952D06A943D5B4DC4116D360E3276" groups/GROUP_NAME.yaml > groups/GROUP_NAME.enc.yaml
@@ -125,7 +125,7 @@ $ grep "fp: " groups/GROUP_NAME.enc.yaml
 Explanation to the `sops` command:
 
 - `encrypt` flag encrypts a resource
-- `encrypted-regex` value maps to the XPath-like regex to specifies which parts of the file should be encrypted. The rest of the file is left as a plaintext for easier management. In this case we want to encrypt only the `users` property in the file. See the docs [here](https://github.com/mozilla/sops#encrypting-only-parts-of-a-file).
+- `encrypted-regex` value maps to the XPath-like regex to specifies which parts of the file should be encrypted. The rest of the file is left as a plaintext for easier management. In this case we want to encrypt only the `users` property in the file. See the docs [here][12].
 - `pgp` list all the GPG keys which will be used to encrypt this file.
 
 Don't forget to remove the plaintext variant of the resource before staging for a commit:
@@ -155,8 +155,21 @@ Then simply append the list of users with the new users that need to be added.
 
 ## Finalize
 
-Please stage your changes and send them as a PR against the [operate-first/apps](https://github.com/operate-first/apps) repository. Make sure:
+Please stage your changes and send them as a PR against the [operate-first/apps][1] repository. Make sure:
 
 - Change set includes only your modifications within the `cluster-scope` application.
 - Change set may include your optional changes to the `.sops.yaml` file.
 - Your commit **doesn't include any sensitive data such as an unencrypted resource**, such resources should be included only as encrypted.
+
+[1]: https://github.com/operate-first/apps
+[2]: https://github.com/operate-first/support
+[3]: https://github.com/operate-first/toolbox
+[4]: https://kustomize.io/
+[5]: https://github.com/mozilla/sops
+[6]: https://github.com/viaduct-ai/kustomize-sops
+[7]: https://github.com/operate-first/opfcli/releases
+[8]: ../argocd-gitops/onboarding_to_argocd.md
+[9]: https://github.com/operate-first/blueprint
+[10]: https://www.operate-first.cloud/
+[11]: https://github.com/operate-first/apps/tree/master/cluster-scope/overlays/prod/moc#secret-management
+[12]: https://github.com/mozilla/sops#encrypting-only-parts-of-a-file

--- a/docs/content/grafana/README.md
+++ b/docs/content/grafana/README.md
@@ -1,28 +1,38 @@
 # Grafana
 
-[Grafana](https://grafana.com/oss/grafana) is a multi-platform open source analytics and interactive visualization tool. It allows you to query, create dashboards, explore, and alert on metrics when connected to supported data sources.
+[Grafana][1] is a multi-platform open source analytics and interactive visualization tool. It allows you to query, create dashboards, explore, and alert on metrics when connected to supported data sources.
 
 We use Grafana to visualize the metrics that we source from our [User Workload Monitoring][../uwm]. These monitoring dashboards are useful for visualizing the metrics (such as Prometheus metrics) collected from the applications to track and analyze the system's overall health.
 
 The dashboards can be altered, saved and reused as per your specific monitoring needs.
 
-Dashboards can be represented by the `GrafanaDashboard` custom resource or by their raw `JSON` files. You can find example monitoring dashboards defined in separate `JSON` files for each of the Operate First managed applications in our [apps repo](https://github.com/operate-first/apps/tree/master/grafana/base/dashboards). For more information on how the Grafana dashboards are defined, please refer to [this documentation](https://github.com/integr8ly/grafana-operator/blob/master/documentation/dashboards.md).
+Dashboards can be represented by the `GrafanaDashboard` custom resource or by their raw `JSON` files. You can find example monitoring dashboards defined in separate `JSON` files for each of the Operate First managed applications in our [apps repo][2]. For more information on how the Grafana dashboards are defined, please refer to [this documentation][3].
 
 ## Get Access to Grafana
 
 Grafana can be accessed at: https://grafana.operate-first.cloud/
 
-You will need to be onboarded to access the UI, this can be self serviced, please follow the instructions [here](map_groups_to_roles.md) to do so. You will need to belong to an OCP `group` in order to gain access, current list of groups and their belonging users can be found [here](https://github.com/operate-first/apps/tree/master/cluster-scope/base/user.openshift.io/groups). If you do not belong to one, please create one, and then include this group in the `smaug` cluster overlay [here](https://github.com/operate-first/apps/blob/master/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml).
+You will need to be onboarded to access the UI, this can be self serviced, please follow the instructions [here][4] to do so. You will need to belong to an OCP `group` in order to gain access, current list of groups and their belonging users can be found [here][5]. If you do not belong to one, please create one, and then include this group in the `smaug` cluster overlay [here][6].
 
 ## Adding the Dashboards
 
-To add your dashboards to Grafana, you will need to create a `GrafanaDashboard` custom resource. To do this, you can follow the instructions available [here](add_grafana_dashboard.md).
+To add your dashboards to Grafana, you will need to create a `GrafanaDashboard` custom resource. To do this, you can follow the instructions available [here][7].
 
 ## Using the Dashboards
 
 Grafana dashboards can easily be exported and imported, either from the UI or from the HTTP API.
 Dashboards are exported in Grafana JSON format, and contain everything you need (layout, variables, styles, data sources, queries, etc) to import the dashboard at a later time.
 
-You can import these dashboards in Grafana either by pasting the dashboard JSON text directly into the text area or directly uploading the JSON file. Make sure to add/connect your [data sources](https://grafana.com/docs/grafana/latest/datasources/) to Grafana and pick what data source you want the dashboard to use.
+You can import these dashboards in Grafana either by pasting the dashboard JSON text directly into the text area or directly uploading the JSON file. Make sure to add/connect your [data sources][8] to Grafana and pick what data source you want the dashboard to use.
 
-For more details on importing/exporting dashboards, you can refer to the Grafana documentation [here](https://grafana.com/docs/grafana/latest/dashboards/export-import/).
+For more details on importing/exporting dashboards, you can refer to the Grafana documentation [here][9].
+
+[1]: https://grafana.com/oss/grafana
+[2]: https://github.com/operate-first/apps/tree/master/grafana/overlays/moc/smaug/dashboards
+[3]: https://github.com/integr8ly/grafana-operator/blob/master/documentation/dashboards.md
+[4]: map_groups_to_roles.md
+[5]: https://github.com/operate-first/apps/tree/master/cluster-scope/base/user.openshift.io/groups
+[6]: https://github.com/operate-first/apps/blob/master/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+[7]: add_grafana_dashboard.md
+[8]: https://grafana.com/docs/grafana/latest/datasources/
+[9]: https://grafana.com/docs/grafana/latest/dashboards/export-import/

--- a/docs/content/grafana/add_grafana_dashboard.md
+++ b/docs/content/grafana/add_grafana_dashboard.md
@@ -23,7 +23,7 @@ In this template, all you need to do is update:
 1. `metadata.name` - the dashboard name
 2. `spec.url` - the URL pointing to the location of your dashboard JSON file
 
-Pick a suitable `metadata.name`, ensure that its unique in the [`grafana/base/dashboards`](https://github.com/operate-first/apps/tree/master/grafana/base/dashboards) folder.
+Pick a suitable `metadata.name`, ensure that its unique in the [`grafana/base/dashboards`][1] folder.
 
 Save this file under `grafana/base/dashboards/${DASHBOARD_FOLDER}/grafana-dashboard-example.yaml`.
 
@@ -33,3 +33,5 @@ Then add it to `grafana/base/dashboards/kustomization.yaml` by running the follo
 $ cd grafana/base/dashboards
 $ kustomize edit add resource grafana-dashboard-example.yaml
 ```
+
+[1]: https://github.com/operate-first/apps/tree/master/grafana/base/dashboards

--- a/docs/content/kubeflow/README.md
+++ b/docs/content/kubeflow/README.md
@@ -1,6 +1,6 @@
 # Kubeflow
 
-> Note: Currently our Kubeflow deployments are no longer active, see [this discussion](https://github.com/operate-first/support/issues/435) for details.
+> Note: Currently our Kubeflow deployments are no longer active, see [this discussion][4] for details.
 
 The Operate First managed Kubeflow deployment on the MOC cluster is available for the public to experience.
 
@@ -25,3 +25,4 @@ Link to UI: http://tekton-dashboard-tekton-pipelines.apps.zero.massopen.cloud/
 [1]: https://www.kubeflow.org/docs/components/central-dash/overview/
 [2]: https://www.kubeflow.org/docs/components/pipelines/
 [3]: https://github.com/tektoncd/pipeline
+[4]: https://github.com/operate-first/support/issues/435

--- a/docs/content/kubeflow/kubeflow-dashboard/README.md
+++ b/docs/content/kubeflow/kubeflow-dashboard/README.md
@@ -1,8 +1,8 @@
 # Kubeflow Access
 
-> Note: Currently our Kubeflow deployments are no longer active, see [this discussion](https://github.com/operate-first/support/issues/435) for details.
+> Note: Currently our Kubeflow deployments are no longer active, see [this discussion][1] for details.
 
-[Kubeflow](https://www.kubeflow.org/docs/about/kubeflow/) is a machine learning toolkit for Kubernetes.
+[Kubeflow][2] is a machine learning toolkit for Kubernetes.
 
 An instance of Kubeflow is available for use in OperateFirst.
 
@@ -11,3 +11,7 @@ You can access the Kubeflow dashboard with the following url.
 - URL: http://istio-ingressgateway-istio-system.apps.zero.massopen.cloud/
 
 There is a demo profile (`kf-demo`) with limited resources set up in our Kubeflow instance. This profile is accessible publicly [here](http://istio-ingressgateway-istio-system.apps.zero.massopen.cloud/?ns=kf-demo).
+
+[1]: https://github.com/operate-first/support/issues/435
+[2]: https://www.kubeflow.org/docs/about/kubeflow/
+[3]: http://istio-ingressgateway-istio-system.apps.zero.massopen.cloud/?ns=kf-demo

--- a/docs/content/kubeflow/kubeflow-pipelines/README.md
+++ b/docs/content/kubeflow/kubeflow-pipelines/README.md
@@ -1,14 +1,19 @@
 # Kubeflow-Pipelines Access
 
-> Note: Currently our Kubeflow deployments are no longer active, see [this discussion](https://github.com/operate-first/support/issues/435) for details.
+> Note: Currently our Kubeflow deployments are no longer active, see [this discussion][1] for details.
 
-[Kubeflow Pipelines](https://www.kubeflow.org/docs/pipelines/overview/pipelines-overview/#what-is-kubeflow-pipelines) is a platform for building and deploying portable, scalable machine learning (ML) workflows based on Docker containers.
+[Kubeflow Pipelines][2] is a platform for building and deploying portable, scalable machine learning (ML) workflows based on Docker containers.
 
 An instance of Kubeflow Pipelines is available for use in OperateFirst.
 
 - API Endpoint: http://istio-ingressgateway-istio-system.apps.zero.massopen.cloud/pipeline
 - UI: http://istio-ingressgateway-istio-system.apps.zero.massopen.cloud/pipeline/#/pipelines
 
-You can find some samples and tutorials for Kubeflow Pipelines [here](https://www.kubeflow.org/docs/pipelines/tutorials/build-pipeline/).
+You can find some samples and tutorials for Kubeflow Pipelines [here][3].
 
-If you need a Jupyter Notebook environment, you can use the OperateFirst JupyterHub instance, which is available [here](https://jupyterhub-opf-jupyterhub.apps.zero.massopen.cloud/).
+If you need a Jupyter Notebook environment, you can use the OperateFirst JupyterHub instance, which is available [here][4].
+
+[1]: https://github.com/operate-first/support/issues/435
+[2]: https://www.kubeflow.org/docs/pipelines/overview/pipelines-overview/#what-is-kubeflow-pipelines
+[3]: https://www.kubeflow.org/docs/pipelines/tutorials/build-pipeline/
+[4]: https://jupyterhub-opf-jupyterhub.apps.zero.massopen.cloud/

--- a/docs/content/observatorium/loki/README.md
+++ b/docs/content/observatorium/loki/README.md
@@ -1,6 +1,6 @@
 # Loki Access
 
-[Loki](https://github.com/grafana/loki#loki-like-prometheus-but-for-logs) is a horizontally-scalable, highly-available, multi-tenant log aggregation system.
+[Loki][1] is a horizontally-scalable, highly-available, multi-tenant log aggregation system.
 
 An instance of Loki is available for use in OperateFirst.
 
@@ -12,7 +12,7 @@ Loki access is open to public and is divided into 3 different components:
 
 While pushing logs into Loki or while querying Loki for logs,
 you will need to have a header `'X-Scope-OrgID'` set in your requests.
-This header (OrgID) is used to identify tenants in a multi tenancy setup ([more info](https://grafana.com/docs/loki/latest/operations/multi-tenancy/)),
+This header (OrgID) is used to identify tenants in a multi tenancy setup ([more info][2]),
 it will also play a role when adding a Loki Grafana datasource, more on that later.
 
 The value for this header can be anything.
@@ -35,7 +35,7 @@ curl -v -H "Content-Type: application/json" \
 
 This command sends a log line `"my-log-line"` with the label `"app": "my-app-1"` for the timestamp `1607526347000000000` (`2020-12-09T15:05:47.000Z`) and uses `"opf-example"` as the OrgID (or tenant ID).
 
-More Info on [/push](https://grafana.com/docs/loki/latest/api/#post-lokiapiv1push)
+More Info on [/push][3]
 
 ## Loki Frontend
 
@@ -56,7 +56,7 @@ This command queries logs from Loki using `"app="my-app-1"` label as the
 query and the start time for the query is set to `1607526347000000000` (`2020-12-09T15:05:47.000Z`).
 _Notice that we had to provide the same OrgID "opf-example" to be able to query for the logs that we pushed in._
 
-More Info on [/query_range](https://grafana.com/docs/loki/latest/api/#get-lokiapiv1query_range)
+More Info on [/query_range][4]
 
 ## Grafana
 
@@ -65,7 +65,13 @@ More Info on [/query_range](https://grafana.com/docs/loki/latest/api/#get-lokiap
 This is the endpoint for Grafana that can be used to query logs from Loki in a UI.
 
 To be able to query logs using Grafana, you will need to add a Grafana Datasource
-specific to your Org-ID (the `'X-Scope-OrgID'` header). To do that instructions are available [here](add_loki_grafana_datasource.md).
+specific to your Org-ID (the `'X-Scope-OrgID'` header). To do that instructions are available [here][5].
 
 An example query should be accessible at the following url:
 https://grafana.operate-first.cloud/explore?orgId=1&left=["1607519717000","1607526347000","loki-opf-example",{"expr":"{app%3D\"my-app-1\"}"}]
+
+[1]: https://github.com/grafana/loki#loki-like-prometheus-but-for-logs
+[2]: https://grafana.com/docs/loki/latest/operations/multi-tenancy/
+[3]: https://grafana.com/docs/loki/latest/api/#post-lokiapiv1push
+[4]: https://grafana.com/docs/loki/latest/api/#get-lokiapiv1query_range
+[5]: add_loki_grafana_datasource.md

--- a/docs/content/observatorium/loki/add_loki_grafana_datasource.md
+++ b/docs/content/observatorium/loki/add_loki_grafana_datasource.md
@@ -1,6 +1,6 @@
 # Add a Loki Data Source in OperateFirst Grafana
 
-To be able to query logs for your [OrgID](https://grafana.com/docs/loki/latest/operations/multi-tenancy/) in Grafana, you need to add a new Loki data source
+To be able to query logs for your [OrgID][1] in Grafana, you need to add a new Loki data source
 with the `'X-Scope-OrgID'` header set to your OrgID.
 
 An example Data source template is shown below:
@@ -32,7 +32,7 @@ replace `opf-example` in `httpHeaderValue1` with a preferred OrgID.
 _Please note that you will have to use this OrgID to push logs into Loki,
 otherwise your logs won't be visible in Grafana._
 
-Pick a suitable name, and add it our `smaug` `grafana` configurations [here](https://github.com/operate-first/apps/tree/master/grafana/overlays/moc/smaug). Ensure that the name is unique amongst the `GrafanaDataSource`.
+Pick a suitable name, and add it our `smaug` `grafana` configurations [here][2]. Ensure that the name is unique amongst the `GrafanaDataSource`.
 
 Also add this datasource file to the main `kustomization.yaml` by running the following:
 
@@ -40,3 +40,6 @@ Also add this datasource file to the main `kustomization.yaml` by running the fo
 $ cd grafana/overlays/moc/smaug/kustomization.yaml
 $ kustomize edit add resource opf-example-loki-source.yaml
 ```
+
+[1]: https://grafana.com/docs/loki/latest/operations/multi-tenancy/
+[2]: https://github.com/operate-first/apps/tree/master/grafana/overlays/moc/smaug

--- a/docs/content/observatorium/thanos/README.md
+++ b/docs/content/observatorium/thanos/README.md
@@ -1,6 +1,6 @@
 # Thanos Access
 
-[Thanos](https://github.com/thanos-io/thanos) is a set of components that can be composed into a highly available metric system with unlimited storage capacity, which can be added seamlessly on top of existing Prometheus deployments.
+[Thanos][1] is a set of components that can be composed into a highly available metric system with unlimited storage capacity, which can be added seamlessly on top of existing Prometheus deployments.
 
 An instance of Thanos is available for use in Operate First.
 ## Requesting Thanos access
@@ -13,14 +13,14 @@ Thanos metrics can be accessed in two different ways:
 ### Grafana Console access
 The Operate First Grafana console can be accessed at: https://grafana.operate-first.cloud/
 
-To request access to the Grafana Console, read the [following guide](request_grafana_access.md).
+To request access to the Grafana Console, read the [following guide][2].
 
 ### Thanos Query API/Console access
 The Thanos Query API/Console can be accessed at:
 
 https://thanos-query-frontend-opf-observatorium.apps.smaug.na.operate-first.cloud/
 
-To request access to the Thanos Query API, read the [following guide](request_thanos_access.md).
+To request access to the Thanos Query API, read the [following guide][3].
 
 ## Thanos Metrics Retention
 In this instance of Thanos, metric data will be stored as following:
@@ -33,9 +33,14 @@ In this instance of Thanos, metric data will be stored as following:
 
 Here the `Original/Raw` resolution means the resolution at which metrics were collected.
 
-More information on how this retention of metric data can be found [here](https://github.com/thanos-io/thanos/blob/main/docs/components/compact.md#enforcing-retention-of-data).
+More information on how this retention of metric data can be found [here][4].
 
 *Note: the resolution and duration of the stored metric data might change in the future*
 
 ## Adding new metrics to Thanos
 All of Thanos metric data is pushed in by the Openshift Monitoring Prometheus instances from various Operate First clusters.
+
+[1]: https://github.com/thanos-io/thanos
+[2]: request_grafana_access.md
+[3]: request_thanos_access.md
+[4]: https://github.com/thanos-io/thanos/blob/main/docs/components/compact.md#enforcing-retention-of-data

--- a/docs/content/observatorium/thanos/request_grafana_access.md
+++ b/docs/content/observatorium/thanos/request_grafana_access.md
@@ -11,17 +11,22 @@ We support three different roles for accessing the Operate First Grafana instanc
 * **Editor**: In addition to *Viewer* permissions, user can edit/create new visualization dashboards.
 * **Admin**: In addition to *Editor* permissions, user can manage Dashboards and Datasources.
 
-More information about these roles is available [here](https://grafana.com/docs/grafana/latest/permissions/organization_roles/#compare-roles).
+More information about these roles is available [here][1].
 
 
 ## Steps to follow
 To get the specific permissions needed to get Grafana access, please follow these steps:
 
-1. Onboard your project/group to Operate First ([guide](https://github.com/operate-first/hitchhikers-guide/blob/main/pages/onboarding_project.ipynb)).
-2. Once your group has been onboarded, add your group and desired role to [this list](https://github.com/operate-first/apps/blob/master/grafana/overlays/moc/smaug/grafana-oauth.yaml#L29) in a new line as: <br>
+1. Onboard your project/group to Operate First ([guide][2]).
+2. Once your group has been onboarded, add your group and desired role to [this list][3] in a new line as: <br>
 
    `contains(groups[*], 'MY_GROUP_NAME')        && 'MY_DESIRED_ROLE' ||` <br>
 
-   and create a PR (Pull Request). You can see an example Pull Request [here](https://github.com/operate-first/apps/pull/1323).
+   and create a PR (Pull Request). You can see an example Pull Request [here][4].
 
 3. After your PR is reviewed/merged, you should have access to the Thanos Query Console and API.
+
+[1]: https://grafana.com/docs/grafana/latest/permissions/organization_roles/#compare-roles
+[2]: https://github.com/operate-first/hitchhikers-guide/blob/main/pages/onboarding_project.ipynb
+[3]: https://github.com/operate-first/apps/blob/master/grafana/overlays/moc/smaug/grafana-oauth.yaml#L29
+[4]: https://github.com/operate-first/apps/pull/1323

--- a/docs/content/observatorium/thanos/request_thanos_access.md
+++ b/docs/content/observatorium/thanos/request_thanos_access.md
@@ -1,18 +1,24 @@
 # Thanos Query API
 
 With Thanos Query access, you will be able to:
-1. Access the [Thanos Query Frontend UI](https://thanos-query-frontend-opf-observatorium.apps.smaug.na.operate-first.cloud/)
-2. Access the Thanos metrics programmatically using your OpenShift personal token ([instructions](thanos_programmatic_access.md))
+1. Access the [Thanos Query Frontend UI][1]
+2. Access the Thanos metrics programmatically using your OpenShift personal token ([instructions][2])
 
 ## Steps to follow
 To get the specific permissions needed query metrics directly from the Thanos Query API, please follow these steps:
 
-1. Onboard your project/group to Operate First ([guide](https://github.com/operate-first/hitchhikers-guide/blob/main/pages/onboarding_project.ipynb))
-2. Once your group has been onboarded, add your group to [this list](https://github.com/operate-first/apps/blob/master/observatorium/overlays/moc/smaug/thanos/rolebindings/opf-observatorium-view.yaml#L10) in a new line as: <br>
+1. Onboard your project/group to Operate First ([guide][3])
+2. Once your group has been onboarded, add your group to [this list][4] in a new line as: <br>
    ```yaml
     - kind: Group
       apiGroup: rbac.authorization.k8s.io
       name: MY_GROUP_NAME
    ```
-   and create a PR (Pull Request). You can see an example Pull Request [here](https://github.com/operate-first/apps/pull/1378)
+   and create a PR (Pull Request). You can see an example Pull Request [here][5]
 3. After your PR is reviewed/merged, you should have access to the Thanos Query Console and API
+
+[1]: https://thanos-query-frontend-opf-observatorium.apps.smaug.na.operate-first.cloud/
+[2]: thanos_programmatic_access.md
+[3]: https://github.com/operate-first/hitchhikers-guide/blob/main/pages/onboarding_project.ipynb
+[4]: https://github.com/operate-first/apps/blob/master/observatorium/overlays/moc/smaug/thanos/rolebindings/opf-observatorium-view.yaml#L10
+[5]: https://github.com/operate-first/apps/pull/1378

--- a/docs/content/observatorium/thanos/thanos_programmatic_access.md
+++ b/docs/content/observatorium/thanos/thanos_programmatic_access.md
@@ -1,8 +1,8 @@
 # Thanos Programmatic Access
 
-The Thanos metrics can be queried using the [this](https://prometheus-api-client-python.readthedocs.io/) Python client library.
+The Thanos metrics can be queried using the [this][1] Python client library.
 You can install the latest version with `pip install prometheus-api-client`.
-You will need to extract the OpenShift bearer token for the client library to authenticate the [thanos](https://thanos-query-frontend-opf-observatorium.apps.smaug.na.operate-first.cloud/) instance.
+You will need to extract the OpenShift bearer token for the client library to authenticate the [thanos][2] instance.
 
 ## Personal token
 
@@ -20,5 +20,10 @@ You can use your personal token for testing and ad-hoc scripts, but it will expi
    )
    ```
 4. The metric data can be extracted locally using the prometheus client in a Jupyter notebook
-   * [Sample notebook](https://github.com/aicoe-aiops/time-series/blob/master/notebooks/ts-1-fetching-metrics.ipynb)
-5. You can also spawn and run your notebooks on [JupyterHub](https://jupyterhub-opf-jupyterhub.apps.smaug.na.operate-first.cloud/)
+   * [Sample notebook][3]
+5. You can also spawn and run your notebooks on [JupyterHub][4]
+
+[1]: https://prometheus-api-client-python.readthedocs.io/
+[2]: https://thanos-query-frontend-opf-observatorium.apps.smaug.na.operate-first.cloud/
+[3]: https://github.com/aicoe-aiops/time-series/blob/master/notebooks/ts-1-fetching-metrics.ipynb
+[4]: https://jupyterhub-opf-jupyterhub.apps.smaug.na.operate-first.cloud/

--- a/docs/content/observatorium/vector/README.md
+++ b/docs/content/observatorium/vector/README.md
@@ -8,6 +8,6 @@ You can find our Vector configurations [here][config]. If you would like to make
 
 [Vector]: https://github.com/vectordotdev/vector
 [CLO]: https://docs.openshift.com/container-platform/4.9/logging/cluster-logging-external.html
-[Kafka]: https://github.com/operate-first/apps/tree/master/docs/odh/kafka
-[Loki]: https://github.com/operate-first/apps/tree/master/docs/observatorium/loki
+[Kafka]: ../../odh/kafka/README.md
+[Loki]: ../loki/README.md
 [config]: https://github.com/operate-first/apps/tree/master/observatorium/overlays/moc/smaug/vector/smaug/configmap.yaml

--- a/docs/content/odh/README.md
+++ b/docs/content/odh/README.md
@@ -12,13 +12,13 @@ Below is a list of all the components deployed, and relevant links to their UI.
 
 UI: https://jupyterhub-opf-jupyterhub.apps.smaug.na.operate-first.cloud
 
-Docs can be found [here](https://github.com/operate-first/apps/tree/master/docs/odh/jupyterhub).
+Docs can be found [here][1].
 
 ### [Kafka][7]
 
 Kafka broker URL: https://odh-message-bus-kafka-bootstrap-opf-kafka.apps.smaug.na.operate-first.cloud
 
-Docs can be found [here](kafka/README.md).
+Docs can be found [here][2].
 
 ### [ODH Dashboard][8]
 
@@ -28,18 +28,22 @@ UI: https://odh.operate-first.cloud/
 
 UI: https://trino.operate-first.cloud
 
-Docs can be found [here](https://github.com/operate-first/apps/tree/master/docs/odh/trino).
+Docs can be found [here][3].
 
 ### [Superset][12]
 
 UI: https://superset.operate-first.cloud
 
-Docs can be found [here](https://github.com/operate-first/apps/tree/master/docs/odh/superset).
+Docs can be found [here][4].
 
 #### Components not deployed
 
 If you require any components offered by ODH that are not currently managed, please submit a request [here][2].
 
+[1]: jupyterhub/README.md
+[2]: kafka/README.md
+[3]: trino/README.md
+[4]: superset/README.md
 [6]: https://jupyter.org/hub
 [7]: https://kafka.apache.org/
 [8]: https://github.com/opendatahub-io/odh-dashboard

--- a/docs/content/odh/jupyterhub/access_jupyterhub.md
+++ b/docs/content/odh/jupyterhub/access_jupyterhub.md
@@ -2,4 +2,6 @@
 
 Access to JupyterHub is open to the public. All you need is a GitHub account.
 
-Our JupyterHub instance on the `smaug` cluster can be found [here](https://jupyterhub-opf-jupyterhub.apps.smaug.na.operate-first.cloud). Login using the `operate-first` option, and you will be redirected to the JH spawner UI. Select any notebook, a suitable size, and start the server.
+Our JupyterHub instance on the `smaug` cluster can be found [here][1]. Login using the `operate-first` option, and you will be redirected to the JH spawner UI. Select any notebook, a suitable size, and start the server.
+
+[1]: https://jupyterhub-opf-jupyterhub.apps.smaug.na.operate-first.cloud

--- a/docs/content/odh/jupyterhub/add_imagestream_to_jh.md
+++ b/docs/content/odh/jupyterhub/add_imagestream_to_jh.md
@@ -4,7 +4,7 @@ This doc provides instructions on adding a new imagestream so that it may be ava
 
 ## Steps
 
-- Please fork/clone the [operate-first/apps](https://github.com/operate-first/apps) repository
+- Please fork/clone the [operate-first/apps][1] repository
 - Navigate to: `kfdefs/base/jupyterhub/notebook-images` , this is where all our imagestreams reside
 - Create a new imagestream, use the template below:
 
@@ -45,3 +45,5 @@ spec:
 * Add this filename to the `kustomization.yaml` to `kfdefs/base/jupyterhub/notebook-images/kustomization.yaml`
 
 Commit your changes and make a PR. Once merged, the imagestream will be deployed by ArgoCD and show up on the JupyterHub spawner UI.
+
+[1]: https://github.com/operate-first/apps

--- a/docs/content/odh/jupyterhub/analyze_storage.md
+++ b/docs/content/odh/jupyterhub/analyze_storage.md
@@ -6,9 +6,8 @@ This doc aims to answer commonly asked questions pertaining to investigating/ana
 
 You can do this using one of 2 ways:
 
-* Using Grafana: Visit our dashboard for Jupyterhub found [here](https://grafana.operate-first.cloud/d/fuJBFErMz/jupyterhub-user-perspective?orgId=1). Select the `openshift-monitoring` datasource, and your OCP `user` from the dropdown. Then the amount of free storage in my pvc can be assessed by inspecting the used/total space panel.
+* Using Grafana: Visit our dashboard for Jupyterhub found [here][1]. Select the `openshift-monitoring` datasource, and your OCP `user` from the dropdown. Then the amount of free storage in my pvc can be assessed by inspecting the used/total space panel.
 * Start your notebook server, go into your `terminal`, type the command `df -h` , the amount of free storage in your pvc should be listed under "Available" column, mounted on /opt/app-root/src
-
 
 
 ## I want to know what is consuming most of the space on my PVC
@@ -22,7 +21,8 @@ du -h --max-depth=2 . | sort -h
 This should display a list of folders on your PVC sorted by their size.
 
 
-
 ## How can I cleanup my `Pipenv` cache?
 
 Simply delete the folder named `.cache/pipenv`.
+
+[1]: https://grafana.operate-first.cloud/d/fuJBFErMz/jupyterhub-user-perspective?orgId=1

--- a/docs/content/odh/jupyterhub/increase_pvc_size_jh.md
+++ b/docs/content/odh/jupyterhub/increase_pvc_size_jh.md
@@ -28,4 +28,6 @@ spec:
 
 Add this filename to the `kustomization.yaml` located at: `kfdefs/overlays/moc/smaug/opf-jupyterhub/pvcs/kustomization.yaml`
 
-Commit your changes and make a PR, once merged ArgoCD will deploy the changes and you should then see an increase in your storage. You can verify your changes by following the instructions [here](analyze_storage.md).
+Commit your changes and make a PR, once merged ArgoCD will deploy the changes and you should then see an increase in your storage. You can verify your changes by following the instructions [here][1].
+
+[1]: analyze_storage.md

--- a/docs/content/odh/jupyterhub/user_profiles.md
+++ b/docs/content/odh/jupyterhub/user_profiles.md
@@ -8,11 +8,20 @@ The following steps serves as a guide for maintenance on user profiles for ODH J
 
 You will need pre-requisite tools to follow along with this doc, please do one of the following:
 
-- Install our [toolbox](https://github.com/operate-first/toolbox) to have the developer setup ready automatically for you.
-- Install the tools manually. You'll need [kustomize](https://kustomize.io/), [sops](https://github.com/mozilla/sops) and [ksops](https://github.com/viaduct-ai/kustomize-sops).
+- Install our [toolbox][1] to have the developer setup ready automatically for you.
+- Install the tools manually. You'll need [kustomize][2], [sops][3] and [ksops][4].
 
-Please fork/clone the [operate-first/apps](https://github.com/operate-first/apps) repository.
+Please fork/clone the [operate-first/apps][5] repository.
 
 ## JupyterHub user profiles and HW quota
 
-JupyterHub userprofiles are managed [here](https://github.com/operate-first/apps/tree/master/odh-manifests/smaug/jupyterhub/base). These are amendments to the configmaps that are pulled from the [odh-manifests repo](https://github.com/opendatahub-io/odh-manifests). They are managed by ODH operator. Any new configmaps ought to be added [here](https://github.com/operate-first/apps/tree/master/kfdefs/overlays/moc/smaug/opf-jupyterhub), so they may be managed by ArgoCD.
+JupyterHub userprofiles are managed [here][6]. These are amendments to the configmaps that are pulled from the [odh-manifests repo][7]. They are managed by ODH operator. Any new configmaps ought to be added [here][8], so they may be managed by ArgoCD.
+
+[1]: https://github.com/operate-first/toolbox
+[2]: https://kustomize.io/
+[3]: https://github.com/mozilla/sops
+[4]: https://github.com/viaduct-ai/kustomize-sops
+[5]: https://github.com/operate-first/apps
+[6]: https://github.com/operate-first/apps/tree/master/odh-manifests/smaug/jupyterhub/base
+[7]: https://github.com/opendatahub-io/odh-manifests
+[8]: https://github.com/operate-first/apps/tree/master/kfdefs/overlays/moc/smaug/opf-jupyterhub

--- a/docs/content/odh/kafka/README.md
+++ b/docs/content/odh/kafka/README.md
@@ -15,8 +15,11 @@ Credentials/certs are generated per `KafkaUser` bases.
 
 ## Adding Kafka topics
 
-To add Kafka topics follow the instructions [here](add_kafka_topics.md).
+To add Kafka topics follow the instructions [here][1].
 
 ## Adding Kafka users
 
-To add Kafka users follow the instructions [here](add_kafka_users.md).
+To add Kafka users follow the instructions [here][2].
+
+[1]: add_kafka_topics.md
+[2]: add_kafka_users.md

--- a/docs/content/odh/kafka/add_kafka_users.md
+++ b/docs/content/odh/kafka/add_kafka_users.md
@@ -1,6 +1,6 @@
 # Add Kafka Users
 
-We manage access to Kafka Topics in our Kafka instance using the [`KafkaUser` resource](https://strimzi.io/docs/operators/0.22.1/using.html#type-KafkaUser-reference).
+We manage access to Kafka Topics in our Kafka instance using the [`KafkaUser` resource][1].
 
 To add a new `KafkaUser`, create a new `KafkaUser` resource within the `odh-manifests/smaug/kafka/overlays/users` sub directory.
 
@@ -46,7 +46,7 @@ spec:
     type: simple
 ```
 You need a group id that has access to your topic to be able to consume from it, so make sure that you have at least one group with access to your topics.
-To learn more about how consumer groups work [here](https://www.tutorialspoint.com/apache_kafka/apache_kafka_consumer_group_example.htm) is a tutorial.
+To learn more about how consumer groups work [here][2] is a tutorial.
 
 The label `strimzi.io/cluster` should have the value `odh-message-bus`.
 
@@ -62,3 +62,6 @@ $ kustomize edit add resource my-user.yaml
 ```
 
 If you don't have `kustomize` then simply add this file manually.
+
+[1]: https://strimzi.io/docs/operators/0.22.1/using.html#type-KafkaUser-reference
+[2]: https://www.tutorialspoint.com/apache_kafka/apache_kafka_consumer_group_example.htm

--- a/docs/content/odh/kafka/runbook.md
+++ b/docs/content/odh/kafka/runbook.md
@@ -4,7 +4,7 @@
 
 | Env                                    | Namespace                                                    | GitHub Repo                        |
 |----------------------------------------|-----------------------------------------------------------------------------------------------------------|-------------------------------|
-| MOC-Smaug Prod                   | [opf-kafka](https://console-openshift-console.apps.smaug.na.operate-first.cloud/k8s/ns/opf-kafka/) | - [kfdef app](https://github.com/operate-first/apps/tree/master/kfdefs/overlays/moc/smaug/opf-kafka)<br />- [odh overrides](https://github.com/operate-first/apps/tree/master/odh-manifests/smaug/kafka) |
+| MOC-Smaug Prod                   | [opf-kafka][1] | - [kfdef app][2]<br />- [odh overrides][3] |
 
 ## Contact for Additional Help
 
@@ -17,7 +17,7 @@ Links to the monitoring dashboards for this service.
 
 | Dashboard Description                     | Dashboard URL     |
 | ------------------------------------------- | ------------ |
-| Kafka Overview                       | N/A - [pending](https://github.com/operate-first/SRE/issues/382) |
+| Kafka Overview                       | N/A - [pending][4] |
 
 Some items to take note of:
 
@@ -42,7 +42,7 @@ They are as follows:
 
 | Pods | Description |
 | --------- | ----------- |
-| [Strimzi cluster operator](https://console-openshift-console.apps.smaug.na.operate-first.cloud/k8s/ns/openshift-operators/pods) | This is the main Strimzi operator pod. It orchestrates all other pods and resides in the `openshift-operators` namespace. |
+| [Strimzi cluster operator][5] | This is the main Strimzi operator pod. It orchestrates all other pods and resides in the `openshift-operators` namespace. |
 | Zookeeper | Zookeper performs controller election, cluster membership and maintain a list of all topics and configurations for the kafka brokers. |
 | Kafka Brokers| Kafka brokers handle and store the topic log partitions and services the consumers and producers. These are deployed and managed by the Strimzi Operator. |
 | Kafka Connect | Kafka connect utilizes various connectors to connect the Kafka cluster to a variety of data sources and streams. These are deployed and managed by the Strimzi Operator. |
@@ -142,3 +142,9 @@ allocation seems sane, then to apply it, run:
 ```
 
 You may also need to do this to decrease the replication factor.
+
+[1]: https://console-openshift-console.apps.smaug.na.operate-first.cloud/k8s/ns/opf-kafka/
+[2]: https://github.com/operate-first/apps/tree/master/kfdefs/overlays/moc/smaug/opf-kafka
+[3]: https://github.com/operate-first/apps/tree/master/odh-manifests/smaug/kafka
+[4]: https://github.com/operate-first/SRE/issues/382
+[5]: https://console-openshift-console.apps.smaug.na.operate-first.cloud/k8s/ns/openshift-operators/pods

--- a/docs/content/odh/superset/add_superset_users.md
+++ b/docs/content/odh/superset/add_superset_users.md
@@ -1,12 +1,17 @@
 # Provision Superset Access
 
 ## For Smaug cluster
-To provision Superset access to an individual user, we have a Superset rolebinding that provides [Alpha level](https://superset.apache.org/docs/security) access.
+To provision Superset access to an individual user, we have a Superset rolebinding that provides [Alpha level][1] access.
 
 Steps:
 1. Fork/Clone https://github.com/operate-first/apps
-2. Navigate to [this location](https://github.com/operate-first/apps/tree/master/cluster-scope/base/user.openshift.io/groups/superset-user).
-3. Add the github users to [this](https://github.com/operate-first/apps/blob/master/cluster-scope/base/user.openshift.io/groups/superset-user/group.yaml) ocp group.
+2. Navigate to [this location][2].
+3. Add the github users to [this][3] ocp group.
 4. Make a PR
 
-If you would like to give another OCP `group` access to Superset follow the instructions [here](map_groups_to_roles.md).
+If you would like to give another OCP `group` access to Superset follow the instructions [here][4].
+
+[1]: https://superset.apache.org/docs/security
+[2]: https://github.com/operate-first/apps/tree/master/cluster-scope/base/user.openshift.io/groups/superset-user
+[3]: https://github.com/operate-first/apps/blob/master/cluster-scope/base/user.openshift.io/groups/superset-user/group.yaml
+[4]: map_groups_to_roles.md

--- a/docs/content/odh/superset/runbook.md
+++ b/docs/content/odh/superset/runbook.md
@@ -26,7 +26,7 @@ supersetdb=# UPDATE public.dbs SET password = null;
 supersetdb=# UPDATE public.dbs SET encrypted_extra = null;
 ```
 
-Explained more [here](https://github.com/operate-first/SRE/issues/408)
+Explained more [here][1]
 
 ### Duplicate key value violates unique constraint
 
@@ -48,3 +48,4 @@ If it reports an error, try adding in the password again where it says `XXX..` a
 [oauth-mapping]: https://github.com/operate-first/apps/blob/master/odh-manifests/smaug/superset/base/secret.yaml#L29
 [superset]: https://superset.operate-first.cloud
 [repo]: https://github.com/operate-first/apps/tree/master/kfdefs/overlays/moc/smaug/opf-superset
+[1]: https://github.com/operate-first/SRE/issues/408

--- a/docs/content/odh/trino/add_more_postgress_catalogs.md
+++ b/docs/content/odh/trino/add_more_postgress_catalogs.md
@@ -50,3 +50,5 @@ stringData:
 ```
 
 Commit changes, make a pr.
+
+[kfdefs]: https://github.com/operate-first/apps/tree/master/kfdefs/overlays

--- a/docs/content/odh/trino/trino_superset_user_guide.md
+++ b/docs/content/odh/trino/trino_superset_user_guide.md
@@ -6,22 +6,22 @@ The purpose of this document is to list out all the steps to be followed while i
 
 The following are the pre-requisites needed before you can start interacting with Trino and Superset:
 
-* Access to [CloudBeaver](http://cloudbeaver-opf-trino.apps.smaug.na.operate-first.cloud)
+* Access to [CloudBeaver][1]
     * Reach out to Operate First team for credentials (only `admin` account is available now, user authentication is a WIP)
-* Access to [Trino](https://trino.operate-first.cloud)
+* Access to [Trino][2]
     * Login with `trino` via OCP
-* Access to [Superset](https://superset.operate-first.cloud)
-    * Follow instructions [here](../superset/add_superset_users.md).
+* Access to [Superset][3]
+    * Follow instructions [here][4].
 * Data is stored in an S3 bucket hosted on Operate First and the bucket is configured with Trino i.e. Trino has the correct credentials and permission to read the bucket
-    * Follow [this document](https://www.operate-first.cloud/users/support/docs/claiming_object_store.md) for provisioning an S3 bucket.
-* Data in S3 bucket is contained within directories/folders for it to be exported as a table in Trino and is of the supported data types mentioned [here](https://trino.io/docs/current/connector/hive.html#supported-file-types)
+    * Follow [this document][5] for provisioning an S3 bucket.
+* Data in S3 bucket is contained within directories/folders for it to be exported as a table in Trino and is of the supported data types mentioned [here][6]
 
 
 ## Ceph (S3) to Trino via CloudBeaver
 
-* **Trino** - [Trino](https://trino.io/) is a distributed SQL query engine designed to query large data sets distributed over one or more heterogeneous data sources. Since our data is stored in Ceph, **the Operate First Trino is currently configured to use the** ``opf-datacatalog-bucket`` **S3 bucket**.
+* **Trino** - [Trino][7] is a distributed SQL query engine designed to query large data sets distributed over one or more heterogeneous data sources. Since our data is stored in Ceph, **the Operate First Trino is currently configured to use the** ``opf-datacatalog-bucket`` **S3 bucket**.
 
-* **CloudBeaver** - [CloudBeaver](https://cloudbeaver.io/) is a popular web application which provides a rich UI for working and interacting with SQL databases.
+* **CloudBeaver** - [CloudBeaver][8] is a popular web application which provides a rich UI for working and interacting with SQL databases.
 
 Data in Ceph needs to be contained within a directory/folder in order to be exported as a table in Trino. A folder in Ceph (S3) maps to a table in Trino. If you put multiple files in a S3 folder, all of them will be treated as data for the same table. For example, in your S3 bucket, you can create a folder `datasets` and within this folder you can either create sub-directories like `animal-datasets`, `flower-datasets`, etc or have all your individual data files within this folder alone. While creating a table, specify the appropriate directory path containing the data files you want to populate your table with, such as:
 
@@ -29,7 +29,7 @@ Data in Ceph needs to be contained within a directory/folder in order to be expo
 
 ### Login to CloudBeaver
 
-In order to create the tables in Trino, we will use [CloudBeaver](https://github.com/dbeaver/cloudbeaver).
+In order to create the tables in Trino, we will use [CloudBeaver][9].
 
 * **Login to CloudBeaver at**: http://cloudbeaver-opf-trino.apps.smaug.na.operate-first.cloud
 
@@ -43,7 +43,7 @@ Each database has the following structure:
 
 **Database -> Catalog -> Schema -> Tables**
 
-For eg: In the `Operate First Trino` db, we have 2 [catalogs](https://trino.io/docs/current/overview/concepts.html#catalog) (data sources) i.e. ‘hive’ and ‘system’. In the `hive` catalog we have the different schemas such as `default`, `ocp` etc. Under each of these schemas, we have different tables created.
+For eg: In the `Operate First Trino` db, we have 2 [catalogs][10] (data sources) i.e. ‘hive’ and ‘system’. In the `hive` catalog we have the different schemas such as `default`, `ocp` etc. Under each of these schemas, we have different tables created.
 
 <img src="assets/images/cloudbeaver-table-view.png" width="200">
 
@@ -80,10 +80,10 @@ WITH (
 **Note: Ensure that the table column names are the same as the column names mentioned in your data set.**
 
 Reference documents, if the result differs from the desired one:
-* [SQL Syntax](https://trino.io/docs/current/sql.html)
-* [Supported file types](https://trino.io/docs/current/connector/hive.html#supported-file-types)
-* [Supported data types](https://trino.io/docs/current/language/types.html)
-* [Create table statement](https://trino.io/docs/current/sql/create-table.html)
+* [SQL Syntax][11]
+* [Supported file types][6]
+* [Supported data types][12]
+* [Create table statement][13]
 
 ### Trino
 
@@ -102,7 +102,7 @@ You can click on a particular query ID to view its logs like so:
 
 ## Trino to Superset
 
-Now that we have the tables created in Trino, we can start creating our dashboards in Superset. [Apache Superset](https://superset.apache.org/) is an open source visualization tool that allows users to create interactive dashboards. Superset is very simple to use and requires no coding knowledge.
+Now that we have the tables created in Trino, we can start creating our dashboards in Superset. [Apache Superset][14] is an open source visualization tool that allows users to create interactive dashboards. Superset is very simple to use and requires no coding knowledge.
 
 **The Operate First Superset is already configured to use Trino as the database**.
 
@@ -173,3 +173,18 @@ Hover under the “**Actions**” column next to the dashboard name you are inte
 Another useful feature of Superset is the ability to quickly export dashboards. To export a dashboard first go to the “**Dashboards**” tab of the top bar.  Next, hover under the “**Actions**” column next to the dashboard you would like to export. Finally, click on the **arrow icon** to export the dashboard and a JSON file download should start. Make sure that you have pop-ups enabled for this page or the download might not run.
 
 <img src="assets/images/superset-export-dashboard.png" width="800" height="250">
+
+[1]: http://cloudbeaver-opf-trino.apps.smaug.na.operate-first.cloud
+[2]: https://trino.operate-first.cloud
+[3]: https://superset.operate-first.cloud
+[4]: ../superset/add_superset_users.md
+[5]: ../../ocs/claiming_object_store.md
+[6]: https://trino.io/docs/current/connector/hive.html#supported-file-types
+[7]: https://trino.io/
+[8]: https://cloudbeaver.io/
+[9]: https://github.com/dbeaver/cloudbeaver
+[10]: https://trino.io/docs/current/overview/concepts.html#catalog
+[11]: https://trino.io/docs/current/sql.html
+[12]: https://trino.io/docs/current/language/types.html
+[13]: https://trino.io/docs/current/sql/create-table.html
+[14]: https://superset.apache.org/


### PR DESCRIPTION
This docs update various links in our docs, types of changes can be summed up as follows: 

- Update outdated links to point to their proper locations
- Change remote links to their relative locations where it applies
- Convert inline links to ref format, currently our docs used a mixture, this makes it consistent throughout. 

Resolves: https://github.com/operate-first/apps/issues/1412