### PR TITLE
Add access to Grafana for the thoth team

### DIFF
--- a/grafana/overlays/moc/smaug/grafana-oauth.yaml
+++ b/grafana/overlays/moc/smaug/grafana-oauth.yaml
@@ -35,5 +35,6 @@ spec:
         contains(groups[*], 'data-science')   && 'Viewer' ||
         contains(groups[*], 'curator')        && 'Editor' ||
         contains(groups[*], 'prometheus-anomaly-detector') && 'Editor' ||
+        contains(groups[*], 'thoth')          && 'Editor' ||
         'Deny'
       role_attribute_strict: true


### PR DESCRIPTION
There are a few Grafana dashboards for the Thoth team, but the team is not explicitly listed as a group with access.

In particular, as I am not part of any of the current groups, this means I don't have access to Grafana :innocent: 

This PR is to add the `thoth` team to Grafana.