### PR TITLE
Corrected namespace for snapscheduler

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/snapscheduler/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/snapscheduler/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: snapscheduler-system
+namespace: openshift-operators
 resources:
 - subscription.yaml


### PR DESCRIPTION
The previous PR https://github.com/operate-first/apps/pull/1644 had the namespace set as snapscheduler-system, which doesn't exist. This PR corrects the namespace to openshift-operators in accordance with other operators installed in the cluster.

cc: @larsks 