### PR TITLE
Adding Blackbox deployment

### DIFF
--- a/kfdefs/overlays/moc/smaug/opf-jupyterhub/blackbox-exporter/config-map.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-jupyterhub/blackbox-exporter/config-map.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blackbox-exporter-config
+data:
+  blackbox.yml: |
+    modules:
+      http_2xx:
+        prober: http
+        timeout: 10s
+        http:
+          valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+          method: GET
+          valid_status_codes: [200, 201, 202, 203, 204, 205, 206, 207, 208, 403]
+          preferred_ip_protocol: "ip4"

--- a/kfdefs/overlays/moc/smaug/opf-jupyterhub/blackbox-exporter/deployment.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-jupyterhub/blackbox-exporter/deployment.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    deployment: blackbox-exporter
+  name: blackbox-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      deployment: blackbox-exporter
+  template:
+    metadata:
+      labels:
+        deployment: blackbox-exporter
+    spec:
+      volumes:
+      - name: config-volume
+        configMap:
+          name: blackbox
+      containers:
+      - image: quay.io/integreatly/prometheus-blackbox-exporter:v0.19.0
+        name: blackbox-exporter
+        args:
+        - --log.level=debug
+        - --config.file=/tmp/blackbox.yml
+        volumeMounts:
+        - name: config-volume
+          mountPath: /tmp
+        ports:
+        - containerPort: 9115
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /-/healthy
+            port: 9115
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /-/healthy
+            port: 9115
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        resources:
+          limits:
+            cpu: 50m
+            memory: 50Mi
+          requests:
+            cpu: 50m
+            memory: 50Mi
+      restartPolicy: Always

--- a/kfdefs/overlays/moc/smaug/opf-jupyterhub/blackbox-exporter/kustomization.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-jupyterhub/blackbox-exporter/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - config-map.yaml
+  - deployment.yaml
+  - route.yaml
+  - service.yaml

--- a/kfdefs/overlays/moc/smaug/opf-jupyterhub/blackbox-exporter/route.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-jupyterhub/blackbox-exporter/route.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: blackbox-exporter
+spec:
+  port:
+    targetPort: 9115-tcp
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: blackbox-exporter

--- a/kfdefs/overlays/moc/smaug/opf-jupyterhub/blackbox-exporter/service.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-jupyterhub/blackbox-exporter/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: blackbox-exporter
+    prometheus.io/scrape: "true"
+    prometheus.io/joblabel: "blackbox-metrics"
+  name: blackbox-exporter
+spec:
+  ports:
+  - name: 9115-tcp
+    port: 9115
+    protocol: TCP
+    targetPort: 9115
+  selector:
+    deployment: blackbox-exporter

--- a/kfdefs/overlays/moc/smaug/opf-jupyterhub/kustomization.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-jupyterhub/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../../../../base/jupyterhub
   - ./pvcs/
   - alerts.yaml
+  - ./blackbox-exporter
 patchesJson6902:
   - patch: |
       - op: add


### PR DESCRIPTION
Blackbox exporter is for gathering metrics which we're not getting from the Prometheus exporter directly. 
The specific metrics details are discussed in this Issue. https://github.com/operate-first/operations/issues/444

This adds a deployment of [Prometheus Blackbox Exporter](https://github.com/prometheus/blackbox_exporter) in the namespace `opf-jupyterhub`
/cc @4n4nd 

