### PR TITLE
Fixing the blackbox exporter Name in JupyterHub

### DIFF
--- a/kfdefs/overlays/moc/smaug/opf-jupyterhub/blackbox-exporter/deployment.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-jupyterhub/blackbox-exporter/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       volumes:
       - name: config-volume
         configMap:
-          name: blackbox
+          name: blackbox-exporter-config
       containers:
       - image: quay.io/integreatly/prometheus-blackbox-exporter:v0.19.0
         name: blackbox-exporter


### PR DESCRIPTION
there was a typo in the blackbox-exporter name which is being corrected in this commit