### PR TITLE
Updating Smaug clusterversion.yaml to upgrade to OCP 4.9

### DIFF
--- a/cluster-scope/overlays/prod/moc/smaug/clusterversion.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/clusterversion.yaml
@@ -3,9 +3,9 @@ kind: ClusterVersion
 metadata:
   name: version
 spec:
-  channel: stable-4.8
+  channel: stable-4.9
   clusterID: 5d448ae7-05f1-42cc-aacc-3122a8ad0184
   desiredUpdate:
     image: >-
-      quay.io/openshift-release-dev/ocp-release@sha256:3fab205d36c66825423274eac90f4c142a18cdf358b4a666a1783d325afba860
-    version: 4.8.23
+      quay.io/openshift-release-dev/ocp-release@sha256:fd96300600f9
+    version: 4.9.21

--- a/cluster-scope/overlays/prod/moc/smaug/clusterversion.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/clusterversion.yaml
@@ -7,5 +7,5 @@ spec:
   clusterID: 5d448ae7-05f1-42cc-aacc-3122a8ad0184
   desiredUpdate:
     image: >-
-      quay.io/openshift-release-dev/ocp-release@sha256:fd96300600f9
+      quay.io/openshift-release-dev/ocp-release@sha256:fd96300600f9585e5847f5855ca14e2b3cafbce12aefe3b3f52c5da10c4476eb
     version: 4.9.21


### PR DESCRIPTION
I've changed the stable channel to 4.9 and determined the most recent 4.9 version that we can upgrade to using the tool: [here](https://access.redhat.com/labs/ocpupgradegraph/update_path?channel=stable-4.8&arch=x86_64&is_show_hot_fix=false&current_ocp_version=4.8.23&target_ocp_version=4.9.21)

I am unsure about where the rest of the hash value comes from so for now I've only added the the obvious hash using the current clusterversion.yaml as a guide. 