### PR TITLE
Adding Service Monitor for BlackBox Exporter

### DIFF
--- a/kfdefs/base/monitoring/blackbox-exporter/superset-blackbox-service-monitor.yaml
+++ b/kfdefs/base/monitoring/blackbox-exporter/superset-blackbox-service-monitor.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: blackbox-service-monitor
+spec:
+  endpoints:
+    - interval: 30s
+      metricRelabelings:
+        - sourceLabels:
+            - __address__
+          targetLabel: __param_target
+        - sourceLabels:
+            - __param_target
+          targetLabel: instance
+        - replacement: 'https://help.datahub.redhat.com/'
+          targetLabel: target
+      params:
+        module:
+          - http_2xx
+        target:
+          - 'https://help.datahub.redhat.com/'
+      path: /probe
+      targetPort: 9115
+  jobLabel: prometheus.io/joblabel
+  namespaceSelector:
+    matchNames:
+      - opf-jupyterhub

--- a/kfdefs/base/monitoring/kustomization.yaml
+++ b/kfdefs/base/monitoring/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - alertmanager-config.yaml
   - ./blackbox-exporter
   - ./thanos-query
+  - superset-blackbox-service-monitor.yaml


### PR DESCRIPTION
The service monitor will scrape the metrics from the blackbox exporter. It is related to this issue: https://github.com/operate-first/operations/issues/444