### PR TITLE
Remove manual kfdef resource mgmt from odh-cl2.

### DIFF
--- a/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/kfdefs.kfdef.apps.kubeflow.org
   - ../../../../base/core/configmaps/cluster-monitoring-config
   - ../../../../base/core/configmaps/user-workload-monitoring-config
   - ../../../../base/core/namespaces/acme-operator


### PR DESCRIPTION
Part of: https://github.com/operate-first/apps/pull/1658