### PR TITLE
Grant thoth-devops access to tekton-chains

### DIFF
--- a/cluster-scope/base/core/namespaces/tekton-chains/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/tekton-chains/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 namespace: tekton-chains
 components:
   - ../../../../components/project-admin-rolebindings/operate-first
+  - ../../../../components/project-admin-rolebindings/thoth-devops
   - ../../../../components/monitoring-rbac
   - ../../../../components/resourcequotas/small
   - ../../../../components/limitranges/default


### PR DESCRIPTION
I would like to add our team to access tekton-chains.

If it helps: this would match the existing access to the [opf ci pipelines access](https://github.com/operate-first/apps/blob/9d082291740f45154d58f62b601fd62f062ba172/cluster-scope/base/core/namespaces/opf-ci-pipelines/kustomization.yaml#L3).

Tekton chains are integrated with the pipelines and I believe this access makes sense.
