### PR TITLE
Configure opf-trino vpa to Auto update policy

### DIFF
--- a/kfdefs/overlays/moc/smaug/opf-trino/vpa/vpa-custom-resource.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-trino/vpa/vpa-custom-resource.yaml
@@ -21,4 +21,4 @@ spec:
     kind: Deployment
     name: trino-worker
   updatePolicy:
-    updateMode: "Off"
+    updateMode: "Auto"


### PR DESCRIPTION
Currently `opf-trino` deployment has:
```
        - resources:
            limits:
              cpu: '8'
              memory: 16Gi
            requests:
              cpu: '4'
              memory: 8Gi
```
Which is 1:2 ratio with request and limits.

Current recommendation of VPA is:
```
  Recommendation:
    Container Recommendations:
      Container Name:  trino-worker
      Lower Bound:
        Cpu:     1
        Memory:  8275475046
      Target:
        Cpu:     1
        Memory:  9616998332
      Uncapped Target:
        Cpu:     25m
        Memory:  9616998332
      Upper Bound:
        Cpu:     1
        Memory:  10042521168
```
VPA boundaries that we have: 
```
        maxAllowed:
          cpu: 8000m
          memory: 16Gi
        minAllowed:
          cpu: 1000m
          memory: 4Gi
```
So if we turn on auto-update mode now, capped resources will be:
```
        - resources:
            limits:
              cpu: '2'
              memory: 16Gi
            requests:
              cpu: '1'
              memory: 8Gi
```

This seems reasonable. This PR changes update policy of VPA to auto mode, thereby VPA being able to update pods when usage goes outside lower/upper bounds of recommendation. As per this recommendation of today, CPU will reduce by 75% and memory allocation is same. cc @HumairAK , @4n4nd 