### PR TITLE
Correct smaug jh user pvc with actual pvc on live.

### DIFF
--- a/kfdefs/overlays/moc/smaug/opf-jupyterhub/pvcs/ofir-shechtman.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-jupyterhub/pvcs/ofir-shechtman.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
     annotations:
         hub.jupyter.org/username: ofir-shechtman
-    name: jupyterhub-nb-ofir-shechtman-pvc
+    name: jupyterhub-nb-ofir-2dshechtman-pvc
     labels:
         app: jupyterhub
         component: singleuser-storage


### PR DESCRIPTION
This is the actual pvc: https://console-openshift-console.apps.smaug.na.operate-first.cloud/k8s/ns/opf-jupyterhub/persistentvolumeclaims/jupyterhub-nb-ofir-2dshechtman-pvc 