### PR TITLE
Add empty reviewers list in owners. And add new approver.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,3 +6,5 @@ approvers:
   - tumido
   - larsks
   - durandom
+
+reviewers: []

--- a/OWNERS
+++ b/OWNERS
@@ -6,5 +6,6 @@ approvers:
   - tumido
   - larsks
   - durandom
+  - harshad16
 
 reviewers: []


### PR DESCRIPTION
We expect this change will prevent sesheta from randomly assigning reviewers from approvers list.