### PR TITLE
Update Argo, odhdashboard, kafka, seldon kfdefs to 1.1.1

### DIFF
--- a/kfdefs/base/argo/kfdef.yaml
+++ b/kfdefs/base/argo/kfdef.yaml
@@ -24,5 +24,5 @@ spec:
       name: odhargo
   repos:
     - name: manifests
-      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.1.0"
-  version: v1.1.0
+      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.1.1"
+  version: v1.1.1

--- a/kfdefs/base/dashboard/kfdef.yaml
+++ b/kfdefs/base/dashboard/kfdef.yaml
@@ -22,7 +22,7 @@ spec:
       name: odh-dashboard
   repos:
     - name: manifests
-      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.1.0"
+      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.1.1"
     - name: opf
       uri: "https://github.com/operate-first/apps/tarball/master"
-  version: v1.1.0
+  version: v1.1.1

--- a/kfdefs/base/kafka/kfdef.yaml
+++ b/kfdefs/base/kafka/kfdef.yaml
@@ -25,5 +25,5 @@ spec:
       name: kafka-cluster
   repos:
     - name: manifests
-      uri: https://github.com/opendatahub-io/odh-manifests/tarball/v1.1.0
-  version: v1.1.0
+      uri: https://github.com/opendatahub-io/odh-manifests/tarball/v1.1.1
+  version: v1.1.1

--- a/kfdefs/base/seldon/kfdef.yaml
+++ b/kfdefs/base/seldon/kfdef.yaml
@@ -19,5 +19,5 @@ spec:
       name: odhseldon
   repos:
     - name: manifests
-      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.1.0"
-  version: v1.1.0
+      uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.1.1"
+  version: v1.1.1


### PR DESCRIPTION
Argo: minor route ssl config change
odh-dashboard: minor [changes](https://github.com/opendatahub-io/odh-manifests/commits/v1.1.1/odh-dashboard)
Kafka: no changes
Seldon: no changes

Related #1476 