### PR TITLE
Add argo, dashboard, seldon to smaug kfdef kustomization

### DIFF
--- a/kfdefs/overlays/moc/smaug/kustomization.yaml
+++ b/kfdefs/overlays/moc/smaug/kustomization.yaml
@@ -4,10 +4,13 @@ kind: Kustomization
 
 resources:
   - ds-ml-workflows-ws
+  - opf-argo
+  - opf-dashboard
   - opf-google-spark-operator
   - opf-jupyterhub
   - opf-jupyterhub-stage
   - opf-kafka
+  - opf-seldon
   - opf-superset
   - opf-trino
   - opf-trino-stage


### PR DESCRIPTION
Kfdefs for argo, odh-dashboard and seldon were not added to the Smaug kustomization. This PR fixes that.