### PR TITLE
adding argocd-notifications argocd application manifests

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/infra/cluster-management/argocd-notifications.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/infra/cluster-management/argocd-notifications.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-notifications
+spec:
+  destination:
+    server: moc-infra
+    namespace: argocd
+  project: cluster-management
+  source:
+    path: argocd-notifications/overlays/infra
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/argocd/overlays/moc-infra/applications/envs/moc/infra/cluster-management/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/infra/cluster-management/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - acm.yaml
   - alertreceiver.yaml
+  - argocd-notifications.yaml
   - argocd-projects.yaml
   - argocd.yaml
   - cert-manager.yaml


### PR DESCRIPTION
Related to [Investigate Argocd-notifications Issue in Operate-first/SRE](https://github.com/operate-first/SRE/issues/410).

Every other piece was deployed in #1520, short of the argocd-notifications application manifest itself, which has been addressed here.