### PR TITLE
Set up summit cluster to be handled with opf argocd

### DIFF
--- a/argocd/overlays/moc-infra/secrets/clusters/octo-gohan.enc.yaml
+++ b/argocd/overlays/moc-infra/secrets/clusters/octo-gohan.enc.yaml
@@ -1,0 +1,43 @@
+kind: Secret
+apiVersion: v1
+metadata:
+    name: gohan-cluster-secret
+    labels:
+        apps.open-cluster-management.io/acm-cluster: "true"
+        apps.open-cluster-management.io/cluster-name: ""
+        apps.open-cluster-management.io/cluster-server: ""
+        argocd.argoproj.io/secret-type: cluster
+data:
+    config: ENC[AES256_GCM,data:OxD1SqasoAdSU1tCqPYDi+uGs/z58DbGAQkic1Ib0orbrkUhzvD5kqKKQMTGR0otna09uTprci1O+CU1u+uPL+XVY7WoFtNNJ7Y+Hmf8Xl+wcxejMxyJfQL99C+Jnm0IPYmqbAI3amlXn8R355qgoqe8cPvvyHOCC0+WUN1IDDAPEe8S6dYJwH8pgKmMn1TZMKMw0zOi2LF5ra8IqVXWs3cMJ9nr1BrQltfJYqCltWUYTJx0jwffpuTBN0+VJQLSjjICvZgXnAIc3kPlXswgOw3P+S0zq7t1yecXT5g7oBRANDgJB3HVADDmpl7PeDTW/iMJf+YcbZsLfFU6YqfwOcQeimLttJGIkBRsgnA/P1e1jLgXGiwzUongAENFywTHnG4kk41VkAosbSNzuoMdl+WQfLkRwdV7Vj9lSx5ARbbuAH8FjIefnzmAP7kxPtHbHa/ivXNXIi8q+zggL9ERtfcEJnK/FwPM73nf5T92i1R/oLVbatkSw44E4IUbxxEHfmVPwjgwMZgHLG5kQjjTrSaKA7IML5UMBzRfTKIVDQJcMVbjsIUGAjfPA6F0JogaagZ9UwsnQErTGV4vezJ0//QRyx4pWoSFUb23GOMvI7jiMVwKj/dHXUMRklAzDsVKu/z5W8i9eoeO3mw29uZuUHRkrpZWCxfeY3iHDPowRY5Qis6EYpqTjBFf0Q51czco6cbSmdPAwtrMXWnWsFV1YJCtghhMn8kZ8XmzEccs6SKCFIEpzzQNCJItYdCHcGkMebo8RQG1M4ui5OdXVkOJCmW40XtYi+LO//OfDThvZiYA+EzcUuimHa2/dzauPrL3Y5O+x2cxL+5rJxuk/I+93JgMIw/+TyvGnsgcxNO2m2+vw2Jpyhl7eT2zumo+L2KsjV5xF1ThRvCr3fe+kn4f5NJFCUAQs4TgXX1kFFMyMD9RF8PWTCq+Ke54QVX73Qg7ZRn3R1YB3jDMCen6RVNiseildTbspiYeW1R26cUdK5kQZ/yc8w6X7EByS+PI3aZ+oTSLm/eGz7bMcIfqjUQcq3ueu98cdGcXXxXVsnGhgG195tWaRFQCnLkKPbWm69FOhI3zvaeb2Tnwdj4Nd7vXv37JuDpP81/7vBbLmD6m4GbR/etANUU2zpBDAXe+Es6mx/KEhk4xVhDCrv7A469I3MfcSok2VAObWrtABKsdo4M1CWDbENa4b9hHoqhH4tGXjQ6XVDjA/hNA+8oxpxHAX1xvZ18I9fPl/6G8H83obsT/t5650Mn2GP0kt2yGujXgVafaD1JaNdQYjfq2Xk+8t7GMrz3sNyYkBSeEI4MGwdgugfhGlF2uhUZrAaros5m29uIwXhMo4C7WCKoWFnYk8/LPZ3//wmv9uk5DbpvHOX2satEor/EwGZIndYCVNlf+7+c/16EXK2Hd0sS6AXMLP9f3LFwQoOfxQVCeuj4/P7io61qCUy1oru0NMLkKT5ftNgN6PUrJ4UUKJ+69y+eyotMMxDdVWvJZaHnYdCnrSthULF+E+pxcHRaqoFbVEobFwAIM7kAVuz3YupHPvK7DKRZEAXjt7eDyS2j/W25l8qksSrViNr4omWuj5ZHwHLyv3/ryfSod3muuKUC/UJBaV3MCdZmf0sgZjfi7VkbscuNb4uapJ1K1D4yOK1zf7+Fm79cuHq159YnxbB0YnXmrAL5YCCaH/LzQ/n3Xv8C4yWiUdTVXObRtT7zbGhDFEQGac7b6VyquBzSooXZIPdrmHsbXEq247S8qv+bdYOHUZaMQz4nT4wdJXMEh+BMcL+EZI3DpDS9dfFoIra63,iv:NTMut1LjVNA+DMhTqo3HdOJuO4YCniQO8KnEAxxn+xA=,tag:dQ5WbKgh+qHRN+i8MEmoJg==,type:str]
+    name: Z29oYW4=
+    server: aHR0cHM6Ly9nb2hhbi5vY3RvLWVtZXJnaW5nLnJlZGhhdGFpY29lLmNvbTo2NDQz
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    lastmodified: '2022-03-02T17:11:22Z'
+    mac: ENC[AES256_GCM,data:aBgaNANlT94tSjAPstVI7NsqYdDmfKQKa4BaDa4cgloEatG+m+lspUcTTKgJ0Djyk+SY1lIyCEIDwFYpjDUs/WYxRhQeNm5ZNh0miE3sYQrbRYxVyx6OCfwjmdn+UAGjBOvjFdPdDbvYrtZBe76CepmtlZdL+DZFAI2HRBuNU00=,iv:6NuDVpX1KW2hTZEc7lpmbziFPNak8QO/7+AH9Gd/E8Y=,tag:j0vJBSPKfrT2LrNRz/7RHQ==,type:str]
+    pgp:
+    -   created_at: '2022-03-02T17:11:21Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA9aKBcudqifiAQ//XP5JxtHmNnFlJ8pAc9e31bkK/MrENgmxai4OnG8K+kTY
+            YPGqnKw6xUV06A6xmTW7bB0u81Cs/rEDV8KhrDCtux0jGjEQgvmjGbNB3ye6WRjF
+            r3ok8J0BEKlXsTDqZRXpll9/9dAvTDUoQhtSEyvtUzPtNuRp6S8cQplh6CSzTP0A
+            QveETWx9fDfzLNrgBZPMj5PLe2fcy2eNdBF89k5Q5Yaw7TXClwi6W2MoWT01fKB9
+            exEscIGOQjNYZz9Gy50hCNK2PGcMBKpPJWDgHY2uMrX3TmFqQWi5twul0tCBPDeH
+            L6hlnoMGNmitdCck9o0GgQy8BC7P0RWR874tpG2mdI3L/Ju9KJQ4ZvrS09RrUMe+
+            4VJgZtOf7gi7LEi9vF8p60waElNmqpFM+o+uUnFJLszkB/NBUjEb3UJcmW2VHA/n
+            VA5kroVeDTGyxWGp3b08Z2Fkl/qELYvDeMfm7S9CLRoZEL+2iTs8VWNQtiSfpEOu
+            QpXAVesEhl80plLu5QE8Bahvu4nnBDEDsrbEBV2QaUxSHCLXlYdvJczT3a+XWnaf
+            LGiT+BtpEIpDM5d7EyGJXlxf1ds/9jC3DmrHqF0x67KIedJEdakHGvJGaZ/kSELV
+            epcjUp9NQx7VXsFtMmghbOereK1pbkdotNEg5nu6o1KKv2Jqt8DIh771ZPTG71HS
+            XAFGUOlibNeaT1Sbzi2IHsrBdFFEsR2g9qA+GbjtvP5Uqsqv6nWTOyzOK3JI1xrj
+            xJeilRAgzFZDy/PjV89EpbUNZD01gjPyOm443FaIzFDfqKty9/yfJoKJWrTr
+            =jq6/
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^(config)$
+    version: 3.5.0

--- a/argocd/overlays/moc-infra/secrets/clusters/secret-generator.yaml
+++ b/argocd/overlays/moc-infra/secrets/clusters/secret-generator.yaml
@@ -4,3 +4,4 @@ metadata:
   name: cluster-generator
 files:
 - secrets/clusters/moc-infra.enc.yaml
+- secrets/clusters/octo-gohan.enc.yaml


### PR DESCRIPTION
Set up summit cluster to be handled with opf argocd
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Related-to: https://github.com/AICoE/summit-2021-octo-keynote/issues/69


we would like to set up a summit cluster to be managed via argocd for easy deployment of the application.
AS opf argocd take the account of the cluster from the opf ACM, this pr is adding the cluster to be managed via opf ACM.
this pr was generated following these docs: https://www.operate-first.cloud/apps/content/acm/adding_users_to_acm.html
