### PR TITLE
Make sparkoperator in jh ocp 4.9 compatible.

### DIFF
--- a/kfdefs/base/jupyterhub/kfdef.yaml
+++ b/kfdefs/base/jupyterhub/kfdef.yaml
@@ -29,6 +29,13 @@ spec:
           name: manifests
           path: radanalyticsio/spark/cluster
       name: radanalyticsio-spark-cluster
+    # TODO: Remove this override (and associated manifests in odh-manifests/smaug/radanalyticsio/*)
+    # Once this PR is merged: https://github.com/opendatahub-io/odh-manifests/pull/509
+    - kustomizeConfig:
+        repoRef:
+          name: opf-manifests
+          path: odh-manifests/smaug/radanalyticsio/spark/cluster
+      name: radanalyticsio-spark-cluster
   repos:
     - name: manifests
       uri: "https://github.com/opendatahub-io/odh-manifests/tarball/v1.1.1"

--- a/odh-manifests/smaug/radanalyticsio/spark/cluster/base/crds.yaml
+++ b/odh-manifests/smaug/radanalyticsio/spark/cluster/base/crds.yaml
@@ -1,0 +1,142 @@
+---
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1
+metadata:
+  name: sparkclusters.radanalytics.io
+spec:
+  group: radanalytics.io
+  names:
+    kind: SparkCluster
+    listKind: SparkClusterList
+    plural: sparkclusters
+    singular: sparkcluster
+  scope: Namespaced
+  version: v1
+  additionalPrinterColumns:
+  - name: Worker
+    type: string
+    description: The number of workers in the Spark cluster
+    JSONPath: .spec.worker.instances
+  - name: Master
+    type: string
+    description: The number of masters in the Spark cluster
+    JSONPath: .spec.master.instances
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SparkCluster is the schema for the sparkcluster api
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SparkClusterSpec defines the configuration for the deployed spark cluster
+            properties:
+              worker:
+                type: object
+              master:
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1
+metadata:
+  name: sparkapplications.radanalytics.io
+spec:
+  group: radanalytics.io
+  names:
+    kind: SparkApplication
+    listKind: SparkApplicationList
+    plural: sparkapplications
+    singular: sparkapplication
+  scope: Namespaced
+  version: v1
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SparkApplications is the schema for the sparkapplication api
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SparkApplications defines the configuration for submitting a spark application that will run in an on demand SparkCluster
+            properties:
+              mainApplicationFile:
+                type: string
+              mainClass:
+                type: string
+              driver:
+                type: object
+              executor:
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1
+metadata:
+  name: sparkhistoryservers.radanalytics.io
+spec:
+  group: radanalytics.io
+  names:
+    kind: SparkHistoryServer
+    listKind: SparkHistoryServerList
+    plural: sparkhistoryservers
+    singular: sparkhistoryserver
+  scope: Namespaced
+  version: v1
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SparkHistoryServers is the schema for the sparkhistoryserver api
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SparkHistoryServer defines the configuration for the spark history server
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/odh-manifests/smaug/radanalyticsio/spark/cluster/base/deployment.yaml
+++ b/odh-manifests/smaug/radanalyticsio/spark/cluster/base/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spark-operator
+  labels:
+    app: jupyterhub
+    component: spark-operator
+    app.kubernetes.io/name: spark-operator
+    app.kubernetes.io/version: v0.1.5-v1alpha1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: spark-operator
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        component: spark-operator
+    spec:
+      serviceAccountName: spark-operator
+      containers:
+      - name: spark-operator
+        image: spark-operator
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['olm.targetNamespaces']
+        - name: CRD
+          value: "true"
+        imagePullPolicy: IfNotPresent
+        resources:
+        limits:
+          cpu: 500m
+          memory: 600Mi
+        requests:
+          cpu: 500m
+          memory: 600Mi

--- a/odh-manifests/smaug/radanalyticsio/spark/cluster/base/kustomization.yaml
+++ b/odh-manifests/smaug/radanalyticsio/spark/cluster/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: opendatahub
+resources:
+- serviceaccount.yaml
+- role.yaml
+- rolebinding.yaml
+- crds.yaml
+- deployment.yaml
+
+images:
+  - name: spark-operator
+    newName: quay.io/opendatahub/spark-operator
+    newTag: 1.2.0

--- a/odh-manifests/smaug/radanalyticsio/spark/cluster/base/role.yaml
+++ b/odh-manifests/smaug/radanalyticsio/spark/cluster/base/role.yaml
@@ -1,0 +1,23 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spark-edit-resources
+  labels:
+    app: spark
+    component: spark-operator
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "replicationcontrollers", "services", "configmaps"]
+    verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch", "patch"]
+  - apiGroups: ["", "route.openshift.io"]
+    resources: ["routes"]
+    verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["radanalytics.io/v1"]
+    resources: ["SparkCluster", "SparkApplication", "SparkHistoryServer"]
+    verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]

--- a/odh-manifests/smaug/radanalyticsio/spark/cluster/base/rolebinding.yaml
+++ b/odh-manifests/smaug/radanalyticsio/spark/cluster/base/rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: spark-operator-edit-resources
+  labels:
+    app: jupyterhub
+    component: spark-operator
+roleRef:
+  kind: ClusterRole
+  name: spark-edit-resources
+  apiGroup: ""
+subjects:
+  - kind: ServiceAccount
+    name: spark-operator

--- a/odh-manifests/smaug/radanalyticsio/spark/cluster/base/serviceaccount.yaml
+++ b/odh-manifests/smaug/radanalyticsio/spark/cluster/base/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spark-operator
+  labels:
+    app: jupyterhub
+    component: spark-operator


### PR DESCRIPTION
While we wait for https://github.com/opendatahub-io/odh-manifests/pull/509 to merge. 

Could also help illustrate the PR is in working order. 

Note: this slightly violates the "crds in `cluster-scope/base` rule, but that's because the ODH operator is deploying these manifests, and they are effectively part of ODH platform (not something argocd manages/deploys). 