### PR TITLE
Fix volsync smaug overlay path

### DIFF
--- a/volsync/overlays/moc/smaug/kustomization.yaml
+++ b/volsync/overlays/moc/smaug/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
+- ../../../base


### PR DESCRIPTION
The smaug overlay for the volsync app didn't match the expectations of
the argocd application.