### PR TITLE
Add osc-cl1 cluster to osc clusterset.

### DIFF
--- a/acm/overlays/moc/infra/managedclusters/osc-cl1.yaml
+++ b/acm/overlays/moc/infra/managedclusters/osc-cl1.yaml
@@ -3,4 +3,4 @@ kind: ManagedCluster
 metadata:
   name: osc-cl1
   labels:
-    cluster.open-cluster-management.io/clusterset: argocd-managed
+    cluster.open-cluster-management.io/clusterset: osc

--- a/acm/overlays/moc/infra/managedclustersetbindings/osc.yaml
+++ b/acm/overlays/moc/infra/managedclustersetbindings/osc.yaml
@@ -1,0 +1,7 @@
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+kind: ManagedClusterSetBinding
+metadata:
+  name: osc
+  namespace: argocd
+spec:
+  clusterSet: osc

--- a/acm/overlays/moc/infra/managedclustersets/osc.yaml
+++ b/acm/overlays/moc/infra/managedclustersets/osc.yaml
@@ -1,0 +1,5 @@
+kind: ManagedClusterSet
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+metadata:
+  name: osc
+spec: {}

--- a/acm/overlays/moc/infra/placements/argocd-managed-clusters.yaml
+++ b/acm/overlays/moc/infra/placements/argocd-managed-clusters.yaml
@@ -7,3 +7,4 @@ spec:
   clusterSets:
     - argocd-managed
     - octo-ushift-dev
+    - osc

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:managedclusterset:admin:osc/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:managedclusterset:admin:osc/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: open-cluster-management:managedclusterset:admin:osc
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: osc-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: open-cluster-management:managedclusterset:admin:osc

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:managedclusterset:admin:osc/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:managedclusterset:admin:osc/kustomization.yaml
@@ -1,8 +1,4 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
-  - argocd-managed.yaml
-  - octo-ushift-dev.yaml
-  - osc.yaml
+- clusterrolebinding.yaml

--- a/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
@@ -31,6 +31,7 @@ resources:
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/moc-nfs-democratic-csi-node-rb
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:admin:osc-cl1
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:managedclusterset:admin:octo-ushift-dev
+  - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:managedclusterset:admin:osc
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/acme-operator
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/moc-nfs-democratic-csi-controller-cr
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/moc-nfs-democratic-csi-node-cr


### PR DESCRIPTION
This will create a new `manageclusterset` called `osc`, and add the `os-cl1` cluster to it. In the future we will be adding the prod OSC cluster to this cluster set as well. I have left out the provisioner role for the [osc admins group](). 

This will result in the following [issue](https://github.com/operate-first/support/issues/436) -- but based on the comments on the jira we should be able to just create a namespace via gitops to workaround it (we can test this when importing the osc prod cluster).