### PR TITLE
Give admin replicationsource read/write perms.

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/volsync-rs-aggregate-to-admin/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/volsync-rs-aggregate-to-admin/clusterrole.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: volsync-rs-aggregate-to-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups:
+  - volsync.backube
+  resources:
+  - replicationsources
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/volsync-rs-aggregate-to-admin/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/volsync-rs-aggregate-to-admin/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrole.yaml

--- a/cluster-scope/bundles/volsync/kustomization.yaml
+++ b/cluster-scope/bundles/volsync/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - ../../base/rbac.authorization.k8s.io/clusterroles/volsync-manager
   - ../../base/rbac.authorization.k8s.io/clusterroles/volsync-metrics-reader
   - ../../base/rbac.authorization.k8s.io/clusterroles/volsync-proxy
+  - ../../base/rbac.authorization.k8s.io/clusterroles/volsync-rs-aggregate-to-admin
   - ../../base/security.openshift.io/securitycontextconstraints/volsync-mover


### PR DESCRIPTION
Currently project admins cannot deploy replication sources for
volsync. The addition of this clusterrole will aggregate
read/write permissions to the project admin.