### PR TITLE
Correct osc superset kustomization to 1.1.0 version.

### DIFF
--- a/odh-manifests/osc/superset/base/kustomization.yaml
+++ b/odh-manifests/osc/superset/base/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - service-account.yaml
   - secret-superset.yaml
   - deployment.yaml
   - service.yaml
@@ -13,7 +14,6 @@ resources:
 commonLabels:
   opendatahub.io/component: "true"
   component.opendatahub.io/name: superset
-  app: superset
 
 namespace: opendatahub
 
@@ -23,94 +23,143 @@ configMapGenerator:
       - params.env
 
 vars:
-  - name: superset_secret
+  - name: SUPERSET_ADMIN_PASSWORD
     objref:
       name: superset-config
       kind: ConfigMap
       apiVersion: v1
     fieldref:
-      fieldpath: data.superset_secret
-  - name: superset_db_secret
+      fieldpath: data.SUPERSET_ADMIN_PASSWORD
+  - name: SUPERSET_ADMIN_USER
     objref:
       name: superset-config
       kind: ConfigMap
       apiVersion: v1
     fieldref:
-      fieldpath: data.superset_db_secret
-  - name: superset_memory_requests
+      fieldpath: data.SUPERSET_ADMIN_USER
+  - name: SUPERSET_ADMIN_FNAME
     objref:
       name: superset-config
       kind: ConfigMap
       apiVersion: v1
     fieldref:
-      fieldpath: data.superset_memory_requests
-  - name: superset_memory_limits
+      fieldpath: data.SUPERSET_ADMIN_FNAME
+  - name: SUPERSET_ADMIN_LNAME
     objref:
       name: superset-config
       kind: ConfigMap
       apiVersion: v1
     fieldref:
-      fieldpath: data.superset_memory_limits
-  - name: superset_cpu_requests
+      fieldpath: data.SUPERSET_ADMIN_LNAME
+  - name: SUPERSET_ADMIN_EMAIL
     objref:
       name: superset-config
       kind: ConfigMap
       apiVersion: v1
     fieldref:
-      fieldpath: data.superset_cpu_requests
-  - name: superset_cpu_limits
+      fieldpath: data.SUPERSET_ADMIN_EMAIL
+  - name: SUPERSET_VOLUME_SIZE
     objref:
       name: superset-config
       kind: ConfigMap
       apiVersion: v1
     fieldref:
-      fieldpath: data.superset_cpu_limits
-  - name: superset_db_memory_requests
+      fieldpath: data.SUPERSET_VOLUME_SIZE
+  - name: SUPERSET_SECRET_KEY
     objref:
       name: superset-config
       kind: ConfigMap
       apiVersion: v1
     fieldref:
-      fieldpath: data.superset_db_memory_requests
-  - name: superset_db_memory_limits
+      fieldpath: data.SUPERSET_SECRET_KEY
+  - name: SUPERSET_DB_USERNAME
     objref:
       name: superset-config
       kind: ConfigMap
       apiVersion: v1
     fieldref:
-      fieldpath: data.superset_db_memory_limits
-  - name: superset_db_cpu_requests
+      fieldpath: data.SUPERSET_DB_USERNAME
+  - name: SUPERSET_DB_PASSWORD
     objref:
       name: superset-config
       kind: ConfigMap
       apiVersion: v1
     fieldref:
-      fieldpath: data.superset_db_cpu_requests
-  - name: superset_db_cpu_limits
+      fieldpath: data.SUPERSET_DB_PASSWORD
+  - name: LOG_LEVEL
     objref:
       name: superset-config
       kind: ConfigMap
       apiVersion: v1
     fieldref:
-      fieldpath: data.superset_db_cpu_limits
-  - name: storage_class
+      fieldpath: data.LOG_LEVEL
+  - name: SUPERSET_MEMORY_REQUESTS
     objref:
       name: superset-config
       kind: ConfigMap
       apiVersion: v1
     fieldref:
-      fieldpath: data.storage_class
+      fieldpath: data.SUPERSET_MEMORY_REQUESTS
+  - name: SUPERSET_MEMORY_LIMITS
+    objref:
+      name: superset-config
+      kind: ConfigMap
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.SUPERSET_MEMORY_LIMITS
+  - name: SUPERSET_CPU_REQUESTS
+    objref:
+      name: superset-config
+      kind: ConfigMap
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.SUPERSET_CPU_REQUESTS
+  - name: SUPERSET_CPU_LIMITS
+    objref:
+      name: superset-config
+      kind: ConfigMap
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.SUPERSET_CPU_LIMITS
+  - name: SUPERSET_DB_MEMORY_REQUESTS
+    objref:
+      name: superset-config
+      kind: ConfigMap
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.SUPERSET_DB_MEMORY_REQUESTS
+  - name: SUPERSET_DB_MEMORY_LIMITS
+    objref:
+      name: superset-config
+      kind: ConfigMap
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.SUPERSET_DB_MEMORY_LIMITS
+  - name: SUPERSET_DB_CPU_REQUESTS
+    objref:
+      name: superset-config
+      kind: ConfigMap
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.SUPERSET_DB_CPU_REQUESTS
+  - name: SUPERSET_DB_CPU_LIMITS
+    objref:
+      name: superset-config
+      kind: ConfigMap
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.SUPERSET_DB_CPU_LIMITS
+  - name: SUPERSET_IMAGE
+    objref:
+      name: superset-config
+      kind: ConfigMap
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.SUPERSET_IMAGE
+
 
 configurations:
   - params.yaml
 
 generatorOptions:
   disableNameSuffixHash: true
-
-images:
-  - name: superset
-    newName: quay.io/opendatahub/superset
-    newTag: "1.3.2"
-  - name: supersetdb
-    newName: quay.io/internaldatahub/postgresql-96-centos7
-    newTag: "9.6"


### PR DESCRIPTION
Accidentally added the ODH 1.1.1 version, but osc is still on 1.1.0. 