### PR TITLE
removing capitals from thoth group

### DIFF
--- a/cluster-scope/base/user.openshift.io/groups/thoth/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/thoth/group.yaml
@@ -12,4 +12,4 @@ users:
   - mayacostantini
   - xtuchyna
   - gregory-pereira
-  - Gkrumbach07
+  - gkrumbach07


### PR DESCRIPTION
In Response to [Trouble accessing the grafana dashboard](https://github.com/operate-first/apps/issues/1511). Once this gets merged we can test and see if this works. Another possible workaround that could be tried, if this is not an issue, is adding the [`fde` group](https://github.com/operate-first/apps/blob/master/cluster-scope/base/user.openshift.io/groups/fde/group.yaml) to the [`grafana-oauth.yaml` file](https://github.com/operate-first/apps/blob/master/grafana/overlays/moc/smaug/grafana-oauth.yaml#L38-39).