### PR TITLE
Remove the namespace field

### DIFF
--- a/cosigned/base/kustomization.yaml
+++ b/cosigned/base/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: cosigned
 resources:
 - configmap.yaml
 - deployment.yaml


### PR DESCRIPTION
Remove the namespace field to allow for the user or argocd to define the namespace creation at launch 