### PR TITLE
Onboarding project notebook custom quota default change

### DIFF
--- a/docs/content/notebooks/onboarding_project.ipynb
+++ b/docs/content/notebooks/onboarding_project.ipynb
@@ -115,7 +115,7 @@
     "# See details here: https://www.operate-first.cloud/apps/content/cluster-scope/quotas.html\n",
     "QUOTA=\"small\"\n",
     "# If instead you want to use a custom quota, ignore QUOTA and set the following to True\n",
-    "CUSTOM_QUOTA=True\n",
+    "CUSTOM_QUOTA=False\n",
     "\n",
     "# Target cluster variables\n",
     "TARGET_CLUSTER_NAME = \"smaug\"\n",


### PR DESCRIPTION
Allows cell block where add a default quota to run

Resolves issue [#1561 ](https://github.com/operate-first/apps/issues/1561)

