### PR TITLE
Allow thoth users for view access to grafana

### DIFF
--- a/cluster-scope/base/core/namespaces/opf-monitoring/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/opf-monitoring/kustomization.yaml
@@ -3,6 +3,7 @@ components:
 - ../../../../components/project-admin-rolebindings/operate-first
 - ../../../../components/project-admin-rolebindings/odh-admin
 - ../../../../components/project-view-rolebindings/data-science
+- ../../../../components/project-view-rolebindings/thoth
 - ../../../../components/monitoring-rbac
 - ../../../../components/limitranges/default
 kind: Kustomization

--- a/cluster-scope/components/project-view-rolebindings/thoth/kustomization.yaml
+++ b/cluster-scope/components/project-view-rolebindings/thoth/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ./rbac.yaml

--- a/cluster-scope/components/project-view-rolebindings/thoth/rbac.yaml
+++ b/cluster-scope/components/project-view-rolebindings/thoth/rbac.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-view-thoth
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: thoth


### PR DESCRIPTION
Allow thoth users for view access to grafana
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>



Thoth developers who are not a part of operate-first don't have view/read access of grafana
this pr is to get them access to view the dashboards.