### PR TITLE
Giving Admin Privileges to the opf-alerting group

### DIFF
--- a/cluster-scope/base/core/namespaces/opf-jupyterhub-stage/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/opf-jupyterhub-stage/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 components:
 - ../../../../components/project-admin-rolebindings/operate-first
+- ../../../../components/project-admin-rolebindings/opf-alerting
 - ../../../../components/project-admin-rolebindings/odh-admin
 - ../../../../components/monitoring-rbac
 - ../../../../components/limitranges/default

--- a/cluster-scope/components/project-admin-rolebindings/opf-alerting/kustomization.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/opf-alerting/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ./rbac.yaml

--- a/cluster-scope/components/project-admin-rolebindings/opf-alerting/rbac.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/opf-alerting/rbac.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-admin-opf-alerting
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: opf-alerting


### PR DESCRIPTION
This will give Admin Privileges to the opf-alerting group in which the alerts will be tested. cc @4n4nd 