### PR TITLE
apply v0.2.5 of osc-trino-acl-dsl

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         entry: yamllint --strict -c yamllint-config.yaml
 
   - repo: https://github.com/os-climate/osc-trino-acl-dsl
-    rev: v0.2.3
+    rev: v0.2.5
     hooks:
       # manage rules.json files using a DSL for trino ACL
       # this check enforces that rules.json is consistent with dsl file

--- a/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/rules.json
+++ b/kfdefs/overlays/osc/osc-cl1/trino-dev/configs/rules.json
@@ -5,6 +5,7 @@
             "allow": "all"
         },
         {
+            "catalog": ".*",
             "allow": "read-only"
         }
     ],
@@ -14,6 +15,8 @@
             "owner": true
         },
         {
+            "catalog": ".*",
+            "schema": ".*",
             "owner": false
         }
     ],
@@ -28,6 +31,9 @@
             ]
         },
         {
+            "catalog": ".*",
+            "schema": ".*",
+            "table": ".*",
             "privileges": [
                 "SELECT"
             ]

--- a/kfdefs/overlays/osc/osc-cl1/trino/configs/rules.json
+++ b/kfdefs/overlays/osc/osc-cl1/trino/configs/rules.json
@@ -15,6 +15,7 @@
             "allow": "all"
         },
         {
+            "catalog": ".*",
             "allow": "read-only"
         }
     ],
@@ -72,6 +73,8 @@
             "owner": true
         },
         {
+            "catalog": ".*",
+            "schema": ".*",
             "owner": false
         }
     ],
@@ -205,6 +208,7 @@
             "group": "corporate_data.*",
             "catalog": "osc_datacommons_dev",
             "schema": "corporate_data",
+            "table": ".*",
             "privileges": [
                 "SELECT",
                 "INSERT",
@@ -215,6 +219,7 @@
         {
             "catalog": "osc_datacommons_dev",
             "schema": "corporate_data",
+            "table": ".*",
             "privileges": [
                 "SELECT"
             ]
@@ -223,6 +228,7 @@
             "group": "itr.*",
             "catalog": "osc_datacommons_dev",
             "schema": "itr",
+            "table": ".*",
             "privileges": [
                 "SELECT",
                 "INSERT",
@@ -233,6 +239,7 @@
         {
             "catalog": "osc_datacommons_dev",
             "schema": "itr",
+            "table": ".*",
             "privileges": [
                 "SELECT"
             ]
@@ -241,6 +248,7 @@
             "group": "physical_risk.*",
             "catalog": "osc_datacommons_dev",
             "schema": "physical_risk",
+            "table": ".*",
             "privileges": [
                 "SELECT",
                 "INSERT",
@@ -251,6 +259,7 @@
         {
             "catalog": "osc_datacommons_dev",
             "schema": "physical_risk",
+            "table": ".*",
             "privileges": [
                 "SELECT"
             ]
@@ -259,6 +268,7 @@
             "group": "entity_matching.*",
             "catalog": "osc_datacommons_dev",
             "schema": "gleif",
+            "table": ".*",
             "privileges": [
                 "SELECT",
                 "INSERT",
@@ -269,6 +279,7 @@
         {
             "catalog": "osc_datacommons_dev",
             "schema": "gleif",
+            "table": ".*",
             "privileges": [
                 "SELECT"
             ]
@@ -277,6 +288,7 @@
             "group": "aicoe_osc_demo",
             "catalog": "osc_datacommons_dev",
             "schema": "aicoe_osc_demo",
+            "table": ".*",
             "privileges": [
                 "SELECT",
                 "INSERT",
@@ -287,6 +299,7 @@
         {
             "catalog": "osc_datacommons_dev",
             "schema": "aicoe_osc_demo",
+            "table": ".*",
             "privileges": [
                 "SELECT"
             ]
@@ -295,6 +308,7 @@
             "group": "aicoe_osc_demo",
             "catalog": "osc_datacommons_dev",
             "schema": "urgentem",
+            "table": ".*",
             "privileges": [
                 "SELECT",
                 "INSERT",
@@ -305,6 +319,7 @@
         {
             "catalog": "osc_datacommons_dev",
             "schema": "urgentem",
+            "table": ".*",
             "privileges": [
                 "SELECT"
             ]
@@ -313,6 +328,7 @@
             "group": ".*",
             "catalog": "osc_datacommons_dev",
             "schema": "sandbox",
+            "table": ".*",
             "privileges": [
                 "SELECT",
                 "INSERT",
@@ -323,6 +339,7 @@
         {
             "catalog": "osc_datacommons_dev",
             "schema": "sandbox",
+            "table": ".*",
             "privileges": [
                 "SELECT"
             ]
@@ -331,6 +348,7 @@
             "group": ".*",
             "catalog": "osc_datacommons_dev",
             "schema": "demo",
+            "table": ".*",
             "privileges": [
                 "SELECT",
                 "INSERT",
@@ -341,23 +359,31 @@
         {
             "catalog": "osc_datacommons_dev",
             "schema": "demo",
+            "table": ".*",
             "privileges": [
                 "SELECT"
             ]
         },
         {
             "catalog": "osc_datacommons_dev",
+            "schema": ".*",
+            "table": ".*",
             "privileges": [
                 "SELECT"
             ]
         },
         {
             "catalog": "osc_datacommons_iceberg_dev",
+            "schema": ".*",
+            "table": ".*",
             "privileges": [
                 "SELECT"
             ]
         },
         {
+            "catalog": ".*",
+            "schema": ".*",
+            "table": ".*",
             "privileges": []
         }
     ]

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/rules.json
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/rules.json
@@ -5,6 +5,7 @@
             "allow": "all"
         },
         {
+            "catalog": ".*",
             "allow": "read-only"
         }
     ],
@@ -14,6 +15,8 @@
             "owner": true
         },
         {
+            "catalog": ".*",
+            "schema": ".*",
             "owner": false
         }
     ],
@@ -28,6 +31,9 @@
             ]
         },
         {
+            "catalog": ".*",
+            "schema": ".*",
+            "table": ".*",
             "privileges": []
         }
     ]


### PR DESCRIPTION
Updating the output of the Trino ACL DSL to test some theories about why file-based-acl is not behaving as expected
cc @caldeirav @rimolive @HumairAK 