### PR TITLE
Remove starting csv from odhseldon subscription in odh.

### DIFF
--- a/kfdefs/overlays/moc/smaug/ds-ml-workflows-ws/kfdef.yaml
+++ b/kfdefs/overlays/moc/smaug/ds-ml-workflows-ws/kfdef.yaml
@@ -15,7 +15,16 @@ spec:
           name: manifests
           path: odhseldon/cluster
       name: odhseldon
+    # TODO: Remove this patch and associated files once this is merged:
+    # https://github.com/opendatahub-io/odh-manifests/pull/521
+    - kustomizeConfig:
+        repoRef:
+          name: opf
+          path: odh-manifests/smaug/odhseldon
+      name: odhseldon
   repos:
     - name: manifests
       uri: https://github.com/opendatahub-io/odh-manifests/tarball/v1.1.1
+    - name: opf
+      uri: https://github.com/operate-first/apps/tarball/master
   version: v1.1.1

--- a/kfdefs/overlays/moc/smaug/opf-seldon/kustomization.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-seldon/kustomization.yaml
@@ -5,3 +5,26 @@ namespace: opf-seldon
 
 resources:
   - ../../../../base/seldon
+
+# TODO: Remove this patch and associated files once this is merged:
+# https://github.com/opendatahub-io/odh-manifests/pull/521
+patchesJson6902:
+  - patch: |
+      - op: add
+        path: /spec/applications/-
+        value:
+          kustomizeConfig:
+            repoRef:
+              name: opf
+              path: odh-manifests/smaug/odhseldon
+          name: odhseldon
+      - op: add
+        path: /spec/repos/-
+        value:
+          name: opf
+          uri: https://github.com/operate-first/apps/tarball/master
+    target:
+      group: kfdef.apps.kubeflow.org
+      kind: KfDef
+      name: opendatahub
+      version: v1

--- a/odh-manifests/osc-cl1/odhseldon/cluster/base/kustomization.yaml
+++ b/odh-manifests/osc-cl1/odhseldon/cluster/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: opendatahub
+resources:
+- subscription.yaml

--- a/odh-manifests/osc-cl1/odhseldon/cluster/base/subscription.yaml
+++ b/odh-manifests/osc-cl1/odhseldon/cluster/base/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: seldon-operator-certified
+  namespace: opendatahub
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: seldon-operator-certified
+  source: certified-operators
+  sourceNamespace: openshift-marketplace

--- a/odh-manifests/smaug/odhseldon/cluster/base/kustomization.yaml
+++ b/odh-manifests/smaug/odhseldon/cluster/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: opendatahub
+resources:
+- subscription.yaml

--- a/odh-manifests/smaug/odhseldon/cluster/base/subscription.yaml
+++ b/odh-manifests/smaug/odhseldon/cluster/base/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: seldon-operator-certified
+  namespace: opendatahub
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: seldon-operator-certified
+  source: certified-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Similar to: https://github.com/operate-first/apps/pull/1606 

This will make seldon compatible with ocp 4.9

We can remove this addition once either of these prs is merged upstream: 
https://github.com/opendatahub-io/odh-manifests/pull/522
https://github.com/opendatahub-io/odh-manifests/pull/521
