### PR TITLE
add DSL management for trino rules.json files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,16 @@ repos:
         files: \.(yaml|yml)$
         types: [file, yaml]
         entry: yamllint --strict -c yamllint-config.yaml
+
+  - repo: https://github.com/os-climate/osc-trino-acl-dsl
+    rev: v0.2.3
+    hooks:
+      # manage rules.json files using a DSL for trino ACL
+      # this check enforces that rules.json is consistent with dsl file
+      # https://github.com/os-climate/osc-trino-acl-dsl/blob/main/.pre-commit-hooks.yaml
+      - id: trino-acl-dsl-check
+        files: |
+          (?x)^(.*/)?(
+            trino-acl-dsl\.yaml|
+            rules\.json
+          )$

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/rules.json
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/rules.json
@@ -1,20 +1,36 @@
 {
-  "catalogs": [
-    {
-      "group": "admins",
-      "allow": "all"
-    }
-  ],
-  "schemas": [
-    {
-      "group": "admins",
-      "owner": true
-    }
-  ],
-  "tables": [
-    {
-      "group": "admins",
-      "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP"]
-    }
-  ]
+    "catalogs": [
+        {
+            "group": "admins",
+            "allow": "all"
+        },
+        {
+            "allow": "read-only"
+        }
+    ],
+    "schemas": [
+        {
+            "group": "admins",
+            "owner": true
+        },
+        {
+            "owner": false
+        }
+    ],
+    "tables": [
+        {
+            "group": "admins",
+            "privileges": [
+                "SELECT",
+                "INSERT",
+                "DELETE",
+                "OWNERSHIP"
+            ]
+        },
+        {
+            "privileges": [
+                "SELECT"
+            ]
+        }
+    ]
 }

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/trino-acl-dsl.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/trino-acl-dsl.yaml
@@ -1,0 +1,10 @@
+# this is a development only cluster
+admin-groups: [admins]
+
+# all user groups have read privileges
+public-tables: true
+
+# currently no non-admin rules for any ACL granularities
+catalogs: []
+schemas: []
+tables: []

--- a/kfdefs/overlays/osc/osc-cl1/trino/configs/rules.json
+++ b/kfdefs/overlays/osc/osc-cl1/trino/configs/rules.json
@@ -1,182 +1,364 @@
 {
-  "catalogs": [
-    {
-      "group": "admins",
-      "allow": "all"
-    },
-    {
-      "group": "aicoe_osc_demo|corporate_data.*|itr.*|physical_risk.*",
-      "catalog": "osc_datacommons_dev",
-      "allow": "all"
-    },
-    {
-      "group": "demo_.*",
-      "catalog": "osc_datacommons_dev",
-      "allow": "all"
-    },
-    {
-      "allow": "none"
-    }
-  ],
-  "schemas": [
-    {
-      "group": "admins",
-      "owner": true
-    },
-    {
-      "group": "corporate_data.*",
-      "catalog": "osc_datacommons_dev",
-      "schema": "corporate_data",
-      "owner": true
-    },
-    {
-      "group": "itr.*",
-      "catalog": "osc_datacommons_dev",
-      "schema": "itr",
-      "owner": true
-    },
-    {
-      "group": "physical_risk.*",
-      "catalog": "osc_datacommons_dev",
-      "schema": "physical_risk",
-      "owner": true
-    },
-    {
-      "group": "entity_matching.*",
-      "catalog": "osc_datacommons_dev",
-      "schema": "gleif",
-      "owner": true
-    },
-    {
-      "group": "aicoe_osc_demo",
-      "catalog": "osc_datacommons_dev",
-      "schema": "aicoe_osc_demo|urgentem",
-      "owner": true
-    },
-    {
-      "catalog": "osc_datacommons_dev",
-      "schema": "demo|sandbox",
-      "owner": true
-    },
-    {
-      "owner": false
-    }
-  ],
-  "tables": [
-    {
-      "group": "admins",
-      "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP"]
-    },
-    {
-      "group": "demo_dv_user|demo_dv_quant",
-      "catalog": "osc_datacommons_dev",
-      "schema": "demo",
-      "table": "demo_dv_backend",
-      "privileges": []
-    },
-    {
-      "group": "demo_dv_quant",
-      "catalog": "osc_datacommons_dev",
-      "schema": "demo",
-      "table": "demo_dv_userfacing",
-      "privileges": ["SELECT"],
-      "filter": "contains(current_groups(), access) or access = 'public'",
-      "columns": [
-        { "name": "dev1", "allow": false }
-      ]
-    },
-    {
-      "group": "demo_dv_user",
-      "catalog": "osc_datacommons_dev",
-      "schema": "demo",
-      "table": "demo_dv_userfacing",
-      "privileges": ["SELECT"],
-      "filter": "contains(current_groups(), access) or access = 'public'",
-      "columns": [
-        { "name": "dev1", "allow": false },
-        { "name": "quant1", "allow": false }
-      ]
-    },
-    {
-      "group": "demo_dv_dev",
-      "catalog": "osc_datacommons_dev",
-      "schema": "demo",
-      "table": "gppd",
-      "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP"]
-    },
-    {
-      "group": "demo_dv_quant",
-      "catalog": "osc_datacommons_dev",
-      "schema": "demo",
-      "table": "gppd",
-      "privileges": ["SELECT"],
-      "filter": "country = 'France'"
-    },
-    {
-      "group": "demo_dv_user",
-      "catalog": "osc_datacommons_dev",
-      "schema": "demo",
-      "table": "gppd",
-      "privileges": ["SELECT"],
-      "filter": "country = 'France'",
-      "columns": [
+    "catalogs": [
         {
-          "name": "rating",
-          "allow": false
+            "group": "admins",
+            "allow": "all"
+        },
+        {
+            "group": "corporate_data.*|itr.*|physical_risk.*|aicoe_osc_demo|demo_.*",
+            "catalog": "osc_datacommons_dev",
+            "allow": "all"
+        },
+        {
+            "group": "admins",
+            "catalog": "osc_datacommons_iceberg_dev",
+            "allow": "all"
+        },
+        {
+            "allow": "read-only"
         }
-      ]
-    },
-    {
-      "catalog": "osc_datacommons_dev",
-      "schema": "demo",
-      "table": "gppd",
-      "privileges": []
-    },
-    {
-      "catalog": "osc_datacommons_dev",
-      "schema": "demo|sandbox",
-      "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP"]
-    },
-    {
-      "group": "demo_.*",
-      "privileges": []
-    },
-    {
-      "group": "corporate_data_pipeline_.*",
-      "catalog": "osc_datacommons_dev",
-      "schema": "corporate_data",
-      "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP"]
-    },
-    {
-      "group": "itr_pipeline_.*",
-      "catalog": "osc_datacommons_dev",
-      "schema": "itr",
-      "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP"]
-    },
-    {
-      "group": "physical_risk_pipeline_.*",
-      "catalog": "osc_datacommons_dev",
-      "schema": "physical_risk",
-      "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP"]
-    },
-    {
-      "group": "entity_matching_pipeline_.*",
-      "catalog": "osc_datacommons_dev",
-      "schema": "gleif",
-      "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP"]
-    },
-    {
-      "group": "aicoe_osc_demo",
-      "catalog": "osc_datacommons_dev",
-      "schema": "urgentem|aicoe_osc_demo",
-      "privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP"]
-    },
-    {
-      "catalog": "osc_datacommons_dev",
-      "privileges": ["SELECT"]
-    },
-    {
-      "privileges": []
-    }
-  ]
+    ],
+    "schemas": [
+        {
+            "group": "admins",
+            "owner": true
+        },
+        {
+            "group": "corporate_data.*",
+            "catalog": "osc_datacommons_dev",
+            "schema": "corporate_data",
+            "owner": true
+        },
+        {
+            "group": "itr.*",
+            "catalog": "osc_datacommons_dev",
+            "schema": "itr",
+            "owner": true
+        },
+        {
+            "group": "physical_risk.*",
+            "catalog": "osc_datacommons_dev",
+            "schema": "physical_risk",
+            "owner": true
+        },
+        {
+            "group": "entity_matching.*",
+            "catalog": "osc_datacommons_dev",
+            "schema": "gleif",
+            "owner": true
+        },
+        {
+            "group": "aicoe_osc_demo",
+            "catalog": "osc_datacommons_dev",
+            "schema": "aicoe_osc_demo",
+            "owner": true
+        },
+        {
+            "group": "aicoe_osc_demo",
+            "catalog": "osc_datacommons_dev",
+            "schema": "urgentem",
+            "owner": true
+        },
+        {
+            "group": ".*",
+            "catalog": "osc_datacommons_dev",
+            "schema": "sandbox",
+            "owner": true
+        },
+        {
+            "group": ".*",
+            "catalog": "osc_datacommons_dev",
+            "schema": "demo",
+            "owner": true
+        },
+        {
+            "owner": false
+        }
+    ],
+    "tables": [
+        {
+            "group": "admins",
+            "privileges": [
+                "SELECT",
+                "INSERT",
+                "DELETE",
+                "OWNERSHIP"
+            ]
+        },
+        {
+            "group": "demo_dv_dev",
+            "catalog": "osc_datacommons_dev",
+            "schema": "demo",
+            "table": "gppd",
+            "privileges": [
+                "SELECT",
+                "INSERT",
+                "DELETE",
+                "OWNERSHIP"
+            ]
+        },
+        {
+            "group": "demo_dv_quant",
+            "catalog": "osc_datacommons_dev",
+            "schema": "demo",
+            "table": "gppd",
+            "privileges": [
+                "SELECT"
+            ],
+            "filter": "country = 'France'"
+        },
+        {
+            "group": "demo_dv_user",
+            "catalog": "osc_datacommons_dev",
+            "schema": "demo",
+            "table": "gppd",
+            "privileges": [
+                "SELECT"
+            ],
+            "filter": "country = 'France'",
+            "columns": [
+                {
+                    "name": "rating",
+                    "allow": false
+                }
+            ]
+        },
+        {
+            "catalog": "osc_datacommons_dev",
+            "schema": "demo",
+            "table": "gppd",
+            "privileges": []
+        },
+        {
+            "group": "demo_dv_dev",
+            "catalog": "osc_datacommons_dev",
+            "schema": "demo",
+            "table": "demo_dv_backend",
+            "privileges": [
+                "SELECT",
+                "INSERT",
+                "DELETE",
+                "OWNERSHIP"
+            ]
+        },
+        {
+            "catalog": "osc_datacommons_dev",
+            "schema": "demo",
+            "table": "demo_dv_backend",
+            "privileges": []
+        },
+        {
+            "group": "demo_dv_dev",
+            "catalog": "osc_datacommons_dev",
+            "schema": "demo",
+            "table": "demo_dv_userfacing",
+            "privileges": [
+                "SELECT",
+                "INSERT",
+                "DELETE",
+                "OWNERSHIP"
+            ]
+        },
+        {
+            "group": "demo_dv_quant",
+            "catalog": "osc_datacommons_dev",
+            "schema": "demo",
+            "table": "demo_dv_userfacing",
+            "privileges": [
+                "SELECT"
+            ],
+            "filter": "contains(current_groups(), access) or access = 'public'",
+            "columns": [
+                {
+                    "name": "dev1",
+                    "allow": false
+                }
+            ]
+        },
+        {
+            "group": "demo_dv_user",
+            "catalog": "osc_datacommons_dev",
+            "schema": "demo",
+            "table": "demo_dv_userfacing",
+            "privileges": [
+                "SELECT"
+            ],
+            "filter": "contains(current_groups(), access) or access = 'public'",
+            "columns": [
+                {
+                    "name": "dev1",
+                    "allow": false
+                },
+                {
+                    "name": "quant1",
+                    "allow": false
+                }
+            ]
+        },
+        {
+            "catalog": "osc_datacommons_dev",
+            "schema": "demo",
+            "table": "demo_dv_userfacing",
+            "privileges": []
+        },
+        {
+            "group": "corporate_data.*",
+            "catalog": "osc_datacommons_dev",
+            "schema": "corporate_data",
+            "privileges": [
+                "SELECT",
+                "INSERT",
+                "DELETE",
+                "OWNERSHIP"
+            ]
+        },
+        {
+            "catalog": "osc_datacommons_dev",
+            "schema": "corporate_data",
+            "privileges": [
+                "SELECT"
+            ]
+        },
+        {
+            "group": "itr.*",
+            "catalog": "osc_datacommons_dev",
+            "schema": "itr",
+            "privileges": [
+                "SELECT",
+                "INSERT",
+                "DELETE",
+                "OWNERSHIP"
+            ]
+        },
+        {
+            "catalog": "osc_datacommons_dev",
+            "schema": "itr",
+            "privileges": [
+                "SELECT"
+            ]
+        },
+        {
+            "group": "physical_risk.*",
+            "catalog": "osc_datacommons_dev",
+            "schema": "physical_risk",
+            "privileges": [
+                "SELECT",
+                "INSERT",
+                "DELETE",
+                "OWNERSHIP"
+            ]
+        },
+        {
+            "catalog": "osc_datacommons_dev",
+            "schema": "physical_risk",
+            "privileges": [
+                "SELECT"
+            ]
+        },
+        {
+            "group": "entity_matching.*",
+            "catalog": "osc_datacommons_dev",
+            "schema": "gleif",
+            "privileges": [
+                "SELECT",
+                "INSERT",
+                "DELETE",
+                "OWNERSHIP"
+            ]
+        },
+        {
+            "catalog": "osc_datacommons_dev",
+            "schema": "gleif",
+            "privileges": [
+                "SELECT"
+            ]
+        },
+        {
+            "group": "aicoe_osc_demo",
+            "catalog": "osc_datacommons_dev",
+            "schema": "aicoe_osc_demo",
+            "privileges": [
+                "SELECT",
+                "INSERT",
+                "DELETE",
+                "OWNERSHIP"
+            ]
+        },
+        {
+            "catalog": "osc_datacommons_dev",
+            "schema": "aicoe_osc_demo",
+            "privileges": [
+                "SELECT"
+            ]
+        },
+        {
+            "group": "aicoe_osc_demo",
+            "catalog": "osc_datacommons_dev",
+            "schema": "urgentem",
+            "privileges": [
+                "SELECT",
+                "INSERT",
+                "DELETE",
+                "OWNERSHIP"
+            ]
+        },
+        {
+            "catalog": "osc_datacommons_dev",
+            "schema": "urgentem",
+            "privileges": [
+                "SELECT"
+            ]
+        },
+        {
+            "group": ".*",
+            "catalog": "osc_datacommons_dev",
+            "schema": "sandbox",
+            "privileges": [
+                "SELECT",
+                "INSERT",
+                "DELETE",
+                "OWNERSHIP"
+            ]
+        },
+        {
+            "catalog": "osc_datacommons_dev",
+            "schema": "sandbox",
+            "privileges": [
+                "SELECT"
+            ]
+        },
+        {
+            "group": ".*",
+            "catalog": "osc_datacommons_dev",
+            "schema": "demo",
+            "privileges": [
+                "SELECT",
+                "INSERT",
+                "DELETE",
+                "OWNERSHIP"
+            ]
+        },
+        {
+            "catalog": "osc_datacommons_dev",
+            "schema": "demo",
+            "privileges": [
+                "SELECT"
+            ]
+        },
+        {
+            "catalog": "osc_datacommons_dev",
+            "privileges": [
+                "SELECT"
+            ]
+        },
+        {
+            "catalog": "osc_datacommons_iceberg_dev",
+            "privileges": [
+                "SELECT"
+            ]
+        },
+        {
+            "privileges": []
+        }
+    ]
 }

--- a/kfdefs/overlays/osc/osc-cl1/trino/configs/trino-acl-dsl.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino/configs/trino-acl-dsl.yaml
@@ -1,0 +1,104 @@
+# the current OS-Climate data commons trino deployment on the dev cluster
+admin-groups: [admins]
+
+# global default is non-public (no read/select access)
+public-tables: false
+
+catalogs:
+  - catalog: osc_datacommons_dev
+    public-tables: true
+    # setting 'admin' at catalog level does not translate to
+    # admin-like privs at table or schema level: see 'allow'
+    # in trino access control docs
+    admin-groups:
+      - 'corporate_data.*'
+      - 'itr.*'
+      - 'physical_risk.*'
+      - 'aicoe_osc_demo'
+      - 'demo_.*'
+
+  - catalog: osc_datacommons_iceberg_dev
+    public-tables: true
+    # only db 'admins' group has admin privs
+    # I'll put it in again because group list cannot be empty
+    admin-groups: [admins]
+
+schemas:
+  - schema: corporate_data
+    catalog: osc_datacommons_dev
+    admin-groups: ['corporate_data.*']
+    public-tables: true
+
+  - schema: itr
+    catalog: osc_datacommons_dev
+    admin-groups: ['itr.*']
+    public-tables: true
+
+  - schema: physical_risk
+    catalog: osc_datacommons_dev
+    admin-groups: ['physical_risk.*']
+    public-tables: true
+
+  - schema: gleif
+    catalog: osc_datacommons_dev
+    admin-groups: ['entity_matching.*']
+    public-tables: true
+
+  - schema: aicoe_osc_demo
+    catalog: osc_datacommons_dev
+    admin-groups: ['aicoe_osc_demo']
+    public-tables: true
+
+  - schema: urgentem
+    catalog: osc_datacommons_dev
+    admin-groups: ['aicoe_osc_demo']
+    public-tables: true
+
+  - schema: sandbox
+    catalog: osc_datacommons_dev
+    admin-groups: ['.*']
+    public-tables: true
+
+  - schema: demo
+    catalog: osc_datacommons_dev
+    admin-groups: ['.*']
+    public-tables: true
+
+tables:
+  - table: gppd
+    schema: demo
+    catalog: osc_datacommons_dev
+    admin-groups: [demo_dv_dev]
+    public: false
+    row-acl:
+      type: filter
+      filter: "country = 'France'"
+    # hide-columns are cumulative, top to bottom
+    column-acl:
+      - groups: [demo_dv_quant]
+        # quants can see all columns but only have select privs
+        # and row filtering still applies
+        hide-columns: []
+      - groups: [demo_dv_user]
+        hide-columns: [rating]
+
+  - table: demo_dv_backend
+    schema: demo
+    catalog: osc_datacommons_dev
+    admin-groups: [demo_dv_dev]
+    public: false
+
+  - table: demo_dv_userfacing
+    schema: demo
+    catalog: osc_datacommons_dev
+    admin-groups: [demo_dv_dev]
+    public: false
+    row-acl:
+      type: filter
+      filter: "contains(current_groups(), access) or access = 'public'"
+    column-acl:
+      - groups: [demo_dv_quant]
+        hide-columns: [dev1]
+      - groups: [demo_dv_user]
+        # hide-columns are cumulative, top to bottom
+        hide-columns: [quant1]


### PR DESCRIPTION
This PR adds a DSL management layer to the `rules.json` files for trino deployments.

The motivation is that `rules.json` rules are:
- difficult to read
- conducive to errors, since one has to scan down all rules to identify first-match in all relevant circumstances
- easy to break, because adding a rule in one place can shadow lower rules if one is not careful
- do not support human readable comments

I implemented a simplified DSL-like yaml format to try and make these configurations easier:
https://github.com/os-climate/osc-trino-acl-dsl

The basic concept is that one creates configurations in this DSL format, and it is translated into a `rules.json` file.

The DSL is declarative - one does NOT have to figure out which entries apply "first": they are order independent.
It can also be written in YAML - and so supports white space and comments, to increase readability and maintainability.

One trade-off with this approach is that proper consistency between this DSL file and the corresponding rules.json file must
be maintained. I have addressed this by implementing a pre-commit check that verifies the rules.json file being committed
is the result of running the translator on the corresponding DSL file.  If it detects a difference it will fail the commit.