### PR TITLE
Add lowercase constraint for Superset users

### DIFF
--- a/cluster-scope/base/user.openshift.io/groups/superset-user/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/superset-user/group.yaml
@@ -11,4 +11,4 @@ users:
   - skanthed
   - antter
   - suppathak
-  - Shreyanand
+  - shreyanand

--- a/docs/content/odh/superset/add_superset_users.md
+++ b/docs/content/odh/superset/add_superset_users.md
@@ -6,7 +6,7 @@ To provision Superset access to an individual user, we have a Superset rolebindi
 Steps:
 1. Fork/Clone https://github.com/operate-first/apps
 2. Navigate to [this location][2].
-3. Add the github users to [this][3] ocp group.
+3. Add the github users to [this][3] ocp group. Make sure that the usernames are lowercase.
 4. Make a PR
 
 If you would like to give another OCP `group` access to Superset follow the instructions [here][4].


### PR DESCRIPTION
Change "Shreyanand" to "shreyanand" and update docs to make sure usernames are always lowercase.
For issue https://github.com/operate-first/support/issues/531