### PR TITLE
Add subscription to snapscheduler operator

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/snapscheduler/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/snapscheduler/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: snapscheduler-system
+resources:
+- subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/snapscheduler/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/snapscheduler/subscription.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: snapscheduler
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: snapscheduler
+  source: community-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -96,6 +96,7 @@ resources:
 - ../../../../base/operators.coreos.com/subscriptions/pulp-operator
 - ../../../../base/operators.coreos.com/subscriptions/strimzi
 - ../../../../base/operators.coreos.com/subscriptions/vertical-pod-autoscaler
+- ../../../../base/operators.coreos.com/subscriptions/snapscheduler
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-interceptor-opf-ci-pipelines
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-monitoring-view
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/jupyterhub-cluster


### PR DESCRIPTION
Related to https://github.com/operate-first/operations/issues/431

In order to use snapscheduler to take snapshots of the Nooba db, we first need to install snapscheduler. This pr subscribes to the snapscheduler operator and pulls that resource into the smaug cluster.

cc: @larsks 