### PR TITLE
feat(infra): Grant oglok cluster admin

### DIFF
--- a/cluster-scope/overlays/prod/moc/infra/groups/cluster-admins.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/groups/cluster-admins.yaml
@@ -12,3 +12,4 @@ users:
   - naved001
   - rob-baron
   - tumido
+  - oglok


### PR DESCRIPTION
@oglok needs a way to manage what ACM addons are installed to his microshift clusters and experiment with it a bit. Since `KlusterletAddonConfig` is a cluster scoped resource kind, he can't touch them. Can we grant him cluster admin access for now?