### PR TITLE
Add scripts/fake-ksops.sh to ease testing w/o ksops

### DIFF
--- a/scripts/fake-ksops.sh
+++ b/scripts/fake-ksops.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# Set up a fake ksops plugin
+
+tmpdir=$(mktemp -d $PWD/pluginsXXXXXX)
+trap "rm -rf $tmpdir" EXIT
+
+mkdir -p $tmpdir/viaduct.ai/v1/ksops
+ln -s /bin/true $tmpdir/viaduct.ai/v1/ksops/ksops
+export KUSTOMIZE_PLUGIN_HOME=$tmpdir
+
+"$@"


### PR DESCRIPTION
We have a number of new co-ops working on this project. Testing out
changes by running `kustomize build` is complicated by our use of ksops.
Rather than distributing decryption keys to all and sundry, we can ease
the testing process by providing a wrapper that sets up a fake ksops
plugin.

The script is used like this:

    ./scripts/fake-ksops.sh kustomize build --enable-alpha-plugins ...

That permits one to test changes that do not involve modifications to
encrypted data.
