### PR TITLE
:fire: Update num of volume in pvPool for noobaa storage

### DIFF
--- a/cluster-scope/overlays/prod/moc/smaug/backingstores/noobaa-default-backing-store_patch.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/backingstores/noobaa-default-backing-store_patch.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: openshift-storage
 spec:
   pvPool:
-    numVolumes: 19
+    numVolumes: 20


### PR DESCRIPTION
Update num of volume in pvPool for noobaa storage
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


Related-to: https://github.com/operate-first/operations/issues/454


All the PVC in storage have reached its limits
https://console-openshift-console.apps.smaug.na.operate-first.cloud/k8s/ns/openshift-storage/persistentvolumeclaims
This is failing all the object bucket using noobaa
https://console-openshift-console.apps.smaug.na.operate-first.cloud/monitoring/alerts/672853483?alertname=NooBaaSystemCapacityWarning85&container=core&endpoint=mgmt&instance=10.129.1.236%3A8080&job=noobaa-mgmt&namespace=openshift-storage&pod=noobaa-core-0&service=noobaa-mgmt&severity=warning
https://console-openshift-console.apps.smaug.na.operate-first.cloud/monitoring/alerts/3605660105?alertname=KubePersistentVolumeFillingUp&endpoint=https-metrics&instance=128.52.62.241%3A10250&job=kubelet&metrics_path=%2Fmetrics&namespace=openshift-storage&node=oct-03-10-compute&persistentvolumeclaim=noobaa-default-backing-store-noobaa-pvc-1bacff63&service=kubelet&severity=warning
For this update to get in we require at least 190Gb mem, as there are 19 PVC's which would get upgrade with 10Gb each.
