### PR TITLE
Remove unneeded argoproj crds from smaug.

### DIFF
--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -16,7 +16,6 @@ resources:
 - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/assets.katalog.fybrik.io
 - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/batchtransfers.motion.fybrik.io
 - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/blueprints.app.fybrik.io
-- ../../../../base/apiextensions.k8s.io/customresourcedefinitions/cronworkflows.argoproj.io
 - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/extensions.dashboard.tekton.dev
 - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/fybrikapplications.app.fybrik.io
 - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/fybrikmodules.app.fybrik.io
@@ -25,8 +24,6 @@ resources:
 - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/prowjobs.prow.k8s.io
 - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/reports.batch.curator.openshift.io
 - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/streamtransfers.motion.fybrik.io
-- ../../../../base/apiextensions.k8s.io/customresourcedefinitions/workflow.argoproj.io
-- ../../../../base/apiextensions.k8s.io/customresourcedefinitions/workflowtemplate.argoproj.io
 - ../../../../base/config.openshift.io/oauths/cluster
 - ../../../../base/core/configmaps/cluster-monitoring-config
 - ../../../../base/core/configmaps/user-workload-monitoring-config


### PR DESCRIPTION
These are being managed by ODH operator:

```
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  annotations:
    kfctl.kubeflow.io/kfdef-instance: opendatahub.opf-argo
  name: cronworkflows.argoproj.io

---
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  annotations:
    kfctl.kubeflow.io/kfdef-instance: opendatahub.opf-argo
  name: workflows.argoproj.io
---
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  annotations:
    kfctl.kubeflow.io/kfdef-instance: opendatahub.opf-argo
  name: workflowtemplates.argoproj.io
```
