### PR TITLE
Giving Grafana Admin permissions to opf-alerting group

### DIFF
--- a/grafana/overlays/moc/smaug/grafana-oauth.yaml
+++ b/grafana/overlays/moc/smaug/grafana-oauth.yaml
@@ -36,5 +36,6 @@ spec:
         contains(groups[*], 'curator')        && 'Editor' ||
         contains(groups[*], 'prometheus-anomaly-detector') && 'Editor' ||
         contains(groups[*], 'thoth')          && 'Editor' ||
+        contains(groups[*], 'opf-alerting')          && 'Admin' ||
         'Deny'
       role_attribute_strict: true


### PR DESCRIPTION
Giving admin permissions so the opf-alerting group can have access to the alerting metrics and the jupyterhub namespace to be able to test the alerts