### PR TITLE
Add opf jh analysis notebook image yaml

### DIFF
--- a/kfdefs/base/jupyterhub/notebook-images/kustomization.yaml
+++ b/kfdefs/base/jupyterhub/notebook-images/kustomization.yaml
@@ -22,3 +22,4 @@ resources:
   - time-series.yaml
   - s2i-pytorch-py38-notebook.yaml
   - bu-cs-jupyterbook.yaml
+  - operate-first-jupyterhub-analysis.yaml

--- a/kfdefs/base/jupyterhub/notebook-images/operate-first-jupyterhub-analysis.yaml
+++ b/kfdefs/base/jupyterhub/notebook-images/operate-first-jupyterhub-analysis.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url:
+      "https://github.com/aicoe-aiops/operate-first-jupyterhub-analysis"
+    opendatahub.io/notebook-image-name:
+      "Operate First Jupyterhub Analysis Notebook Image"
+    opendatahub.io/notebook-image-desc:
+      "Image with notebooks for jupyterhub resource recommendation"
+  name: operate-first-jupyterhub-analysis
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        openshift.io/imported-from: quay.io/aicoe/operate-first-jupyterhub-analysis
+      from:
+        kind: DockerImage
+        name: quay.io/aicoe/operate-first-jupyterhub-analysis:latest
+      importPolicy:
+        scheduled: true
+      name: "latest"


### PR DESCRIPTION
This PR adds yaml file to add Operate First Jupyterhub Analysis project image as a spawn option in Opf Jupyterhub instance.