### PR TITLE
Set default limits for the tekton chains namespace

### DIFF
--- a/cluster-scope/base/core/namespaces/tekton-chains/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/tekton-chains/kustomization.yaml
@@ -6,5 +6,6 @@ components:
   - ../../../../components/project-admin-rolebindings/operate-first
   - ../../../../components/monitoring-rbac
   - ../../../../components/resourcequotas/small
+  - ../../../../components/limitranges/default
 resources:
 - namespace.yaml


### PR DESCRIPTION
Set default limits for the tekton chains namespace
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


Fixes the issues
```
pods "tekton-chains-controller-7f94b7fc57-ts4mq" is forbidden: failed quota: small: must specify limits.cpu,limits.memory,requests.cpu,requests.memory
```