### PR TITLE
Changing repo URL for Fybrik ArgoCD application

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/fybrik/fybrik.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/fybrik/fybrik.yaml
@@ -8,7 +8,7 @@ spec:
     namespace: fybrik-system
   source:
     path: charts/fybrik
-    repoURL: 'https://github.com/fybrik/fybrik'
+    repoURL: 'https://github.com/fybrik/charts'
     targetRevision: HEAD
     helm:
       parameters:


### PR DESCRIPTION
This PR changes the repository URL in the Fybrik ArgoCD application manifest so that resources are synced only on every new release of Fybrik

@roee88 @HumairAK 