### PR TITLE
setup a thoth namespace in morty cluster

### DIFF
--- a/cluster-scope/overlays/prod/emea/morty/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/morty/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 - ../../../../base/core/namespaces/openshift-storage
 - ../../../../base/core/namespaces/opf-alertreceiver
 - ../../../../base/core/namespaces/pixel-secrets
+- ../../../../base/core/namespaces/thoth-test-core
 - ../../../../base/operators.coreos.com/operatorgroups/openshift-local-storage
 - ../../../../base/operators.coreos.com/operatorgroups/openshift-storage
 - ../../../../base/operators.coreos.com/subscriptions/odf-operator


### PR DESCRIPTION
setup a thoth namespace in morty cluster
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


Related-to: https://github.com/operate-first/operations/issues/454


The objective here is to have the thoth namespace setup in Morty, so we can create a OBC in there, for use of the ci-prow bucket.
in this way, we can fix the current issue with prow ci for time being.