### PR TITLE
update onboarding guide link

### DIFF
--- a/docs/content/argocd-gitops/onboarding_to_argocd.md
+++ b/docs/content/argocd-gitops/onboarding_to_argocd.md
@@ -164,7 +164,7 @@ these namespaces using ArgoCD Applications that are part of the `thoth` project.
 [2]: https://argoproj.github.io/argo-cd/user-guide/projects/
 [3]: https://github.com/operate-first/apps/tree/master/argocd/overlays/moc-infra/projects
 [4]: https://github.com/operate-first/apps/blob/master/argocd/overlays/moc-infra/projects/global_project.yaml
-[5]: https://github.com/operate-first/support/blob/main/docs/onboarding_to_cluster.md
+[5]: https://github.com/operate-first/hitchhikers-guide/blob/main/pages/onboarding_project.ipynb
 [6]: https://github.com/operate-first/apps
 [7]: https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#applications
 [8]: https://github.com/operate-first/apps/tree/master/argocd/overlays/moc-infra/applications/envs


### PR DESCRIPTION
previous link to onboarding doc is dead -- long live the link to onboarding doc

https://github.com/operate-first/support/blob/main/docs/onboarding_to_cluster.md -> https://github.com/operate-first/hitchhikers-guide/blob/main/pages/onboarding_project.ipynb