### PR TITLE
Allow smaug to install operatorhub.io operators

### DIFF
--- a/cluster-scope/base/operators.coreos.com/catalogsources/operatorhubio-catalog/catalogsource.yaml
+++ b/cluster-scope/base/operators.coreos.com/catalogsources/operatorhubio-catalog/catalogsource.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: operatorhubio-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: OperatorHub.io
+  image: quay.io/operator-framework/upstream-community-operators:latest
+  publisher: OperatorHub.io
+  sourceType: grpc

--- a/cluster-scope/base/operators.coreos.com/catalogsources/operatorhubio-catalog/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/catalogsources/operatorhubio-catalog/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - catalogsource.yaml

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -78,6 +78,7 @@ resources:
 - ../../../../base/core/persistentvolumeclaims/image-registry-storage
 - ../../../../base/imageregistry.operator.openshift.io/configs/cluster
 - ../../../../base/noobaa.io/backingstores
+- ../../../../base/operators.coreos.com/catalogsources/operatorhubio-catalog/
 - ../../../../base/operators.coreos.com/operatorgroups/cluster-logging
 - ../../../../base/operators.coreos.com/operatorgroups/koku-metrics-operator
 - ../../../../base/operators.coreos.com/operatorgroups/openshift-cnv-rn5jf


### PR DESCRIPTION
This PR adds a catalogsource for https://operatorhub.io/ and enables it on the smaug cluster.