### PR TITLE
Argocd notifications slack integration

### DIFF
--- a/argocd-notifications/base/configmap.yaml
+++ b/argocd-notifications/base/configmap.yaml
@@ -1,0 +1,192 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-notifications-cm
+data:
+  context:
+    argocdUrl:
+  service.slack: |
+    token: $slack-token
+    icon: ":anchor:"
+  trigger.on-sync-failed: |
+    - when: app.status.operationState.phase in ['Error', 'Failed']
+      description: Application syncing has failed
+      send: [app-sync-failed]
+  trigger.on-sync-succeeded: |
+    - when: app.status.operationState.phase in ['Succeeded']
+      description: Application syncing has succeeded
+      send: [app-sync-succeeded]
+      oncePer: app.status.sync.revision
+  trigger.on-sync-status-unknown: |
+    - when: app.status.sync.status == 'Unknown'
+      description: Application status is 'Unknown'
+      send: [app-sync-status-unknown]
+  trigger.on-health-degraded: |
+    - when: app.status.health.status == 'Degraded'
+      description: Application has degraded
+      send: [app-health-degraded]
+  trigger.on-sync-running: |
+    - when: app.status.operationState.phase in ['Running']
+      description: Application is being synced
+      send: [app-sync-running]
+      oncePer: app.status.sync.revision
+  template.app-sync-failed: |
+    message: |
+      {{if eq .serviceType "slack"}}:x:{{end}}  The sync operation of application {{.app.metadata.name}} has failed at {{.app.status.operationState.finishedAt}} with the following error: {{.app.status.operationState.message}}
+      Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .
+    slack:
+      attachments: |
+        [{
+          "title": "Git information: {{ .app.metadata.name}}",
+          "color": "#ffffff",
+          "fields": [
+            {
+              "title": "Target Branch: ",
+              "value": "{{.app.spec.source.targetRevision}}",
+              "short": true
+            },
+            {
+              "title": "Repository: ",
+              "value": "{{.app.spec.source.repoURL}}",
+              "short": true
+            },
+            {
+              "title": "Overlay Path: ",
+              "value": "{{.app.spec.source.path}}"
+            },
+            {
+              "title": "Revision: ",
+              "value": "{{.app.status.sync.revision}}"
+            }
+          ]
+        }]
+      notifyBroadcast: true
+      groupingKey: "{{.app.status.sync.revision}}"
+  template.app-sync-succeeded: |
+    message: |
+      {{if eq .serviceType "slack"}}:white_check_mark:{{end}} Application {{.app.metadata.name}} has been successfully synced at {{.app.status.operationState.finishedAt}}.
+      Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .
+    slack:
+      attachments: |
+        [{
+          "title": "Git information: {{ .app.metadata.name}}",
+          "color": "#ffffff",
+          "fields": [
+            {
+              "title": "Target Branch: ",
+              "value": "{{.app.spec.source.targetRevision}}",
+              "short": true
+            },
+            {
+              "title": "Repository: ",
+              "value": "{{.app.spec.source.repoURL}}",
+              "short": true
+            },
+            {
+              "title": "Overlay Path: ",
+              "value": "{{.app.spec.source.path}}"
+            },
+            {
+              "title": "Revision: ",
+              "value": "{{.app.status.sync.revision}}"
+            }
+          ]
+        }]
+      notifyBroadcast: false
+      groupingKey: "{{.app.status.sync.revision}}"
+  template.app-sync-status-unknown: |
+    message: |
+      {{if eq .serviceType "slack"}}:exclamation:{{end}} Application {{.app.metadata.name}} sync is 'Unknown'.
+      Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
+    slack:
+      attachments: |
+        [{
+          "title": "Git information: {{ .app.metadata.name}}",
+          "color": "#ffffff",
+          "fields": [
+            {
+              "title": "Target Branch: ",
+              "value": "{{.app.spec.source.targetRevision}}",
+              "short": true
+            },
+            {
+              "title": "Repository: ",
+              "value": "{{.app.spec.source.repoURL}}",
+              "short": true
+            },
+            {
+              "title": "Overlay Path: ",
+              "value": "{{.app.spec.source.path}}"
+            },
+            {
+              "title": "Revision: ",
+              "value": "{{.app.status.sync.revision}}"
+            }
+          ]
+        }]
+      notifyBroadcast: true
+      groupingKey: "{{.app.status.sync.revision}}"
+  template.app-health-degraded: |
+    message: |
+      {{if eq .serviceType "slack"}}:small_red_triangle_down:{{end}} Application {{.app.metadata.name}} has degraded.
+      Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
+    slack:
+      attachments: |
+        [{
+          "title": "Git information: {{ .app.metadata.name}}",
+          "color": "#ffffff",
+          "fields": [
+            {
+              "title": "Target Branch: ",
+              "value": "{{.app.spec.source.targetRevision}}",
+              "short": true
+            },
+            {
+              "title": "Repository: ",
+              "value": "{{.app.spec.source.repoURL}}",
+              "short": true
+            },
+            {
+              "title": "Overlay Path: ",
+              "value": "{{.app.spec.source.path}}"
+            },
+            {
+              "title": "Revision: ",
+              "value": "{{.app.status.sync.revision}}"
+            }
+          ]
+        }]
+      notifyBroadcast: true
+      groupingKey: "{{.app.status.sync.revision}}"
+  template.app-sync-running: |
+    message: |
+      The sync operation of application {{.app.metadata.name}} has started at {{.app.status.operationState.startedAt}}.
+      Sync operation details are available at: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true .
+    slack:
+      attachments: |
+        [{
+          "title": "Git information: {{ .app.metadata.name}}",
+          "color": "#ffffff",
+          "fields": [
+            {
+              "title": "Target Branch: ",
+              "value": "{{.app.spec.source.targetRevision}}",
+              "short": true
+            },
+            {
+              "title": "Repository: ",
+              "value": "{{.app.spec.source.repoURL}}",
+              "short": true
+            },
+            {
+              "title": "Overlay Path: ",
+              "value": "{{.app.spec.source.path}}"
+            },
+            {
+              "title": "Revision: ",
+              "value": "{{.app.status.sync.revision}}"
+            }
+          ]
+        }]
+      notifyBroadcast: false
+      groupingKey: "{{.app.status.sync.revision}}"

--- a/argocd-notifications/base/kustomization.yaml
+++ b/argocd-notifications/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd
+
+resources:
+- 'https://raw.githubusercontent.com/argoproj-labs/argocd-notifications/v1.2.0/manifests/install.yaml'
+patchesStrategicMerge:
+- configmap.yaml

--- a/argocd-notifications/overlays/infra/kustomization.yaml
+++ b/argocd-notifications/overlays/infra/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+generators:
+  - secret-generator.yaml
+
+patches:
+  - target:
+      kind: ConfigMap
+      name: argocd-notifications-cm
+    patch: |
+      - op: add
+        path: /data/context/argocdUrl
+        value: https://argocd-server-argocd.apps.moc-infra.massopen.cloud/

--- a/argocd-notifications/overlays/infra/secret-generator.yaml
+++ b/argocd-notifications/overlays/infra/secret-generator.yaml
@@ -1,0 +1,6 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: secret-generator
+files:
+  - secret.enc.yaml

--- a/argocd-notifications/overlays/infra/secret.enc.yaml
+++ b/argocd-notifications/overlays/infra/secret.enc.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: argocd-notifications-secret
+    namespace: argocd
+    annotations:
+        kustomize.config.k8s.io/behavior: replace
+type: Opaque
+stringData:
+    slack-token: ENC[AES256_GCM,data:0mo6OebTHUiu4sOi1Ziobrdw3KcClq+YjB6fQkrnO+KUX9oKn42g3U85FocixnP4ND454I0pEXIZ,iv:tFklGCFsMBFZxShyg06XRD0+CW7n4y3Qje4g+dgtzmc=,tag:Y8MbNd6JEN/bSTfWAGS9gg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-01-16T01:00:47Z"
+    mac: ENC[AES256_GCM,data:9TRP0G46eD/UOggAQbG9uCzFBvliywdUzI46hU4NzGA6MDQgtj0GB/PDbj29s9Lf3sC2KtGpCdcijOWIJNywKF7uFduYNLXQm/cb0uGCAP7lYK+fD1pWed11at88J1ztEwgIsHwVHE+bGSyDt9B6yaOVWfQn9hGf3dcMYI2mjGU=,iv:4orfHhBBzQsH1DiwI6pNHGksU90nbtj0cphyh/715cU=,tag:QeIyMTma5mWKV3suvrPgAQ==,type:str]
+    pgp:
+        - created_at: "2022-01-16T01:00:46Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA9aKBcudqifiARAACSVhN5cIRqsq0pa+h45VeIyn0VIQjk1Kxm6qG6sRqeYm
+            Z5HHmeEad/HMho5Blm3wvvkDUmwjQB1pCA0ZrSDaam0Z9YLvD8+jctue0r8WxkvP
+            ZhPN7uJoTmEf1K8ZkFrtrEcdh3yk2K9VF+1cWlzWGHDIgInQDgkHae6AzNpxuS32
+            dmk1a10uRg2ctbv0iSltUwESpL0FB974eMGJBbG5+1oZ1dmj37WGfs5qcb5x4vR8
+            Uvfra00Phbbzm021egfOGjfHYzNgmVgfsN8Tuo8WQwaMbBWEZuz9t3Hl2DITx6Sv
+            bWndBnW6088YgvwelVtBOvIXz3QpjbaR/tb1VDL+VO6lmj4P6QkPKjtAB2EnAsVn
+            vCT8H7MgZiLEEF9Hoc6TAbWw8rzinoFvrses9E6qGpXesA+yi4huqvWa0LeSohhR
+            +v/xg1kXzJzg6uMg3QxsIkwwbOIjWghflebMP7JPHexP1ZVHt82m3tM5p6IgZVYn
+            rl0Di5G488VmaiRc70qUvLgANXShpb7kdc5+ngHGbLlsV/7HO/4ypkkKulICj+T5
+            8+m/xTFSbuG8Q6NxGI8mNMCPok8jNbUNpawnMhmlkzefBlgViNSnIM0X4QiJcMuP
+            nrlEaeeZe6Z7F6bCa4Xd6JG4vY3z7ZXu/nPTubmlHVGzNjDUC/Hk2a+ZZIAvfM7S
+            5gET1hBQ7hJpAS+lGdb4Cwxzrsc58kioqATe9+nwFa4ojOV5hfyKfoIyFUuX7Ves
+            Zgvjezh/uwlYCWsYFqt1Aebk3o7gKcVnWlhGDUVIM9ZypOJRByfjAA==
+            =EdoT
+            -----END PGP MESSAGE-----
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^(users|data|stringData)$
+    version: 3.7.1

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/cluster-resources.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/cluster-resources.yaml
@@ -2,6 +2,12 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: cluster-resources
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-succeeded.slack: "argocd-notifications"
+    notifications.argoproj.io/subscribe.on-sync-running.slack: "argocd-notifications"
+    notifications.argoproj.io/subscribe.on-sync-failed.slack: "argocd-notifications"
+    notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: "argocd-notifications"
+    notifications.argoproj.io/subscribe.on-sync-degraded.slack: "argocd-notifications"
 spec:
   destination:
     name: smaug

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -33,6 +33,7 @@ parts:
           - file: content/argocd-gitops/setup_argocd_dev_environment.md
           - file: content/argocd-gitops/update_argocd.md
           - file: content/argocd-gitops/update_gpg_key.md
+          - file: content/argocd-gitops/argocd_notifications.md
 
       # Cluster Scope
       - file: content/cluster-scope/README.md

--- a/docs/content/argocd-gitops/argocd_notifications.md
+++ b/docs/content/argocd-gitops/argocd_notifications.md
@@ -1,0 +1,75 @@
+# Where and How do I add notifications to my ArgoCD apps?
+
+Docs: https://argocd-notifications.readthedocs.io/en/latest/
+
+Currently we deploy ArgoCD-Notifications alongside argocd (same namespace).
+
+## Where and How do I add notifications to my ArgoCD apps?
+
+There are either 2 or 3 main things (depending on the specific notification service(s) used in question) needed if to connect a notification service to argocd notifications.
+
+1. Application annotations:
+
+  - Annotations can be added manually in a application manifest, or use the `oc patch`  command:
+```sh
+oc patch app <app_name> -n <namespace -p '{"metadata": {"annotations": {"notifications.argoproj.io/subscribe.on-sync-succeeded.github":""}}}' --type merge
+```
+
+  - NOTE: This example has no value, which is actually correct for the github service. It doesn't need any information there because it identifies the application by `appId`, `installationId`, and `privateKey`. However this varies per service type. For instance the slack integration uses the name of the channel to send to as its value. Also note that in that example `on-sync-succeed` is the trigger name, and `github` refers to the service type.
+
+  - Operate-first's Application manifests for apps deployed via argo under [this directory](https://github.com/operate-first/apps/tree/master/argocd/overlays/moc-infra/applications/envs) per environment.
+
+2. A Configmap with the proper components
+
+    - [ ] trigger
+
+    - [ ] template
+
+    - [ ] service (defines the serivce credentials and configuarations so that Argocd-Notifications can use them when executing a template with content specific to a notifcation service)
+
+  - These components are all defined in [this configmap](https://github.com/operate-first/apps/blob/master/argocd-notifications/base/configmap.yaml), although a different configmap could be defined for each notification service and merged into a single configmap using volumes/volumeMounts. Argocd-Notifications by default looks for the configmap named `argocd-notifications-cm`, and the same is true for secrets `argocd-notifications-secret`.
+
+3. An application specific to the notification service desired.
+
+  - Examples of this would be both github and slack. They require the creation of app that they host. This is what gives the tokens or private information that is specificed in the service.
+
+  - Note: if you are doing something that requires an application, make certain that you have enabled the permisions to accoplish what you are aiming for in that application. See [Github's Application Permissions Docs](https://docs.github.com/en/rest/reference/permissions-required-for-github-apps) for an example.
+
+## References
+
+This is reference material related to ArgoCD-Notifications. It goes more into depth about components. [Triggers](https://github.com/operate-first/apps/blob/master/docs/content/argocd-gitops/argocd-notifications.md#Triggers) and [Templates](https://github.com/operate-first/apps/blob/master/docs/content/argocd-gitops/argocd-notifcations.md#Templates) are both resources speicifc to ArgoCD-Notifications, while [Application Annotations](https://github.com/operate-first/apps/blob/master/docs/content/argocd-gitops/argocd-notifications.md#Application-Annotations) covers how this ArgoCD resource (Application manifests) are utilized in ArgoCD-Notifications.
+
+### Application Annotations
+
+  Argocd notifcations utilizes annotations on the application manifest managed by argocd, to know which applications use which trigger and service to subscribe to. The triggers themselves are what call specific templates based on their conditions.
+
+  - Example:
+``` yaml
+    apiVersion: argoproj.io/v1alpha1
+    kind: Application
+    metadata:
+      annotations:
+        notifications.argoproj.io/subscribe.on-sync-succeeded.slack: "argocd-notifications"
+        notifications.argoproj.io/subscribe.on-sync-failed.googlechat: "opf-argocd-notifications"
+        notifications.argoproj.io/subscribe.<trigger_name>.<service>: <value_if_any_required>
+      name: cluster-resources-smaug
+      namespace: argocd
+```
+
+  As this is in initial deployment stages for this application manifests are modified manually rather than patching them from this dir. For an example, see [cluster resources](https://github.com/operate-first/apps/blob/master/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/cluster-resources.yaml).
+
+### Triggers
+
+  Triggers require two key values, a `when` condition, which states what data from argocd will start the trigger, and a `send` value which contains an array of template names to call when that trigger fires. Other fields can be added like `description`, or `oncePer`, which tells argocd to only fire the trigger one time per value for the parameter passed in. This is utilized currently in the [slack configmap](https://github.com/operate-first/apps/blob/master/argocd-notifications/base/configmap.yaml#L32) to only allow one success of sync-start per run of a Commit SHA. Because the run trigger will hit before any of the others, it fires the sync run template, and the stacks all the other sync-status notifications (such as failed, degraded, etc.) as replies. Triggers are implemented in such a way that they are notification-service agnostic, because they only listen for conditions in argocd and then call templates when those conditions resolve true.
+
+  More documentation to come, for now see [the docs](https://argocd-notifications.readthedocs.io/en/stable/triggers/).
+
+### Templates
+
+  Templates are what will generate the notification content itself, and works using the html/template golang package. Templates can be referenced by multiple triggers. Additionally one template can work for multiple services, provided everything else is also set up properly. It does this by using its `<template_name>.message` property, which will work with almost all mediums of communication (not sure about webhooks). All the other top level properties in a template are notification-service specific and will only render in that given service type (github, slack, googlechat, etc.). All of Operate-First's trigger templates and trigger names can be found [here](https://github.com/operate-first/apps/blob/master/argocd-notifications/base/configmap.yaml), and are named the same ones as the argocd-notifications catalog. They are not protected values, triggers and templates can be named anything. Additionally other values can be passed into the templates through the `data.context` value of the [configMap](https://github.com/operate-first/apps/blob/master/argocd-notifications/base/configmap.yaml), which does not come from argocd. This is useful for specifying different environments, where one can patch the overlay with argocd-server route.
+
+  More documentation and examples to come, for now see [the docs](https://argocd-notifications.readthedocs.io/en/stable/templates/).
+
+### Notification services / integrations
+
+  [The Docs](https://argocd-notifications.readthedocs.io/en/stable/services/overview/) are the best resource on this topic. Refer to them.


### PR DESCRIPTION
Waiting on rebasing until I get some feedback with this as I am sure I am missing some things here.

Related to [Investigating ArgoCD-Notifications issue](https://github.com/operate-first/SRE/issues/410). Meant to be the smallest slice towards a solution here.

Also waiting on removing some slack attachments from `argocd-notifications-cm` for all templates that are not `on-sync-running` because I could not access quick lab for most of today, so I couldn't test changes to the templates. We want to do this to reduce extra noise, so the initial notification would be the information on the sync running, and then each other condition as a small message with the resolved status.