### PR TITLE
Previous commit used the wrong issue for the api certificate

### DIFF
--- a/cert-manager/overlays/moc/common/api-issuer/openshift-api-issuer.yaml
+++ b/cert-manager/overlays/moc/common/api-issuer/openshift-api-issuer.yaml
@@ -2,7 +2,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: api-letsencrypt-production
-  namespace: openshift-config
 spec:
   acme:
     email: ops-team@operate-first.cloud
@@ -12,13 +11,12 @@ spec:
     solvers:
       - selector:
           dnsZones:
-            - .na.operate-first.cloud
+            - "na.operate-first.cloud"
         dns01:
           cnameStrategy: Follow
-          route53:
-            region: us-east-1
-            accessKeyID: AKIAYLUGMT7YHWIC6R62
-            hostedZoneID: Z04486682XFINHTESP6B9
-            secretAccessKeySecretRef:
-              name: aws-route53-credentials
-              key: aws_secret_access_key
+          cloudDNS:
+            project: aicoe-prow
+            hostedZoneName: "na-operate-first"
+            serviceAccountSecretRef:
+              key: key.json
+              name: clouddns-dns01-na-svc-acct

--- a/cert-manager/overlays/moc/common/ingress-issuer/openshift-ingress-issuer.yaml
+++ b/cert-manager/overlays/moc/common/ingress-issuer/openshift-ingress-issuer.yaml
@@ -2,7 +2,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: ingress-letsencrypt-production
-  namespace: openshift-ingress
 spec:
   acme:
     email: ops-team@operate-first.cloud

--- a/cert-manager/overlays/moc/smaug/api/kustomization.yaml
+++ b/cert-manager/overlays/moc/smaug/api/kustomization.yaml
@@ -5,3 +5,4 @@ patchesStrategicMerge:
   - certificate.yaml
 resources:
   - ../../common/api-issuer
+  - ../../common/secrets


### PR DESCRIPTION
PR #1571 was mistakenly using the route53 issuer for the smaug api
certificate. This corrects it to use the google cloud issuer.
