### PR TITLE
Add instructions on how to add an ocp group.

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -38,6 +38,7 @@ parts:
       - file: content/cluster-scope/README.md
         sections:
           - file: content/cluster-scope/add_resource_quotas.md
+          - file: content/cluster-scope/create_ocp_group.md
           - file: content/cluster-scope/add_user_to_group.md
           - file: content/cluster-scope/onboarding_to_cluster.md
           - file: content/cluster-scope/quotas.md

--- a/docs/content/argocd-gitops/onboarding_to_argocd.md
+++ b/docs/content/argocd-gitops/onboarding_to_argocd.md
@@ -28,8 +28,9 @@ Please fork/clone the [operate-first/apps][6].
 
 To add multi-tenancy support, we require the team to have an OpenShift group on the Infra cluster on which our ArgoCD
 instance resides. This OpenShift group should include all the people belonging to the team that will need write-level
-access to applications belonging to the team's ArgoCD Project (explained later). The team being onboarded to ArgoCD
-should have had a group already created during cluster onboarding, as described [here][5].
+access to applications belonging to the team's ArgoCD Project (explained later). Existing OCP groups and their
+membership can be found [here][19]. If you do not have a group to which you belong, you can create a new one and add
+yourself and associated members by following the instructions [here][20].
 
 > Note: We use teams/project names interchangeably throughout this doc as all ArgoCD projects (for end-users) are named
 > after their team names picked during the cluster onboarding process.
@@ -179,3 +180,4 @@ these namespaces using ArgoCD Applications that are part of the `thoth` project.
 [17]: https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#bases-and-overlays
 [18]: https://github.com/operate-first/apps/tree/master/argocd/overlays/moc-infra/applications
 [19]: https://github.com/operate-first/apps/tree/master/cluster-scope/base/user.openshift.io/groups
+[20]: ../cluster-scope/create_ocp_group.md

--- a/docs/content/cluster-scope/create_ocp_group.md
+++ b/docs/content/cluster-scope/create_ocp_group.md
@@ -1,0 +1,64 @@
+# Adding an OCP group to Operate First Cloud
+
+Instructions on how to add an OCP group to Operate First Cloud.
+
+## Add groups manually
+1. Set your GitHub username, your choice of OCP group, and your workingdir:
+```bash
+OCP_GROUP=<enter-your-group-here>
+GITHUB_USER=<your-github-user-handle>
+WORKING_DIR=<path-to-your-working-dir>
+```
+
+2. Fork/Clone apps repo https://github.com/operate-first/apps.git:
+```bash
+# After forking
+$ git clone https://github.com/$GITHUB_USER/apps.git $WORKING_DIR
+```
+
+3. Navigate to the `base` OCP `groups` directory:
+```bash
+$ cd $WORKING_DIR/apps/cluster-scope/base/user.openshift.io/groups/
+```
+
+4. Create your `$OCP_GROUP` folder:
+```bash
+$ mkdir $OCP_GROUP
+$ cd $OCP_GROUP
+```
+
+5. Create `group.yaml` in $OCP_GROUP
+```bash
+$ cat <<EOF > group.yaml
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+    name: $OCP_GROUP
+users: []
+EOF
+```
+
+Add users to the `users` field accordingly.
+
+6. Create the `kustomization.yaml`
+```bash
+$ cat <<EOF > kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - group.yaml
+EOF
+```
+
+7. Add the following line to `cluster-scope/overlays/prod/common/kustomization.yaml` alphabetically:
+```
+- ../../../base/user.openshift.io/groups/$OCP_GROUP
+```
+
+8. Commit and push your changes. Submit a PR to the upstream repository.
+
+## Use the OPF CLI
+
+1. Clone/Fork/Navigate to working directory as shown above
+2. Follow instructions here: https://github.com/operate-first/opfcli#create-group
+3. Commit and push your changes. Submit a PR to the upstream repository.


### PR DESCRIPTION
While this portion is mentioned in the onboarding docs, and/or in the notebook. There are situations where teams /users may want to create an OCP group after onboarding, or without also requiring a namespace. 