### PR TITLE
Correct artifact object storage config for kfp-tekton on smaug.

### DIFF
--- a/kfp-tekton/base/kfp-tekton.yaml
+++ b/kfp-tekton/base/kfp-tekton.yaml
@@ -1049,18 +1049,14 @@ spec:
         application-crd-id: kubeflow-pipelines
     spec:
       containers:
-      - env:
+      - envFrom:
+          - secretRef:
+              name: mlpipeline-ceph-artifact
+        env:
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: OBJECTSTORECONFIG_SECURE
-          value: "false"
-        - name: OBJECTSTORECONFIG_BUCKETNAME
-          valueFrom:
-            configMapKeyRef:
-              key: bucketName
-              name: pipeline-install-config
         - name: DBCONFIG_USER
           valueFrom:
             secretKeyRef:
@@ -1086,16 +1082,6 @@ spec:
             configMapKeyRef:
               key: dbPort
               name: pipeline-install-config
-        - name: OBJECTSTORECONFIG_ACCESSKEY
-          valueFrom:
-            secretKeyRef:
-              key: accesskey
-              name: mlpipeline-ceph-artifact
-        - name: OBJECTSTORECONFIG_SECRETACCESSKEY
-          valueFrom:
-            secretKeyRef:
-              key: secretkey
-              name: mlpipeline-ceph-artifact
         - name: PIPELINE_RUNTIME
           value: tekton
         - name: ARTIFACT_BUCKET
@@ -1310,12 +1296,12 @@ spec:
         - name: MINIO_ACCESS_KEY
           valueFrom:
             secretKeyRef:
-              key: accesskey
+              key: OBJECTSTORECONFIG_ACCESSKEY
               name: mlpipeline-ceph-artifact
         - name: MINIO_SECRET_KEY
           valueFrom:
             secretKeyRef:
-              key: secretkey
+              key: OBJECTSTORECONFIG_SECRETACCESSKEY
               name: mlpipeline-ceph-artifact
         - name: ALLOW_CUSTOM_VISUALIZATIONS
           value: "true"

--- a/kfp-tekton/overlays/moc/smaug/secrets/mlpipeline-ceph-artifact.enc.yaml
+++ b/kfp-tekton/overlays/moc/smaug/secrets/mlpipeline-ceph-artifact.enc.yaml
@@ -8,35 +8,40 @@ metadata:
     annotations:
         kustomize.config.k8s.io/behavior: replace
 stringData:
-    accesskey: ENC[AES256_GCM,data:uPZSXcafV8Tx9fQghpJZmx1HvmE=,iv:H/i0AuYyK2NT+J6nQnnIrfCg+r6YA2lx37qtR/zwh/U=,tag:dvkak94u+T/LN86TSi3Jvg==,type:str]
-    secretkey: ENC[AES256_GCM,data:bRXOM83U6XFclb2vyoMEW8WOubXZDnklLcq7p4WfXY0FR8DIpkIL8w==,iv:EstatJVj8vluaE/qUi2jLNxIIx5ejEnabPufQLn+ZeU=,tag:xztMgnYDJLIPsaGpmdeqrg==,type:str]
+    OBJECTSTORECONFIG_HOST: ENC[AES256_GCM,data:C1Yp12pJ6X+xo2k7xahr8jtsFIQWnjneZKKnzcas9jghFs/zM3kx3m8Q6sgl1avp5pmTYqSC,iv:Z4oMkoWoeVItQW7BfP7KSA63QCYxAlBC9pJob6nwxrU=,tag:6aEjg+Ea5epjWFE2688YJQ==,type:str]
+    OBJECTSTORECONFIG_PORT: ENC[AES256_GCM,data:fkTb,iv:G206cogm53CNvUJQKATRwtBbTPzQ+CY0Rs+DpsHc5gI=,tag:3CE5PaCUJE5Toz7PjtD+AQ==,type:str]
+    OBJECTSTORECONFIG_SECURE: ENC[AES256_GCM,data:ardIUw==,iv:87IfmSHYvTxO/T/VPOu9qZP0irADizaLboPwLSWx5p4=,tag:OMKtXYrcnkHtJyZxKfp0SQ==,type:str]
+    OBJECTSTORECONFIG_BUCKETNAME: ENC[AES256_GCM,data:ZSsg3AghkZzXM9YZQWRqA/xX5Uo=,iv:lVNwnSuALB8ReXKmOsZ6BCRPquI+WxDNf01swMkN0Nk=,tag:IVIyFklb0TozmMeboVCLDg==,type:str]
+    OBJECTSTORECONFIG_ACCESSKEY: ENC[AES256_GCM,data:yoPZ9z7G5gCVqxJt7plhptuiBa8=,iv:UcJSwTPHMvtJWziViNU0AkuRgpZ+TZgUdGdRRZXpAEE=,tag:2MPofvNDUcou07DmrivXSQ==,type:str]
+    OBJECTSTORECONFIG_SECRETACCESSKEY: ENC[AES256_GCM,data:9e1YpdNQ5I1AAxTKUd0YrH4TjOBh83YrZ/KmpRS+xxNweKFZWamuQA==,iv:N6eMcC5nGoPReF2cln03hy1U3kHRWEV15xAlFfUu9BU=,tag:1zZj8BjApGAPRxFzS0uPqg==,type:str]
+    OBJECTSTORECONFIG_PIPELINEPATH: ENC[AES256_GCM,data:Uu5brqKMABWTFw==,iv:+4LciKcR6VRQjpZwqleDc87F4kfSTSmNCxp4Lr7d2No=,tag:Yy3Sfk7jGc5Fwy0nUJXY8Q==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2022-02-02T20:18:34Z'
-    mac: ENC[AES256_GCM,data:6qOKggNcfjX8J8l0r2BGWA0aEDhqCfpWGjjNJJdJPyN9UqKd4tEBGQoyExXvg2Rwgikme46wc6VlgF/nrFhDQ0P/qqLwRuu9cpwOl76IEFMZmRd6NFZoiDWdsceFikWAQGLpUKq5r6otIP4T4iz37hHGm1a/yNXBNvzZhvt1hdE=,iv:8KPmCosQnSyKYA6n+tw3bGZNoP89qVd5HLo+KbePfBQ=,tag:rYSpa7qSymkRqYErQ1YRMQ==,type:str]
+    lastmodified: '2022-02-04T19:59:48Z'
+    mac: ENC[AES256_GCM,data:wB0pnFGDDXATjTzdO4DMYQnTf+HvpeBZl+dAtMiufXcnmWU0i3f2QYudcvsbIi3CYwdlK8X8QUPNp0TCXr5a1ud/jbANhysKh94CvkbLCDPcofc4zyBy5CtkjU2a4Lwmdz/6/tNbJfjMlMPXNXvPnH0bdO9xVGj6zWJCjtzTO7Y=,iv:G62pP+CMTYrKDkeK8ZTFnX3m85UrAvoDMI9KktVvyj8=,tag:2A3iBMKlPaVmR16PeadA5Q==,type:str]
     pgp:
-    -   created_at: '2022-02-02T20:18:33Z'
+    -   created_at: '2022-02-04T19:59:47Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMA9aKBcudqifiARAAg//48A0M+qu6pVG5Rpgp1DJeZ+y8pSSn/jQZdXb3WIGi
-            vMa8crOIz/IK9aVNEoqABrVOSnwEchBOiHgreHkgswNZ07wTiR5hmyzc39XkICk/
-            MW+V8hHR/8ZFBuGsHGV4Kbe1teac1dz5UJ3xZkhXH2ompd1QjnrQN6WTULyQUy4B
-            x21k1dzlrNNrVY7vH1nth+B0jURITonxdjNqDHVe3AdmICXeogLfFdanBOjKJ32b
-            yRqWYZL/2ZhDJIti1ddxuxbdKXP8J0ylrErWIeycKL0Gh98Zd52w7U5NpgyWNL6S
-            7giSxkQEZZhi4z4Xv2N7ZURAAiDddSbD5ap4KdHo0coB3rjNljyJp/QgzE4Wki2M
-            sVmeNZT1Hfn2vnIeolQX03at7aZ4R+fv4d0xZn2FI2Zckpv8BWkQDRLyLhsuAIW7
-            qz0gkLtJotAZQkl0dRJ92nEOQrYLDg5xuAat1AdJtXQlShgBN6K5UZipwtFrD41v
-            J1IJY9MNVxSMaqsncwapqDqplV0yjMcixs0wUXwQ/SrYPSznmEZEkmvHzTHB3ezQ
-            1hPovBExF0tIerKB5+oo21oDj52dAZoito/vWUiAN2RS9SzNp33JERlIvzJbwbCR
-            OT6BAip2rbyjsxz/tvdjdpJnWuJlgBjAD4c+atLlwNXLdbj8u6cG17rlx0dKHMvS
-            4AHkW0Be4n7ht/tbaO6CZHKLMuFqKuCd4GXhpOvgFOLYzuyn4AnlcHnWjPgZEFuL
-            42yR9BckMCQdexltPuBvFs2tRVIlumXg4uSk4/hRnalgen4R/EnrUmfo4mi4UVHh
-            KYYA
-            =gO01
+            wcFMA9aKBcudqifiARAApHc1ZM49g9ylhd93kyfV27wtr1aoaJYPH5J3MNgrCB5l
+            kP7tp0MMKXfKH3IPr4cmMCWDmXI7sAdtjdKZ4ayJk+1pH7j3lQGH68jmHzLLG80j
+            W4eU2l9HBERCuYNfRaRJeqlwuDSEAPST/9e50bNp9je1c9+jMQxQRbA3PIQlmMhm
+            2awdMNtUqgCY4B8pk9ANxNqFfWfyKlb1GqCP0kE57gmzu6U5QRU2wViG24pVFbOb
+            Jq2tl1L6S9wkC2ySx82Pq04zBGL4kr120Emq8P0iS3G5u7yjjcX9K+dLY2MC+5OY
+            VkSzUtp6QH35XN4X/GzPcgNroOVRwD9GxPdUgmy9Sj9EWbEYOqxB9Lc8x3u2jrQH
+            XiG/tUyf2JWQJ6vwrNZ8ST/hONM4G6giBP5KXFdGkUSzq5F86E9xmy8iVC8C8YTu
+            Gn9tk5I0bB6lDl8rRBf7X2ALUPOfsdf2lSG3aq4Gv56YEZ3ln1ACBB4gnxUX1qZp
+            gCqNNIIf/tZL6ocXU0Ow+2jV+8MHfmOya4vQDk78O6W72yuVJfVb8JAkrXzUKtf/
+            Rnky1dGmMLzmta5ZbwkHShN21XH38RBpEzfgSpMI15ibXsGeUs2toLSXmJiNSyGl
+            rLhjmpELop8K8cTDCU8clyR+aU3aE/Mt3BXCf3zoXn1QWwSNEmsj4haNCxwvuJ/S
+            4AHkLl4xC5V8CLWIHKLBKLF8OOGILuBP4DThBO3gxuIR/FE84FDlC+yLiZkf8TKO
+            utqlU/agqkPEI4QjQUeDqGvxHE2LV4vg8+RERHPPq7W1SAB136vfaZNr4unlqCPh
+            kuoA
+            =onqW
             -----END PGP MESSAGE-----
         fp: 0508677DD04952D06A943D5B4DC4116D360E3276
     encrypted_regex: ^(users|data|stringData)$


### PR DESCRIPTION
This will fix the failing ml-pipeline pod which could not create a minio client. 

The issue was that the configuration defaults try to connect to some default minio host, we need to manually set these if we are not deploying our own minio instance: 

References: 

- https://github.com/kubeflow/kfp-tekton/blob/6166c7c2cc62531f3edf1446dc96d9bb20aa2a1e/backend/src/apiserver/client/minio.go#L65
- https://github.com/kubeflow/kfp-tekton/blob/6166c7c2cc62531f3edf1446dc96d9bb20aa2a1e/backend/src/apiserver/client_manager.go#L384-L405