### PR TITLE
Add two OBCs for Observatorium storage move to ceph

### DIFF
--- a/observatorium/overlays/moc/smaug/loki/kustomization.yaml
+++ b/observatorium/overlays/moc/smaug/loki/kustomization.yaml
@@ -8,6 +8,7 @@ commonLabels:
 resources:
   - ../../../../base/instance/loki
   - servicemonitors
+  - obcs
 
 patchesStrategicMerge:
   - configmaps/observatorium-loki-configmap_patch.yaml

--- a/observatorium/overlays/moc/smaug/loki/obcs/kustomization.yaml
+++ b/observatorium/overlays/moc/smaug/loki/obcs/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- opf-observatorium-logs.yaml

--- a/observatorium/overlays/moc/smaug/loki/obcs/opf-observatorium-logs.yaml
+++ b/observatorium/overlays/moc/smaug/loki/obcs/opf-observatorium-logs.yaml
@@ -1,0 +1,7 @@
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: opf-observatorium-logs
+spec:
+  bucketName: opf-observatorium-logs
+  storageClassName: openshift-storage.noobaa.io

--- a/observatorium/overlays/moc/smaug/thanos/kustomization.yaml
+++ b/observatorium/overlays/moc/smaug/thanos/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - serviceaccounts
   - servicemonitors
   - services
+  - obcs
 
 generators:
   - secrets/secrets-generator.yaml

--- a/observatorium/overlays/moc/smaug/thanos/obcs/kustomization.yaml
+++ b/observatorium/overlays/moc/smaug/thanos/obcs/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- opf-observatorium-metrics.yaml

--- a/observatorium/overlays/moc/smaug/thanos/obcs/opf-observatorium-metrics.yaml
+++ b/observatorium/overlays/moc/smaug/thanos/obcs/opf-observatorium-metrics.yaml
@@ -1,0 +1,7 @@
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: opf-observatorium-metrics
+spec:
+  bucketName: opf-observatorium-metrics
+  storageClassName: openshift-storage.noobaa.io


### PR DESCRIPTION
## Description:
Currently our buckets are hosted on the MOC NFS server which is not being maintained anymore.

The goal is to create two Object Bucket Claims in the `opf-observatorium` namespace, and migrate the metrics and logs from our current buckets into the new ones

## Issue:
Related [#1465 ](https://github.com/operate-first/apps/issues/1465)

### Note:
Feel free to request changes!
- Name of manifest filename is subject to change along with bucketName 