### PR TITLE
fix: Remove null value from deployment of reloader securityContext

### DIFF
--- a/reloader/base/deployment.yaml
+++ b/reloader/base/deployment.yaml
@@ -38,5 +38,4 @@ spec:
           failureThreshold: 5
           periodSeconds: 10
           successThreshold: 1
-      securityContext: NULL
       serviceAccountName: reloader-reloader


### PR DESCRIPTION
SSIA -- Kubeval flagged this as not valid. Not sure if it will break anything.
