### PR TITLE
permissions to add the training model group

### DIFF
--- a/cluster-scope/base/core/namespaces/opf-ci-pipelines/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/opf-ci-pipelines/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/thoth-devops
 - ../../../../components/project-admin-rolebindings/operate-first
+- ../../../../components/project-admin-rolebindings/octo-training-model
 - ../../../../components/monitoring-rbac
 - ../../../../components/limitranges/default
 kind: Kustomization


### PR DESCRIPTION
The training model group needs access to opf-ci-pipelines to allow for the creation and modification of pipelines and pipeline runs


Signed-off-by: Ryan Cook <rcook@redhat.com>