### PR TITLE
Changed default time range of the Cluster CPU dashboard

### DIFF
--- a/grafana/overlays/moc/smaug/dashboards/cluster-management/cluster-cpu-overview.yaml
+++ b/grafana/overlays/moc/smaug/dashboards/cluster-management/cluster-cpu-overview.yaml
@@ -1648,8 +1648,8 @@ spec:
         ]
       },
       "time": {
-        "from": "2021-11-16T21:13:55.693Z",
-        "to": "2021-11-16T21:23:55.693Z"
+        "from": "now-15m",
+        "to": "now"
       },
       "timepicker": {},
       "timezone": "",


### PR DESCRIPTION
Previously by default the `Cluster CPU overview` dashboard did not show data on any visualization.
This PR now changes the time frame to display the dashboards data at a 15 minute range interval