### PR TITLE
Add snapshotschedule to take daily snapshots of noobaa db

### DIFF
--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -132,3 +132,4 @@ resources:
 - ingresscontrollers/default.yaml
 - nodenetworkconfigurationpolicies/vlan-210-nfs.yaml
 - nodenetworkconfigurationpolicies/vlan-211-nese.yaml
+- snapshotschedules/schedule.yaml

--- a/cluster-scope/overlays/prod/moc/smaug/snapshotschedules/schedule.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/snapshotschedules/schedule.yaml
@@ -1,0 +1,13 @@
+apiVersion: snapscheduler.backube/v1
+kind: SnapshotSchedule
+metadata:
+    name: daily
+    namespace: openshift-storage
+spec:
+    claimSelector:
+        matchLabels:
+            noobaa-db: postgres
+    retention:
+        maxCount: 7
+    # Note that schedules are in the UTC timezone
+    schedule: “0 0 * * *”


### PR DESCRIPTION
This PR creates a snapshotschedule in smaug that will take daily snapshots of the noobaa database PVC within a 1-week retention time. 

Resolves https://github.com/operate-first/operations/issues/431