### PR TITLE
tremor-demo argocd onboarding

### DIFF
--- a/argocd/overlays/moc-infra/configs/argo_cm/dex.config
+++ b/argocd/overlays/moc-infra/configs/argo_cm/dex.config
@@ -13,10 +13,11 @@ connectors:
         - argocd-admins
         - argocd-readonly
         - b4mad
-        - thoth
-        - operate-first
         - data-science
-        - rekor
-        - lab-cicd
         - fybrik
+        - lab-cicd
+        - operate-first
+        - rekor
+        - thoth
+        - tremor-demo
         - workshops

--- a/argocd/overlays/moc-infra/configs/argo_rbac_cm/policy.csv
+++ b/argocd/overlays/moc-infra/configs/argo_rbac_cm/policy.csv
@@ -28,3 +28,4 @@ g, lab-cicd, role:standard-user
 g, apicurio, role:standard-user
 g, sre, role:standard-user
 g, fybrik, role:standard-user
+g, tremor-demo, role:standard-user

--- a/argocd/overlays/moc-infra/projects/kustomization.yaml
+++ b/argocd/overlays/moc-infra/projects/kustomization.yaml
@@ -12,4 +12,5 @@ resources:
   - operate-first.yaml
   - rekor.yaml
   - thoth.yaml
+  - tremor-demo.yaml
   - workshops.yaml

--- a/argocd/overlays/moc-infra/projects/tremor-demo.yaml
+++ b/argocd/overlays/moc-infra/projects/tremor-demo.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: tremor-demo
+  labels:
+    project-template: global
+spec:
+  destinations:
+    - namespace: 'tremor-demo*'
+      name: 'smaug'
+  sourceRepos:
+    - '*'
+  roles:
+    - name: project-admin
+      description: Read/Write access to this project only
+      policies:
+        - p, proj:tremor-demo:project-admin, applications, get, tremor-demo/*, allow
+        - p, proj:tremor-demo:project-admin, applications, create, tremor-demo/*, allow
+        - p, proj:tremor-demo:project-admin, applications, update, tremor-demo/*, allow
+        - p, proj:tremor-demo:project-admin, applications, delete, tremor-demo/*, allow
+        - p, proj:tremor-demo:project-admin, applications, sync, tremor-demo/*, allow
+        - p, proj:tremor-demo:project-admin, applications, override, tremor-demo/*, allow
+        - p, proj:tremor-demo:project-admin, applications, action/*, tremor-demo/*, allow
+      groups:
+        - tremor-demo
+        - operate-first


### PR DESCRIPTION
following [this guide](https://www.operate-first.cloud/apps/content/argocd-gitops/onboarding_to_argocd.html) i've made changes that should allow the tremor-demo team to make use of argo-cd. Could have missed something, happy for any feedback / changes / other processes we need to follow here.