### PR TITLE
Add parameter to argocd vault application.

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/fybrik/vault.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/fybrik/vault.yaml
@@ -12,6 +12,8 @@ spec:
       valueFiles:
         - env/dev/vault-single-cluster-values.yaml
       parameters:
+        - name: vault.server.authDelegator.enabled
+          value: 'false'
         - name: vault.global.openshift
           value: 'true'
         - name: vault.injector.enabled


### PR DESCRIPTION
This PR adds parameter to argocd vault application.
By disabling vault.server.authDelegator the clusterRoleBinding `vault-server-binding` is not created by this helm deployment which currently causes the deployment to fail.
Moreover, `vault-server-binding` resource already [exists ](https://github.com/operate-first/apps/tree/master/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/vault-server-binding)in the cluster.