### PR TITLE
Remove explicit version from the ODH operator subscription

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/opendatahub-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/opendatahub-operator/subscription.yaml
@@ -10,4 +10,3 @@ spec:
   name: opendatahub-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: opendatahub-operator.v1.1.0


### PR DESCRIPTION
The current version of ODH operator is 1.1.2.

Trying to subscribe to ODH using the current `Subscription` from the repo results in a non-installed operator, due to a failing condition:

```
Message:               constraints not satisfiable:
- bundle community-operators/openshift-marketplace/stable/opendatahub-operator.v1.1.0 is deprecated
- subscription opendatahub-operator requires community-operators/openshift-marketplace/stable/opendatahub-operator.v1.1.0
```

This removes the explicit constraint on the CSV version to avoid that situation