### PR TITLE
Meta labels added to the project namespace manifests

### DIFF
--- a/cluster-scope/base/core/namespaces/acm/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/acm/namespace.yaml
@@ -5,5 +5,8 @@ metadata:
   annotations:
     openshift.io/display-name: "Operate First: ACM"
     openshift.io/requester: operate-first
+    op1st/project-owner: operate-first
+    op1st/onboarding-issue: "https://github.com/open-infrastructure-labs/ops-issues/issues/22"
+    op1st/docs: "https://www.operate-first.cloud/apps/content/acm/README.html"
   name: acm
 spec: {}

--- a/cluster-scope/base/core/namespaces/acme-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/acme-operator/namespace.yaml
@@ -5,5 +5,8 @@ metadata:
   annotations:
     openshift.io/display-name: "Openshift-ACME Controller"
     openshift.io/requester: operate-first
+    op1st/project-owner: operate-first
+    op1st/onboarding-issue: "https://github.com/operate-first/support/issues/237"
+    op1st/docs: "https://www.operate-first.cloud/apps/content/acme/README.html?highlight=acme"
   name: acme-operator
 spec: {}

--- a/cluster-scope/base/core/namespaces/opf-jupyterhub/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/opf-jupyterhub/namespace.yaml
@@ -5,5 +5,8 @@ metadata:
   annotations:
     openshift.io/display-name: "Operate First: JupyterHub"
     openshift.io/requester: operate-first
+    op1st/project-owner: operate-first
+    op1st/onboarding-issue: "https://github.com/operate-first/apps/issues/9"
+    op1st/docs: "https://www.operate-first.cloud/apps/content/odh/jupyterhub/README.html"
   name: opf-jupyterhub
 spec: {}

--- a/cluster-scope/base/core/namespaces/opf-kafka/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/opf-kafka/namespace.yaml
@@ -5,5 +5,8 @@ metadata:
   annotations:
     openshift.io/display-name: "Operate First: Kafka"
     openshift.io/requester: operate-first
+    op1st/project-owner: operate-first
+    op1st/onboarding-issue: "https://github.com/operate-first/support/issues/27"
+    op1st/docs: "https://www.operate-first.cloud/apps/content/odh/kafka/README.html"
   name: opf-kafka
 spec: {}

--- a/cluster-scope/base/core/namespaces/opf-observatorium/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/opf-observatorium/namespace.yaml
@@ -4,5 +4,8 @@ metadata:
   annotations:
     openshift.io/display-name: "Operate First: Observatorium"
     openshift.io/requester: operate-first
+    op1st/project-owner: operate-first
+    op1st/onboarding-issue: "https://github.com/operate-first/support/issues/44"
+    op1st/docs: "https://www.operate-first.cloud/apps/content/observatorium/README.html"
   name: opf-observatorium
 spec: {}


### PR DESCRIPTION
### Issue:
Related #1661 
### Description:
These labels will store project information which will be used in the Workload Dashboard.

**Labels:**
- Owner of project (group)
- The issue which the project/workload was onboarded
- A link the projects documentation

### Note: 
- This is a draft PR, we are still figuring the link logistics
- Observatorium onboarding link is most likely not the right one