### PR TITLE
Add identity mgmt operator to infra cluster.

### DIFF
--- a/acm/overlays/moc/infra/identitatem/authrealms/kustomization.yaml
+++ b/acm/overlays/moc/infra/identitatem/authrealms/kustomization.yaml
@@ -1,7 +1,5 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
-  - argocd-managed-clusters.yaml
-  - primary-auth.yaml
+  - primary.yaml

--- a/acm/overlays/moc/infra/identitatem/authrealms/primary.yaml
+++ b/acm/overlays/moc/infra/identitatem/authrealms/primary.yaml
@@ -1,0 +1,20 @@
+apiVersion: identityconfig.identitatem.io/v1alpha1
+kind: AuthRealm
+metadata:
+  name: primary
+  namespace: idp-mgmt-config
+spec:
+  identityProviders:
+    - github:
+        clientID: b222cb4ccc33667e28bd
+        clientSecret:
+          name: identitatem-github-client-secret
+        organizations:
+          - operate-first
+      mappingMethod: claim
+      name: identitatem-github
+      type: GitHub
+  placementRef:
+    name: primary-auth
+  routeSubDomain: primary
+  type: dex

--- a/acm/overlays/moc/infra/identitatem/clients/github.enc.yaml
+++ b/acm/overlays/moc/infra/identitatem/clients/github.enc.yaml
@@ -1,0 +1,38 @@
+kind: Secret
+apiVersion: v1
+metadata:
+    name: identitatem-github-client-secret
+stringData:
+    clientSecret: ENC[AES256_GCM,data:DXCCLVMHEGoi5id6WYoC5hxQHshtuxnCajxmD8HKwS03HlKOaOKQYQ==,iv:FoBmavOALF80N2z4fkmp9wCtg7Zq7AeFBXq5GaYh8NA=,tag:ATerpMlnqn0pglejYLZdjQ==,type:str]
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2022-02-23T17:47:43Z'
+    mac: ENC[AES256_GCM,data:RXGJzWUiDguQXlKdyUSRWaCi5Fowy2kz1/da2AD8zQv/emaDJ0EYfggs+SLyDAffSStGbm6yQE5ZxB1oN/uq/6ng2PCUjbp1fJKZV1TUm1tKoyTW2NLxmseGTA/2HQup7vqvOI539KCuWnQB1+HQW7z8XzZuD0F/ZYhaMJQxU38=,iv:eu4wir1sg8jkSXgWzuf80Y5G8aDsAnxOtqcrBdNyLCA=,tag:/3le6/5pkVoD8xXV3uGMTA==,type:str]
+    pgp:
+    -   created_at: '2022-02-23T17:47:43Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA9aKBcudqifiARAAwlSBUlv4Lg9ib8kWZjhTyiGVi/OLXskXo1Nk/1S8100q
+            HZ9m2a59+nd5QHmWBCHUtmLHBM77uUiImDE7E/LrhCEFrT+7ja3N1LmayOQ498j5
+            qmX40eP4xW7ext0Nq4qwHW4mq3zCehC324V711tUVflUTbiyB4JzgcWySrSWF0QB
+            wZjCHz7W2IaCEpG/phLeEdZV1uXc6tUFLo0H2Bhp9w+oLSxJiFewALEEcqRnb5SC
+            D9/ARSoBLb/yHC6z8HwF83YoGiPLOM6b2q1v4Bc6I2kBZDVG8abCXaOmGCbDPCvs
+            12TQ/ePRiqEbMh8aclEWQhkXMlfv4CgVlXlBrMBKriRavqc6VOPa1bpe/N0KKOVf
+            bPXqt6S2gHtQGZefnip2zZbr+StLL44WGsnxdeS0dm75+QasVrA2peuq3bGOYGxj
+            A2JS+1EdctObAYERrzRswJas/cSKEWjh1LPDJ24x6a64yzb3HTNpM8UTxdKqmFCT
+            1A+lPoJSvDl7789leWbRrTf5mvzDVt0BB9ygmjb88CuylBqjNCF/AzHYekf6Rx6K
+            jrb3aLfOobtz1IJDRJKDF6vpFzmA4GtWzz3oZ5ZOvNssvP2FTw3Nn5QQOfaVcuJx
+            SZ3YYZEIf9yOhG2BMVshBe3wz7zLojz6lSsWHCZ9jJQDYLw8ZC0drS3jjPkvTfHS
+            4AHk+Ey+f4TSfT6xB/wB/w2hNuFRF+A84MThQs7gsOKAIbeu4LjlxCKmguFkGFvd
+            +U7YRy6LapVQTIKxQspZbHE07Jit9mLgneQDlBIKWBQ0vEyoX2jqh9kj4ozQVETh
+            3aMA
+            =SehH
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^(users|data|stringData)$
+    version: 3.6.1

--- a/acm/overlays/moc/infra/identitatem/clients/kustomization.yaml
+++ b/acm/overlays/moc/infra/identitatem/clients/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - secret-generator.yaml

--- a/acm/overlays/moc/infra/identitatem/clients/secret-generator.yaml
+++ b/acm/overlays/moc/infra/identitatem/clients/secret-generator.yaml
@@ -1,0 +1,6 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: secret-generator
+files:
+  - github.enc.yaml

--- a/acm/overlays/moc/infra/identitatem/kustomization.yaml
+++ b/acm/overlays/moc/infra/identitatem/kustomization.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
+namespace: idp-mgmt-config
 resources:
-  - argocd-managed-clusters.yaml
-  - primary-auth.yaml
+  - authrealms
+  - clients

--- a/acm/overlays/moc/infra/placements/primary-auth.yaml
+++ b/acm/overlays/moc/infra/placements/primary-auth.yaml
@@ -1,0 +1,11 @@
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+kind: Placement
+metadata:
+  name: primary-auth
+  namespace: idp-mgmt-config
+spec:
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            authdeployment: primary

--- a/cluster-scope/base/core/namespaces/idp-mgmt-config/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/idp-mgmt-config/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - namespace.yaml
+components:
+    - ../../../../components/project-admin-rolebindings/operate-first
+    - ../../../../components/limitranges/default
+namespace: idp-mgmt-config

--- a/cluster-scope/base/core/namespaces/idp-mgmt-config/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/idp-mgmt-config/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: idp-mgmt-config
+    annotations:
+        openshift.io/requester: operate-first

--- a/cluster-scope/base/identityconfig.identitatem.io/idpconfigs/idpconfig/idpconfig.yaml
+++ b/cluster-scope/base/identityconfig.identitatem.io/idpconfigs/idpconfig/idpconfig.yaml
@@ -1,0 +1,8 @@
+apiVersion: identityconfig.identitatem.io/v1alpha1
+kind: IDPConfig
+metadata:
+  name: idp-config
+  namespace: idp-mgmt-config
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec: {}

--- a/cluster-scope/base/identityconfig.identitatem.io/idpconfigs/idpconfig/kustomization.yaml
+++ b/cluster-scope/base/identityconfig.identitatem.io/idpconfigs/idpconfig/kustomization.yaml
@@ -1,7 +1,4 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
-  - argocd-managed-clusters.yaml
-  - primary-auth.yaml
+  - idpconfig.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/idp-mgmt-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/idp-mgmt-operator/kustomization.yaml
@@ -1,7 +1,5 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
+namespace: idp-mgmt-config
 resources:
-  - argocd-managed-clusters.yaml
-  - primary-auth.yaml
+  - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/idp-mgmt-operator/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/idp-mgmt-operator/operatorgroup.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: idp-mgmt-operator
+spec:
+  targetNamespaces:
+    - idp-mgmt-config

--- a/cluster-scope/base/operators.coreos.com/subscriptions/idp-mgmt-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/idp-mgmt-operator/kustomization.yaml
@@ -1,7 +1,5 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
-  - argocd-managed-clusters.yaml
-  - primary-auth.yaml
+    - subscription.yaml
+namespace: idp-mgmt-config

--- a/cluster-scope/base/operators.coreos.com/subscriptions/idp-mgmt-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/idp-mgmt-operator/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: idp-mgmt-operator-product
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: idp-mgmt-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/idp-mgmt-operator/kustomization.yaml
+++ b/cluster-scope/bundles/idp-mgmt-operator/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base/core/namespaces/idp-mgmt-config/
+  - ../../base/operators.coreos.com/subscriptions/idp-mgmt-operator/
+  - ../../base/operators.coreos.com/operatorgroups/idp-mgmt-operator/
+  - ../../base/identityconfig.identitatem.io/idpconfigs/idpconfig

--- a/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
@@ -36,6 +36,7 @@ resources:
   - ../../../../base/storage.k8s.io/storageclasses/moc-nfs-csi
   - ../../../../base/user.openshift.io/groups/cluster-admins
   - ../../../../bundles/acme-operator
+  - ../../../../bundles/idp-mgmt-operator
   - apiserver/api_server_cert.yaml
   - clusterversion.yaml
   - nodenetworkconfigurationpolicies/crc-provisioning-vlan.yaml


### PR DESCRIPTION
Related: https://github.com/operate-first/operations/issues/432

This change will deploy the identity mgmt operator (identitatem) to the
Infra cluster. Identitatem allows us to manage authentication via ACM.
This is in contrast to our current implementation of using Keycloak.
This commit does not affect existing OAUTHs for any clusters yet, but
lays the groundwork so that enabling Identitatem to manage any clusters
managed by ACM is as simple as adding required label to a ManagedCluster.

With this commit you will find an Authrealm that is configured to
authenticate any enrolled manageclusters via the Operate First github
org.


For reference docs: 
- https://identitatem.github.io/idp-mgmt-docs-upstream/install_connected.html#installing-while-connected-online
- https://identitatem.github.io/idp-mgmt-docs-upstream/quick_start.html#getting-started