### PR TITLE
Set default storage class for kafka on smaug.

### DIFF
--- a/odh-manifests/smaug/kafka/base/kafka-cluster.yaml
+++ b/odh-manifests/smaug/kafka/base/kafka-cluster.yaml
@@ -43,7 +43,6 @@ spec:
     storage:
       type: persistent-claim
       size: 40Gi
-      class: moc-nfs-csi
       deleteClaim: false
     metricsConfig:
       type: jmxPrometheusExporter
@@ -63,7 +62,6 @@ spec:
     storage:
       type: persistent-claim
       size: 2Gi
-      class: moc-nfs-csi
       deleteClaim: false
     metricsConfig:
       type: jmxPrometheusExporter


### PR DESCRIPTION
Due to: https://github.com/operate-first/SRE/issues/416#issue-1041404796