### PR TITLE
Change vault ArgoCD application to point to different repository

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/fybrik/vault.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/fybrik/vault.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   project: fybrik
   source:
-    repoURL: 'https://github.com/fybrik/fybrik'
+    repoURL: 'https://github.com/fybrik/charts'
     path: charts/vault
     targetRevision: HEAD
     helm:


### PR DESCRIPTION
This PR changes the repo url in the `vault` ArgoCD application manifest to point to the [fybrik/charts](https://github.com/fybrik/charts/tree/master/charts) repo so it stays in sync with the latest release of Fybrik

@revit13 @roytman @HumairAK 