### PR TITLE
Fixed the label used for the node affinity

### DIFF
--- a/pulp/overlays/moc/smaug/opf-pulp.yaml
+++ b/pulp/overlays/moc/smaug/opf-pulp.yaml
@@ -33,7 +33,7 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
-          - key: name
+          - key: kubernetes.io/hostname
             operator: In
             values:
             - oct-03-31-compute


### PR DESCRIPTION
Fixed the label used for the node affinity
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


Fixes: https://github.com/operate-first/support/issues/456
Epic: https://github.com/operate-first/support/issues/176
This would set the node for pulp.