### PR TITLE
bundling resources in emea, infra and smaug clusters

### DIFF
--- a/cluster-scope/bundles/nfd/kustomization.yaml
+++ b/cluster-scope/bundles/nfd/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base/core/namespaces/openshift-nfd
+  - ../../base/operators.coreos.com/operatorgroups/openshift-nfd
+  - ../../base/operators.coreos.com/subscriptions/nfd

--- a/cluster-scope/overlays/prod/emea/balrog/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/balrog/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
     - ../../../../base/config.openshift.io/oauths/cluster
     - ../../../../base/core/configmaps/cluster-monitoring-config
     - ../../../../base/core/configmaps/user-workload-monitoring-config
-    - ../../../../base/core/namespaces/acme-operator
     - ../../../../base/core/namespaces/openshift-logging
     - ../../../../base/core/namespaces/opf-kafka
     - ../../../../base/core/namespaces/thoth-amun-api-prod
@@ -22,10 +21,9 @@ resources:
     - ../../../../base/operators.coreos.com/subscriptions/cert-manager
     - ../../../../base/operators.coreos.com/subscriptions/cluster-logging
     - ../../../../base/operators.coreos.com/subscriptions/strimzi
-    - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator
     - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-monitoring-view-balrog
-    - ../../../../base/rbac.authorization.k8s.io/clusterroles/acme-operator
     - ../../../../base/user.openshift.io/groups/cluster-admins
+    - ../../../../bundles/acme-operator
     - machineautoscalers.yaml
 generators:
     - secret-generator.yaml

--- a/cluster-scope/overlays/prod/emea/rick/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/rick/kustomization.yaml
@@ -7,12 +7,10 @@ resources:
     - ../../../../base/config.openshift.io/oauths/cluster
     - ../../../../base/core/configmaps/cluster-monitoring-config
     - ../../../../base/core/configmaps/user-workload-monitoring-config
-    - ../../../../base/core/namespaces/acme-operator
     - ../../../../base/core/namespaces/openshift-cnv
     - ../../../../base/core/namespaces/openshift-insights
     - ../../../../base/core/namespaces/openshift-logging
     - ../../../../base/core/namespaces/openshift-monitoring
-    - ../../../../base/core/namespaces/openshift-nfd
     - ../../../../base/core/namespaces/openshift-operators
     - ../../../../base/core/namespaces/openshift-storage
     - ../../../../base/core/namespaces/opf-alertreceiver
@@ -25,7 +23,6 @@ resources:
     - ../../../../base/imageregistry.operator.openshift.io/configs/cluster
     - ../../../../base/operators.coreos.com/operatorgroups/openshift-cnv-rn5jf
     - ../../../../base/operators.coreos.com/operatorgroups/openshift-local-storage-zj22x
-    - ../../../../base/operators.coreos.com/operatorgroups/openshift-nfd
     - ../../../../base/operators.coreos.com/operatorgroups/openshift-storage-24n7x
     - ../../../../base/operators.coreos.com/operatorgroups/opf-monitoring
     - ../../../../base/operators.coreos.com/operatorgroups/opf-kafka
@@ -34,16 +31,15 @@ resources:
     - ../../../../base/operators.coreos.com/subscriptions/openshift-local-storage-operator
     - ../../../../base/operators.coreos.com/subscriptions/ocs-operator
     - ../../../../base/operators.coreos.com/subscriptions/openshift-pipelines-operator-rh
-    - ../../../../base/operators.coreos.com/subscriptions/nfd
     - ../../../../base/operators.coreos.com/subscriptions/prometheus-operator
-    - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator
     - ../../../../base/operators.coreos.com/subscriptions/strimzi
     - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/opf-cluster-metrics-federation
     - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/oauth-token-access-review-opf-monitoring
-    - ../../../../base/rbac.authorization.k8s.io/clusterroles/acme-operator
     - ../../../../base/rbac.authorization.k8s.io/clusterroles/oauth-token-access-review
     - ../../../../base/user.openshift.io/groups/cluster-admins
     - ../../../../base/storage.k8s.io/storageclasses/ocs-storagecluster-cephfs
+    - ../../../../bundles/acme-operator
+    - ../../../../bundles/nfd
     - clusterversion.yaml
 
 generators:

--- a/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
@@ -9,7 +9,6 @@ resources:
   - ../../../../base/core/configmaps/cluster-monitoring-config
   - ../../../../base/core/configmaps/user-workload-monitoring-config
   - ../../../../base/core/namespaces/acm
-  - ../../../../base/core/namespaces/acme-operator
   - ../../../../base/core/namespaces/democratic-csi
   - ../../../../base/core/namespaces/keycloak
   - ../../../../base/core/namespaces/openshift-cnv
@@ -26,18 +25,17 @@ resources:
   - ../../../../base/operators.coreos.com/subscriptions/cluster-logging
   - ../../../../base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator
   - ../../../../base/operators.coreos.com/subscriptions/rhsso-operator
-  - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/moc-nfs-democratic-csi-controller-rb
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/moc-nfs-democratic-csi-node-rb
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:admin:osc-cl1
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:managedclusterset:admin:octo-ushift-dev
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:managedclusterset:admin:osc
-  - ../../../../base/rbac.authorization.k8s.io/clusterroles/acme-operator
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/moc-nfs-democratic-csi-controller-cr
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/moc-nfs-democratic-csi-node-cr
   - ../../../../base/storage.k8s.io/csidrivers/org.democratic-csi.nfs
   - ../../../../base/storage.k8s.io/storageclasses/moc-nfs-csi
   - ../../../../base/user.openshift.io/groups/cluster-admins
+  - ../../../../bundles/acme-operator
   - apiserver/api_server_cert.yaml
   - clusterversion.yaml
   - nodenetworkconfigurationpolicies/crc-provisioning-vlan.yaml

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -34,7 +34,6 @@ resources:
 - ../../../../base/core/namespaces/neu-cs6620
 - ../../../../base/core/namespaces/openshift-cnv
 - ../../../../base/core/namespaces/openshift-logging
-- ../../../../base/core/namespaces/openshift-nfd
 - ../../../../base/core/namespaces/openshift-operators
 - ../../../../base/core/namespaces/openshift-pipelines
 - ../../../../base/core/namespaces/openshift-vertical-pod-autoscaler
@@ -82,7 +81,6 @@ resources:
 - ../../../../base/operators.coreos.com/operatorgroups/cluster-logging
 - ../../../../base/operators.coreos.com/operatorgroups/koku-metrics-operator
 - ../../../../base/operators.coreos.com/operatorgroups/openshift-cnv-rn5jf
-- ../../../../base/operators.coreos.com/operatorgroups/openshift-nfd
 - ../../../../base/operators.coreos.com/operatorgroups/openshift-vertical-pod-autoscaler
 - ../../../../base/operators.coreos.com/operatorgroups/opf-monitoring
 - ../../../../base/operators.coreos.com/operatorgroups/opf-pulp
@@ -91,7 +89,6 @@ resources:
 - ../../../../base/operators.coreos.com/subscriptions/cluster-logging
 - ../../../../base/operators.coreos.com/subscriptions/koku-metrics-operator
 - ../../../../base/operators.coreos.com/subscriptions/kubevirt-hyperconverged
-- ../../../../base/operators.coreos.com/subscriptions/nfd
 - ../../../../base/operators.coreos.com/subscriptions/openshift-pipelines-operator-rh
 - ../../../../base/operators.coreos.com/subscriptions/opf-grafana
 - ../../../../base/operators.coreos.com/subscriptions/ovms-operator
@@ -121,6 +118,7 @@ resources:
 - ../../../../bundles/fybrik
 - ../../../../bundles/kfp-tekton
 - ../../../../bundles/meteor-operator
+- ../../../../bundles/nfd
 - ../../../../bundles/reloader
 - ../../../../bundles/seraph
 - ../../../../bundles/tekton-chains


### PR DESCRIPTION
I had kept the resource bundling changes in a separate PR for the smaug cluster. 
This PR has resource bundling for the infra cluster. 
Besides these two clusters, I searched for other clusters in moc and I couldn't find any other place in the moc where we can do resource bundling. 
Edit: Will bundle the acme in EMEA cluster in this PR itself. 