### PR TITLE
Added Namespace Storage Overview dashboard

### DIFF
--- a/grafana/overlays/moc/smaug/dashboards/cluster-management/kustomization.yaml
+++ b/grafana/overlays/moc/smaug/dashboards/cluster-management/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - namespace_cpu_and_memory_overview.yaml
   - node-feature-discovery.yaml
   - vpa-rc-cpu-and-memory-overview.yaml
+  - namespace_storage_overview.yaml

--- a/grafana/overlays/moc/smaug/dashboards/cluster-management/namespace_storage_overview.yaml
+++ b/grafana/overlays/moc/smaug/dashboards/cluster-management/namespace_storage_overview.yaml
@@ -1,0 +1,924 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  labels:
+    app: grafana
+  name: namespace-storage-overview
+spec:
+  customFolderName: Cluster Management
+  plugins:
+    - name: grafana-piechart-panel
+      version: 1.6.2
+  json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": 53,
+      "iteration": 1646404468638,
+      "links": [],
+      "panels": [
+        {
+          "datasource": null,
+          "description": "Shows total free space left in the amespace",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-red",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.25
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.4
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "green",
+                    "value": 0.7
+                  },
+                  {
+                    "color": "dark-green",
+                    "value": 0.85
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 7,
+            "x": 0,
+            "y": 0
+          },
+          "id": 18,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "8.1.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_available_bytes{namespace=\"$namespace\"}) / sum(kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"})",
+              "interval": "",
+              "legendFormat": "{{persistentvolumeclaim}}",
+              "refId": "A"
+            }
+          ],
+          "title": "% of Free Space of Namespace",
+          "type": "stat"
+        },
+        {
+          "datasource": null,
+          "description": "Available space and Total Capacity of cluster",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "blue",
+                "mode": "fixed"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "dark-green",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 10
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 20
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 5,
+            "x": 7,
+            "y": 0
+          },
+          "id": 8,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "8.1.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_available_bytes{cluster=\"$cluster\"})",
+              "interval": "",
+              "legendFormat": "Available Space",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Capacity",
+              "refId": "B"
+            }
+          ],
+          "title": "Total Space on Cluster",
+          "type": "stat"
+        },
+        {
+          "datasource": "moc-smaug",
+          "description": "Used vs Available Space by cluster",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "orange",
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 12,
+            "y": 0
+          },
+          "id": 9,
+          "options": {
+            "displayLabels": [],
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "values": [
+                "value",
+                "percent"
+              ]
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.1.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_used_bytes{cluster=\"$cluster\"})",
+              "interval": "",
+              "legendFormat": "Used {{ namespace }}",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_available_bytes{cluster=\"$cluster\"})",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Available {{ namespace }}",
+              "refId": "B"
+            }
+          ],
+          "title": "Used vs Available Space (Cluster)",
+          "type": "piechart"
+        },
+        {
+          "datasource": null,
+          "description": "Used space by cluster,\nThis is the same as the pie chart except in a different visualization",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "dark-green",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 10
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 20
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 18,
+            "y": 0
+          },
+          "id": 10,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
+          },
+          "pluginVersion": "8.1.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_used_bytes{cluster=\"$cluster\"})",
+              "interval": "",
+              "legendFormat": "Used",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Capacity/Total",
+              "refId": "B"
+            }
+          ],
+          "title": "Used Space by Cluster",
+          "transformations": [
+            {
+              "id": "configFromData",
+              "options": {
+                "configRefId": "B",
+                "mappings": [
+                  {
+                    "fieldName": "Capacity/Total",
+                    "handlerKey": "max"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "bargauge"
+        },
+        {
+          "datasource": null,
+          "description": "A time series-graph which visualizes memory usage throughout time",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 26,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 7,
+            "x": 0,
+            "y": 3
+          },
+          "id": 13,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull"
+              ],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum by(namespace) (container_memory_working_set_bytes{namespace=\"$namespace\",container=\"\",pod!=\"\"})",
+              "interval": "",
+              "legendFormat": "{{namespace}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory Usage by Namespace",
+          "type": "timeseries"
+        },
+        {
+          "datasource": null,
+          "description": "Available and total capacity by selected namespace\nAvailable: How much you space you have to your disposal\nTotal: Total capacity given to your project/namespace",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "blue",
+                "mode": "fixed"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "dark-green",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 10
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 20
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 5,
+            "x": 7,
+            "y": 6
+          },
+          "id": 11,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "8.1.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_available_bytes{namespace=\"$namespace\", cluster=\"$cluster\"})",
+              "interval": "",
+              "legendFormat": "Available Space",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"})",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total Capacity",
+              "refId": "B"
+            }
+          ],
+          "title": "Total Space on Namespace",
+          "type": "stat"
+        },
+        {
+          "datasource": "moc-smaug",
+          "description": "Used Vs Available by the specific namespace\nUsed: How much has been used\nAvailable: How much space you have left (to use)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 12,
+            "y": 6
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "values": [
+                "value",
+                "percent"
+              ]
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.1.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_used_bytes{namespace=\"$namespace\", cluster=\"$cluster\"}) by (namespace)",
+              "interval": "",
+              "legendFormat": "Used ",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_available_bytes{namespace=\"$namespace\"}) by (namespace)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Available",
+              "refId": "B"
+            }
+          ],
+          "title": "Used vs Available Space (Namespace)",
+          "type": "piechart"
+        },
+        {
+          "datasource": null,
+          "description": "Used space by namespace\nThis is the same as the pie chart except in a different visualization",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "dark-green",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 10
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 20
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 18,
+            "y": 6
+          },
+          "id": 4,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
+          },
+          "pluginVersion": "8.1.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_used_bytes{namespace=\"$namespace\"}) by (namespace)",
+              "interval": "",
+              "legendFormat": "Used",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_available_bytes{namespace=\"$namespace\"}) by (namespace)",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "Avail",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"}) by (namespace)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Capacity/Total",
+              "refId": "C"
+            }
+          ],
+          "title": "Used Space by Namespace",
+          "transformations": [
+            {
+              "id": "configFromData",
+              "options": {
+                "configRefId": "C",
+                "mappings": [
+                  {
+                    "fieldName": "Capacity/Total",
+                    "handlerKey": "max"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "bargauge"
+        },
+        {
+          "datasource": null,
+          "description": "Percentage of free space by PVC, note that PVC may show up or be removed. It depends if the PVC is bounded by a pod",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-red",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.25
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.4
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "green",
+                    "value": 0.65
+                  },
+                  {
+                    "color": "dark-green",
+                    "value": 0.85
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
+          "id": 17,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {
+              "titleSize": 13
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "8.1.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "kubelet_volume_stats_available_bytes{namespace=\"$namespace\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"}",
+              "interval": "",
+              "legendFormat": "{{persistentvolumeclaim}}",
+              "refId": "A"
+            }
+          ],
+          "title": "% of Free Space by PVC",
+          "type": "stat"
+        },
+        {
+          "datasource": null,
+          "description": "This panel displays the top 10 pods which the most amount of memory by namespace",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 12,
+            "x": 12,
+            "y": 12
+          },
+          "id": 15,
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "values": [
+                "value",
+                "percent"
+              ]
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sort_desc(topk(10, sum by (pod)(container_memory_working_set_bytes{container=\"\",pod!=\"\",namespace=\"$namespace\"})))",
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory Usage by Pod (Top 10)",
+          "type": "piechart"
+        }
+      ],
+      "schemaVersion": 30,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "thanos-frontend",
+              "value": "thanos-frontend"
+            },
+            "description": null,
+            "error": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "queryValue": "",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          },
+          {
+            "allValue": null,
+            "current": {
+              "selected": false,
+              "text": "moc/smaug",
+              "value": "moc/smaug"
+            },
+            "datasource": "${datasource}",
+            "definition": "label_values(kubelet_node_name, cluster)",
+            "description": null,
+            "error": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "cluster",
+            "options": [],
+            "query": {
+              "query": "label_values(kubelet_node_name, cluster)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          },
+          {
+            "allValue": null,
+            "current": {
+              "selected": false,
+              "text": "opf-jupyterhub",
+              "value": "opf-jupyterhub"
+            },
+            "datasource": "${datasource}",
+            "definition": "label_values(namespace)",
+            "description": null,
+            "error": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": {
+              "query": "label_values(namespace)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Storage Overview by Namespace",
+      "uid": "zkg-tWLnk5",
+      "version": 1
+    }

--- a/grafana/overlays/moc/smaug/dashboards/cluster-management/namespace_storage_overview.yaml
+++ b/grafana/overlays/moc/smaug/dashboards/cluster-management/namespace_storage_overview.yaml
@@ -11,914 +11,987 @@ spec:
       version: 1.6.2
   json: |
     {
-      "annotations": {
-        "list": [
-          {
-            "builtIn": 1,
-            "datasource": "-- Grafana --",
-            "enable": true,
-            "hide": true,
-            "iconColor": "rgba(0, 211, 255, 1)",
-            "name": "Annotations & Alerts",
-            "target": {
-              "limit": 100,
-              "matchAny": false,
-              "tags": [],
-              "type": "dashboard"
-            },
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
             "type": "dashboard"
-          }
-        ]
-      },
-      "editable": true,
-      "gnetId": null,
-      "graphTooltip": 0,
-      "id": 53,
-      "iteration": 1646404468638,
-      "links": [],
-      "panels": [
-        {
-          "datasource": null,
-          "description": "Shows total free space left in the amespace",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "min": 0,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "dark-red",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 0.25
-                  },
-                  {
-                    "color": "orange",
-                    "value": 0.4
-                  },
-                  {
-                    "color": "#EAB839",
-                    "value": 0.5
-                  },
-                  {
-                    "color": "green",
-                    "value": 0.7
-                  },
-                  {
-                    "color": "dark-green",
-                    "value": 0.85
-                  }
-                ]
-              },
-              "unit": "percentunit"
-            },
-            "overrides": []
           },
-          "gridPos": {
-            "h": 3,
-            "w": 7,
-            "x": 0,
-            "y": 0
-          },
-          "id": 18,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "8.1.1",
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "sum(kubelet_volume_stats_available_bytes{namespace=\"$namespace\"}) / sum(kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"})",
-              "interval": "",
-              "legendFormat": "{{persistentvolumeclaim}}",
-              "refId": "A"
-            }
-          ],
-          "title": "% of Free Space of Namespace",
-          "type": "stat"
-        },
-        {
-          "datasource": null,
-          "description": "Available space and Total Capacity of cluster",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "blue",
-                "mode": "fixed"
-              },
-              "mappings": [],
-              "min": 0,
-              "thresholds": {
-                "mode": "percentage",
-                "steps": [
-                  {
-                    "color": "dark-green",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 10
-                  },
-                  {
-                    "color": "#EAB839",
-                    "value": 20
-                  },
-                  {
-                    "color": "red",
-                    "value": 30
-                  }
-                ]
-              },
-              "unit": "decbytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 5,
-            "x": 7,
-            "y": 0
-          },
-          "id": 8,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "8.1.1",
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "sum(kubelet_volume_stats_available_bytes{cluster=\"$cluster\"})",
-              "interval": "",
-              "legendFormat": "Available Space",
-              "refId": "A"
-            },
-            {
-              "exemplar": true,
-              "expr": "sum(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "Capacity",
-              "refId": "B"
-            }
-          ],
-          "title": "Total Space on Cluster",
-          "type": "stat"
-        },
-        {
-          "datasource": "moc-smaug",
-          "description": "Used vs Available Space by cluster",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "orange",
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                }
-              },
-              "mappings": [],
-              "min": 0,
-              "unit": "decbytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 6,
-            "x": 12,
-            "y": 0
-          },
-          "id": 9,
-          "options": {
-            "displayLabels": [],
-            "legend": {
-              "displayMode": "table",
-              "placement": "right",
-              "values": [
-                "value",
-                "percent"
-              ]
-            },
-            "pieType": "pie",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "tooltip": {
-              "mode": "single"
-            }
-          },
-          "pluginVersion": "8.1.1",
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "sum(kubelet_volume_stats_used_bytes{cluster=\"$cluster\"})",
-              "interval": "",
-              "legendFormat": "Used {{ namespace }}",
-              "refId": "A"
-            },
-            {
-              "exemplar": true,
-              "expr": "sum(kubelet_volume_stats_available_bytes{cluster=\"$cluster\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "Available {{ namespace }}",
-              "refId": "B"
-            }
-          ],
-          "title": "Used vs Available Space (Cluster)",
-          "type": "piechart"
-        },
-        {
-          "datasource": null,
-          "description": "Used space by cluster,\nThis is the same as the pie chart except in a different visualization",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "min": 0,
-              "thresholds": {
-                "mode": "percentage",
-                "steps": [
-                  {
-                    "color": "dark-green",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 10
-                  },
-                  {
-                    "color": "#EAB839",
-                    "value": 20
-                  },
-                  {
-                    "color": "red",
-                    "value": 30
-                  }
-                ]
-              },
-              "unit": "decbytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 6,
-            "x": 18,
-            "y": 0
-          },
-          "id": 10,
-          "options": {
-            "displayMode": "gradient",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showUnfilled": true,
-            "text": {}
-          },
-          "pluginVersion": "8.1.1",
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "sum(kubelet_volume_stats_used_bytes{cluster=\"$cluster\"})",
-              "interval": "",
-              "legendFormat": "Used",
-              "refId": "A"
-            },
-            {
-              "exemplar": true,
-              "expr": "sum(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "Capacity/Total",
-              "refId": "B"
-            }
-          ],
-          "title": "Used Space by Cluster",
-          "transformations": [
-            {
-              "id": "configFromData",
-              "options": {
-                "configRefId": "B",
-                "mappings": [
-                  {
-                    "fieldName": "Capacity/Total",
-                    "handlerKey": "max"
-                  }
-                ]
-              }
-            }
-          ],
-          "type": "bargauge"
-        },
-        {
-          "datasource": null,
-          "description": "A time series-graph which visualizes memory usage throughout time",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 26,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "decbytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 7,
-            "x": 0,
-            "y": 3
-          },
-          "id": 13,
-          "options": {
-            "legend": {
-              "calcs": [
-                "mean",
-                "lastNotNull"
-              ],
-              "displayMode": "list",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "single"
-            }
-          },
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "sum by(namespace) (container_memory_working_set_bytes{namespace=\"$namespace\",container=\"\",pod!=\"\"})",
-              "interval": "",
-              "legendFormat": "{{namespace}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Memory Usage by Namespace",
-          "type": "timeseries"
-        },
-        {
-          "datasource": null,
-          "description": "Available and total capacity by selected namespace\nAvailable: How much you space you have to your disposal\nTotal: Total capacity given to your project/namespace",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "blue",
-                "mode": "fixed"
-              },
-              "mappings": [],
-              "min": 0,
-              "thresholds": {
-                "mode": "percentage",
-                "steps": [
-                  {
-                    "color": "dark-green",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 10
-                  },
-                  {
-                    "color": "#EAB839",
-                    "value": 20
-                  },
-                  {
-                    "color": "red",
-                    "value": 30
-                  }
-                ]
-              },
-              "unit": "decbytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 5,
-            "x": 7,
-            "y": 6
-          },
-          "id": 11,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "8.1.1",
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "sum(kubelet_volume_stats_available_bytes{namespace=\"$namespace\", cluster=\"$cluster\"})",
-              "interval": "",
-              "legendFormat": "Available Space",
-              "refId": "A"
-            },
-            {
-              "exemplar": true,
-              "expr": "sum(kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"})",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "Total Capacity",
-              "refId": "B"
-            }
-          ],
-          "title": "Total Space on Namespace",
-          "type": "stat"
-        },
-        {
-          "datasource": "moc-smaug",
-          "description": "Used Vs Available by the specific namespace\nUsed: How much has been used\nAvailable: How much space you have left (to use)",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                }
-              },
-              "mappings": [],
-              "min": 0,
-              "unit": "decbytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 6,
-            "x": 12,
-            "y": 6
-          },
-          "id": 2,
-          "options": {
-            "legend": {
-              "displayMode": "table",
-              "placement": "right",
-              "values": [
-                "value",
-                "percent"
-              ]
-            },
-            "pieType": "pie",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "tooltip": {
-              "mode": "single"
-            }
-          },
-          "pluginVersion": "8.1.1",
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "sum(kubelet_volume_stats_used_bytes{namespace=\"$namespace\", cluster=\"$cluster\"}) by (namespace)",
-              "interval": "",
-              "legendFormat": "Used ",
-              "refId": "A"
-            },
-            {
-              "exemplar": true,
-              "expr": "sum(kubelet_volume_stats_available_bytes{namespace=\"$namespace\"}) by (namespace)",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "Available",
-              "refId": "B"
-            }
-          ],
-          "title": "Used vs Available Space (Namespace)",
-          "type": "piechart"
-        },
-        {
-          "datasource": null,
-          "description": "Used space by namespace\nThis is the same as the pie chart except in a different visualization",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "min": 0,
-              "thresholds": {
-                "mode": "percentage",
-                "steps": [
-                  {
-                    "color": "dark-green",
-                    "value": null
-                  },
-                  {
-                    "color": "green",
-                    "value": 10
-                  },
-                  {
-                    "color": "#EAB839",
-                    "value": 20
-                  },
-                  {
-                    "color": "red",
-                    "value": 30
-                  }
-                ]
-              },
-              "unit": "decbytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 6,
-            "w": 6,
-            "x": 18,
-            "y": 6
-          },
-          "id": 4,
-          "options": {
-            "displayMode": "gradient",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showUnfilled": true,
-            "text": {}
-          },
-          "pluginVersion": "8.1.1",
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "sum(kubelet_volume_stats_used_bytes{namespace=\"$namespace\"}) by (namespace)",
-              "interval": "",
-              "legendFormat": "Used",
-              "refId": "A"
-            },
-            {
-              "exemplar": true,
-              "expr": "sum(kubelet_volume_stats_available_bytes{namespace=\"$namespace\"}) by (namespace)",
-              "hide": true,
-              "interval": "",
-              "legendFormat": "Avail",
-              "refId": "B"
-            },
-            {
-              "exemplar": true,
-              "expr": "sum(kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"}) by (namespace)",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "Capacity/Total",
-              "refId": "C"
-            }
-          ],
-          "title": "Used Space by Namespace",
-          "transformations": [
-            {
-              "id": "configFromData",
-              "options": {
-                "configRefId": "C",
-                "mappings": [
-                  {
-                    "fieldName": "Capacity/Total",
-                    "handlerKey": "max"
-                  }
-                ]
-              }
-            }
-          ],
-          "type": "bargauge"
-        },
-        {
-          "datasource": null,
-          "description": "Percentage of free space by PVC, note that PVC may show up or be removed. It depends if the PVC is bounded by a pod",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "dark-red",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 0.25
-                  },
-                  {
-                    "color": "orange",
-                    "value": 0.4
-                  },
-                  {
-                    "color": "#EAB839",
-                    "value": 0.5
-                  },
-                  {
-                    "color": "green",
-                    "value": 0.65
-                  },
-                  {
-                    "color": "dark-green",
-                    "value": 0.85
-                  }
-                ]
-              },
-              "unit": "percentunit"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 11,
-            "w": 12,
-            "x": 0,
-            "y": 12
-          },
-          "id": 17,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {
-              "titleSize": 13
-            },
-            "textMode": "auto"
-          },
-          "pluginVersion": "8.1.1",
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "kubelet_volume_stats_available_bytes{namespace=\"$namespace\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"}",
-              "interval": "",
-              "legendFormat": "{{persistentvolumeclaim}}",
-              "refId": "A"
-            }
-          ],
-          "title": "% of Free Space by PVC",
-          "type": "stat"
-        },
-        {
-          "datasource": null,
-          "description": "This panel displays the top 10 pods which the most amount of memory by namespace",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                }
-              },
-              "mappings": [],
-              "min": 0,
-              "unit": "decbytes"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 11,
-            "w": 12,
-            "x": 12,
-            "y": 12
-          },
-          "id": 15,
-          "options": {
-            "legend": {
-              "displayMode": "table",
-              "placement": "right",
-              "values": [
-                "value",
-                "percent"
-              ]
-            },
-            "pieType": "pie",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "tooltip": {
-              "mode": "single"
-            }
-          },
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "sort_desc(topk(10, sum by (pod)(container_memory_working_set_bytes{container=\"\",pod!=\"\",namespace=\"$namespace\"})))",
-              "interval": "",
-              "legendFormat": "{{pod}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Memory Usage by Pod (Top 10)",
-          "type": "piechart"
+          "type": "dashboard"
         }
-      ],
-      "schemaVersion": 30,
-      "style": "dark",
-      "tags": [],
-      "templating": {
-        "list": [
-          {
-            "current": {
-              "selected": false,
-              "text": "thanos-frontend",
-              "value": "thanos-frontend"
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 49,
+    "iteration": 1646860413759,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "description": "Shows total free space left in the namespace",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
             },
-            "description": null,
-            "error": null,
-            "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "datasource",
-            "options": [],
-            "query": "prometheus",
-            "queryValue": "",
-            "refresh": 1,
-            "regex": "",
-            "skipUrlSync": false,
-            "type": "datasource"
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "dark-red",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0.25
+                },
+                {
+                  "color": "orange",
+                  "value": 0.4
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 0.5
+                },
+                {
+                  "color": "green",
+                  "value": 0.7
+                },
+                {
+                  "color": "dark-green",
+                  "value": 0.85
+                }
+              ]
+            },
+            "unit": "percentunit"
           },
-          {
-            "allValue": null,
-            "current": {
-              "selected": false,
-              "text": "moc/smaug",
-              "value": "moc/smaug"
-            },
-            "datasource": "${datasource}",
-            "definition": "label_values(kubelet_node_name, cluster)",
-            "description": null,
-            "error": null,
-            "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "cluster",
-            "options": [],
-            "query": {
-              "query": "label_values(kubelet_node_name, cluster)",
-              "refId": "StandardVariableQuery"
-            },
-            "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 0,
-            "type": "query"
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 3,
+          "w": 7,
+          "x": 0,
+          "y": 0
+        },
+        "id": 18,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
           },
+          "text": {},
+          "textMode": "auto"
+        },
+        "pluginVersion": "8.4.3",
+        "targets": [
           {
-            "allValue": null,
-            "current": {
-              "selected": false,
-              "text": "opf-jupyterhub",
-              "value": "opf-jupyterhub"
-            },
-            "datasource": "${datasource}",
-            "definition": "label_values(namespace)",
-            "description": null,
-            "error": null,
-            "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "namespace",
-            "options": [],
-            "query": {
-              "query": "label_values(namespace)",
-              "refId": "StandardVariableQuery"
-            },
-            "refresh": 1,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 0,
-            "type": "query"
+            "exemplar": true,
+            "expr": "sum(kubelet_volume_stats_available_bytes{namespace=\"$namespace\"}) / sum(kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"})",
+            "interval": "",
+            "legendFormat": "{{persistentvolumeclaim}}",
+            "refId": "A"
           }
-        ]
+        ],
+        "title": "% of Free Space of Namespace",
+        "type": "stat"
       },
-      "time": {
-        "from": "now-1h",
-        "to": "now"
+      {
+        "description": "Available space and Total Capacity of cluster\n(These metrics are aggregated by querying Persistent Volumes.)",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "blue",
+              "mode": "fixed"
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "dark-green",
+                  "value": null
+                },
+                {
+                  "color": "green",
+                  "value": 10
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 20
+                },
+                {
+                  "color": "red",
+                  "value": 30
+                }
+              ]
+            },
+            "unit": "decbytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 6,
+          "w": 5,
+          "x": 7,
+          "y": 0
+        },
+        "id": 8,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "text": {},
+          "textMode": "auto"
+        },
+        "pluginVersion": "8.4.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PF0BA5EC94FCB9BBE"
+            },
+            "exemplar": true,
+            "expr": "sum(kubelet_volume_stats_available_bytes{cluster=\"$cluster\"})",
+            "interval": "",
+            "legendFormat": "Available Space",
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PF0BA5EC94FCB9BBE"
+            },
+            "exemplar": true,
+            "expr": "sum(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Capacity",
+            "refId": "B"
+          }
+        ],
+        "title": "Total Space on Cluster",
+        "type": "stat"
       },
-      "timepicker": {},
-      "timezone": "",
-      "title": "Storage Overview by Namespace",
-      "uid": "zkg-tWLnk5",
-      "version": 1
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PDD709D2516BFAE8A"
+        },
+        "description": "Used vs Available Space by cluster",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "orange",
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "unit": "decbytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 6,
+          "w": 6,
+          "x": 12,
+          "y": 0
+        },
+        "id": 9,
+        "options": {
+          "displayLabels": [],
+          "legend": {
+            "displayMode": "table",
+            "placement": "right",
+            "values": [
+              "value",
+              "percent"
+            ]
+          },
+          "pieType": "pie",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "8.1.1",
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "sum(kubelet_volume_stats_used_bytes{cluster=\"$cluster\"})",
+            "interval": "",
+            "legendFormat": "Used {{ namespace }}",
+            "refId": "A"
+          },
+          {
+            "exemplar": true,
+            "expr": "sum(kubelet_volume_stats_available_bytes{cluster=\"$cluster\"})",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Available {{ namespace }}",
+            "refId": "B"
+          }
+        ],
+        "title": "Used vs Available Space (Cluster)",
+        "type": "piechart"
+      },
+      {
+        "description": "Used space by cluster,\nThis is the same as the pie chart except in a different visualization",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "dark-green",
+                  "value": null
+                },
+                {
+                  "color": "green",
+                  "value": 10
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 20
+                },
+                {
+                  "color": "red",
+                  "value": 30
+                }
+              ]
+            },
+            "unit": "decbytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 6,
+          "w": 6,
+          "x": 18,
+          "y": 0
+        },
+        "id": 10,
+        "options": {
+          "displayMode": "gradient",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "text": {}
+        },
+        "pluginVersion": "8.4.3",
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "sum(kubelet_volume_stats_used_bytes{cluster=\"$cluster\"})",
+            "interval": "",
+            "legendFormat": "Used",
+            "refId": "A"
+          },
+          {
+            "exemplar": true,
+            "expr": "sum(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Capacity/Total",
+            "refId": "B"
+          }
+        ],
+        "title": "Used Space by Cluster",
+        "transformations": [
+          {
+            "id": "configFromData",
+            "options": {
+              "configRefId": "B",
+              "mappings": [
+                {
+                  "fieldName": "Capacity/Total",
+                  "handlerKey": "max"
+                }
+              ]
+            }
+          }
+        ],
+        "type": "bargauge"
+      },
+      {
+        "description": "A time series-graph which visualizes memory usage throughout time",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 26,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "decbytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 7,
+          "x": 0,
+          "y": 3
+        },
+        "id": 13,
+        "options": {
+          "legend": {
+            "calcs": [
+              "mean",
+              "lastNotNull"
+            ],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "sum by(namespace) (container_memory_working_set_bytes{namespace=\"$namespace\",container=\"\",pod!=\"\"})",
+            "interval": "",
+            "legendFormat": "{{namespace}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Memory Usage by Namespace",
+        "type": "timeseries"
+      },
+      {
+        "description": "Available and total capacity by selected namespace. \n(These metrics are aggregated by querying Persistent Volumes.)\nAvailable: How much you space you have to your disposal\nTotal: Total capacity given to your project/namespace",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "blue",
+              "mode": "fixed"
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "dark-green",
+                  "value": null
+                },
+                {
+                  "color": "green",
+                  "value": 10
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 20
+                },
+                {
+                  "color": "red",
+                  "value": 30
+                }
+              ]
+            },
+            "unit": "decbytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 6,
+          "w": 5,
+          "x": 7,
+          "y": 6
+        },
+        "id": 11,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "text": {},
+          "textMode": "auto"
+        },
+        "pluginVersion": "8.4.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PF0BA5EC94FCB9BBE"
+            },
+            "exemplar": false,
+            "expr": "sum(kubelet_volume_stats_available_bytes{namespace=\"$namespace\", cluster=\"$cluster\"})",
+            "interval": "",
+            "legendFormat": "Available Space",
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PF0BA5EC94FCB9BBE"
+            },
+            "exemplar": false,
+            "expr": "sum(kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"})",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Total Capacity",
+            "refId": "B"
+          }
+        ],
+        "title": "Total Space on Namespace",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PDD709D2516BFAE8A"
+        },
+        "description": "Used Vs Available by the specific namespace\nUsed: How much has been used\nAvailable: How much space you have left (to use)",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "unit": "decbytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 6,
+          "w": 6,
+          "x": 12,
+          "y": 6
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "displayMode": "table",
+            "placement": "right",
+            "values": [
+              "value",
+              "percent"
+            ]
+          },
+          "pieType": "pie",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "8.1.1",
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "sum(kubelet_volume_stats_used_bytes{namespace=\"$namespace\", cluster=\"$cluster\"}) by (namespace)",
+            "interval": "",
+            "legendFormat": "Used ",
+            "refId": "A"
+          },
+          {
+            "exemplar": true,
+            "expr": "sum(kubelet_volume_stats_available_bytes{namespace=\"$namespace\"}) by (namespace)",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Available",
+            "refId": "B"
+          }
+        ],
+        "title": "Used vs Available Space (Namespace)",
+        "type": "piechart"
+      },
+      {
+        "description": "Used space by namespace\nThis is the same as the pie chart except in a different visualization",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "dark-green",
+                  "value": null
+                },
+                {
+                  "color": "green",
+                  "value": 10
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 20
+                },
+                {
+                  "color": "red",
+                  "value": 30
+                }
+              ]
+            },
+            "unit": "decbytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 6,
+          "w": 6,
+          "x": 18,
+          "y": 6
+        },
+        "id": 4,
+        "options": {
+          "displayMode": "gradient",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "text": {}
+        },
+        "pluginVersion": "8.4.3",
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "sum(kubelet_volume_stats_used_bytes{namespace=\"$namespace\"}) by (namespace)",
+            "interval": "",
+            "legendFormat": "Used",
+            "refId": "A"
+          },
+          {
+            "exemplar": true,
+            "expr": "sum(kubelet_volume_stats_available_bytes{namespace=\"$namespace\"}) by (namespace)",
+            "hide": true,
+            "interval": "",
+            "legendFormat": "Avail",
+            "refId": "B"
+          },
+          {
+            "exemplar": true,
+            "expr": "sum(kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"}) by (namespace)",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Capacity/Total",
+            "refId": "C"
+          }
+        ],
+        "title": "Used Space by Namespace",
+        "transformations": [
+          {
+            "id": "configFromData",
+            "options": {
+              "configRefId": "C",
+              "mappings": [
+                {
+                  "fieldName": "Capacity/Total",
+                  "handlerKey": "max"
+                }
+              ]
+            }
+          }
+        ],
+        "type": "bargauge"
+      },
+      {
+        "description": "Total percentage of space free on existing mounted PVC's\n(Note: Percentage of free space by PVC, note that PVC may show up or be removed. It depends if the PVC is bounded by a pod)",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "left",
+              "displayMode": "color-text",
+              "filterable": false
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "text",
+                  "value": null
+                },
+                {
+                  "color": "dark-red",
+                  "value": 0.1
+                },
+                {
+                  "color": "red",
+                  "value": 0.25
+                },
+                {
+                  "color": "orange",
+                  "value": 0.4
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 0.5
+                },
+                {
+                  "color": "green",
+                  "value": 0.65
+                },
+                {
+                  "color": "dark-green",
+                  "value": 0.85
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 13,
+          "w": 10,
+          "x": 0,
+          "y": 12
+        },
+        "id": 17,
+        "options": {
+          "footer": {
+            "fields": "",
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": true,
+          "sortBy": [
+            {
+              "desc": true,
+              "displayName": "Value"
+            }
+          ]
+        },
+        "pluginVersion": "8.4.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PF0BA5EC94FCB9BBE"
+            },
+            "exemplar": false,
+            "expr": "kubelet_volume_stats_available_bytes{namespace=\"$namespace\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"}",
+            "format": "table",
+            "instant": true,
+            "interval": "",
+            "legendFormat": "{{persistentvolumeclaim}}",
+            "refId": "A"
+          }
+        ],
+        "title": "% of Free Space by PVC",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "Time": true,
+                "cluster": true,
+                "endpoint": true,
+                "instance": true,
+                "job": true,
+                "metrics_path": true,
+                "namespace": true,
+                "node": true,
+                "prometheus": true,
+                "service": true,
+                "tenant_id": true
+              },
+              "indexByName": {},
+              "renameByName": {
+                "persistentvolumeclaim": "Persistent Volume Claim",
+                "prometheus": "",
+                "service": ""
+              }
+            }
+          }
+        ],
+        "type": "table"
+      },
+      {
+        "description": "This panel displays the top 10 pods which the most amount of memory by namespace",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "unit": "decbytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 13,
+          "w": 14,
+          "x": 10,
+          "y": 12
+        },
+        "id": 15,
+        "options": {
+          "legend": {
+            "displayMode": "table",
+            "placement": "right",
+            "values": [
+              "value",
+              "percent"
+            ]
+          },
+          "pieType": "pie",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "sort_desc(topk(10, sum by (pod)(container_memory_working_set_bytes{container=\"\",pod!=\"\",namespace=\"$namespace\"})))",
+            "interval": "",
+            "legendFormat": "{{pod}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Memory Usage by Pod (Top 10)",
+        "type": "piechart"
+      }
+    ],
+    "schemaVersion": 35,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "selected": false,
+            "text": "thanos-frontend",
+            "value": "thanos-frontend"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "multi": false,
+          "name": "datasource",
+          "options": [],
+          "query": "prometheus",
+          "queryValue": "",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "type": "datasource"
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": "moc/smaug",
+            "value": "moc/smaug"
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "definition": "label_values(kubelet_node_name, cluster)",
+          "hide": 0,
+          "includeAll": false,
+          "multi": false,
+          "name": "cluster",
+          "options": [],
+          "query": {
+            "query": "label_values(kubelet_node_name, cluster)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "type": "query"
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": "opf-jupyterhub",
+            "value": "opf-jupyterhub"
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "definition": "label_values(namespace)",
+          "hide": 0,
+          "includeAll": false,
+          "multi": false,
+          "name": "namespace",
+          "options": [],
+          "query": {
+            "query": "label_values(namespace)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "type": "query"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PF0BA5EC94FCB9BBE"
+          },
+          "filters": [
+            {
+              "condition": "",
+              "key": "persistentvolumeclaim",
+              "operator": "!=",
+              "value": "all"
+            }
+          ],
+          "hide": 0,
+          "name": "Filters",
+          "skipUrlSync": false,
+          "type": "adhoc"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-1h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Storage Overview by Namespace",
+    "uid": "zkg-tWLnk",
+    "version": 0,
+    "weekStart": ""
     }

--- a/grafana/overlays/moc/smaug/dashboards/cluster-management/namespace_storage_overview.yaml
+++ b/grafana/overlays/moc/smaug/dashboards/cluster-management/namespace_storage_overview.yaml
@@ -11,987 +11,987 @@ spec:
       version: 1.6.2
   json: |
     {
-    "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": "-- Grafana --",
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "target": {
-            "limit": 100,
-            "matchAny": false,
-            "tags": [],
-            "type": "dashboard"
-          },
-          "type": "dashboard"
-        }
-      ]
-    },
-    "editable": true,
-    "fiscalYearStartMonth": 0,
-    "graphTooltip": 0,
-    "id": 49,
-    "iteration": 1646860413759,
-    "links": [],
-    "liveNow": false,
-    "panels": [
-      {
-        "description": "Shows total free space left in the namespace",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "dark-red",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 0.25
-                },
-                {
-                  "color": "orange",
-                  "value": 0.4
-                },
-                {
-                  "color": "#EAB839",
-                  "value": 0.5
-                },
-                {
-                  "color": "green",
-                  "value": 0.7
-                },
-                {
-                  "color": "dark-green",
-                  "value": 0.85
-                }
-              ]
-            },
-            "unit": "percentunit"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 3,
-          "w": 7,
-          "x": 0,
-          "y": 0
-        },
-        "id": 18,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "none",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "text": {},
-          "textMode": "auto"
-        },
-        "pluginVersion": "8.4.3",
-        "targets": [
+      "annotations": {
+        "list": [
           {
-            "exemplar": true,
-            "expr": "sum(kubelet_volume_stats_available_bytes{namespace=\"$namespace\"}) / sum(kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"})",
-            "interval": "",
-            "legendFormat": "{{persistentvolumeclaim}}",
-            "refId": "A"
-          }
-        ],
-        "title": "% of Free Space of Namespace",
-        "type": "stat"
-      },
-      {
-        "description": "Available space and Total Capacity of cluster\n(These metrics are aggregated by querying Persistent Volumes.)",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "fixedColor": "blue",
-              "mode": "fixed"
-            },
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "dark-green",
-                  "value": null
-                },
-                {
-                  "color": "green",
-                  "value": 10
-                },
-                {
-                  "color": "#EAB839",
-                  "value": 20
-                },
-                {
-                  "color": "red",
-                  "value": 30
-                }
-              ]
-            },
-            "unit": "decbytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 6,
-          "w": 5,
-          "x": 7,
-          "y": 0
-        },
-        "id": 8,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "text": {},
-          "textMode": "auto"
-        },
-        "pluginVersion": "8.4.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PF0BA5EC94FCB9BBE"
-            },
-            "exemplar": true,
-            "expr": "sum(kubelet_volume_stats_available_bytes{cluster=\"$cluster\"})",
-            "interval": "",
-            "legendFormat": "Available Space",
-            "refId": "A"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PF0BA5EC94FCB9BBE"
-            },
-            "exemplar": true,
-            "expr": "sum(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "Capacity",
-            "refId": "B"
-          }
-        ],
-        "title": "Total Space on Cluster",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PDD709D2516BFAE8A"
-        },
-        "description": "Used vs Available Space by cluster",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "fixedColor": "orange",
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              }
-            },
-            "mappings": [],
-            "min": 0,
-            "unit": "decbytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 12,
-          "y": 0
-        },
-        "id": 9,
-        "options": {
-          "displayLabels": [],
-          "legend": {
-            "displayMode": "table",
-            "placement": "right",
-            "values": [
-              "value",
-              "percent"
-            ]
-          },
-          "pieType": "pie",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "8.1.1",
-        "targets": [
-          {
-            "exemplar": true,
-            "expr": "sum(kubelet_volume_stats_used_bytes{cluster=\"$cluster\"})",
-            "interval": "",
-            "legendFormat": "Used {{ namespace }}",
-            "refId": "A"
-          },
-          {
-            "exemplar": true,
-            "expr": "sum(kubelet_volume_stats_available_bytes{cluster=\"$cluster\"})",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "Available {{ namespace }}",
-            "refId": "B"
-          }
-        ],
-        "title": "Used vs Available Space (Cluster)",
-        "type": "piechart"
-      },
-      {
-        "description": "Used space by cluster,\nThis is the same as the pie chart except in a different visualization",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "dark-green",
-                  "value": null
-                },
-                {
-                  "color": "green",
-                  "value": 10
-                },
-                {
-                  "color": "#EAB839",
-                  "value": 20
-                },
-                {
-                  "color": "red",
-                  "value": 30
-                }
-              ]
-            },
-            "unit": "decbytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 18,
-          "y": 0
-        },
-        "id": 10,
-        "options": {
-          "displayMode": "gradient",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showUnfilled": true,
-          "text": {}
-        },
-        "pluginVersion": "8.4.3",
-        "targets": [
-          {
-            "exemplar": true,
-            "expr": "sum(kubelet_volume_stats_used_bytes{cluster=\"$cluster\"})",
-            "interval": "",
-            "legendFormat": "Used",
-            "refId": "A"
-          },
-          {
-            "exemplar": true,
-            "expr": "sum(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "Capacity/Total",
-            "refId": "B"
-          }
-        ],
-        "title": "Used Space by Cluster",
-        "transformations": [
-          {
-            "id": "configFromData",
-            "options": {
-              "configRefId": "B",
-              "mappings": [
-                {
-                  "fieldName": "Capacity/Total",
-                  "handlerKey": "max"
-                }
-              ]
-            }
-          }
-        ],
-        "type": "bargauge"
-      },
-      {
-        "description": "A time series-graph which visualizes memory usage throughout time",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 26,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "decbytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 9,
-          "w": 7,
-          "x": 0,
-          "y": 3
-        },
-        "id": 13,
-        "options": {
-          "legend": {
-            "calcs": [
-              "mean",
-              "lastNotNull"
-            ],
-            "displayMode": "list",
-            "placement": "bottom"
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "targets": [
-          {
-            "exemplar": true,
-            "expr": "sum by(namespace) (container_memory_working_set_bytes{namespace=\"$namespace\",container=\"\",pod!=\"\"})",
-            "interval": "",
-            "legendFormat": "{{namespace}}",
-            "refId": "A"
-          }
-        ],
-        "title": "Memory Usage by Namespace",
-        "type": "timeseries"
-      },
-      {
-        "description": "Available and total capacity by selected namespace. \n(These metrics are aggregated by querying Persistent Volumes.)\nAvailable: How much you space you have to your disposal\nTotal: Total capacity given to your project/namespace",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "fixedColor": "blue",
-              "mode": "fixed"
-            },
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "dark-green",
-                  "value": null
-                },
-                {
-                  "color": "green",
-                  "value": 10
-                },
-                {
-                  "color": "#EAB839",
-                  "value": 20
-                },
-                {
-                  "color": "red",
-                  "value": 30
-                }
-              ]
-            },
-            "unit": "decbytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 6,
-          "w": 5,
-          "x": 7,
-          "y": 6
-        },
-        "id": 11,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "text": {},
-          "textMode": "auto"
-        },
-        "pluginVersion": "8.4.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PF0BA5EC94FCB9BBE"
-            },
-            "exemplar": false,
-            "expr": "sum(kubelet_volume_stats_available_bytes{namespace=\"$namespace\", cluster=\"$cluster\"})",
-            "interval": "",
-            "legendFormat": "Available Space",
-            "refId": "A"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PF0BA5EC94FCB9BBE"
-            },
-            "exemplar": false,
-            "expr": "sum(kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"})",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "Total Capacity",
-            "refId": "B"
-          }
-        ],
-        "title": "Total Space on Namespace",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PDD709D2516BFAE8A"
-        },
-        "description": "Used Vs Available by the specific namespace\nUsed: How much has been used\nAvailable: How much space you have left (to use)",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              }
-            },
-            "mappings": [],
-            "min": 0,
-            "unit": "decbytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 12,
-          "y": 6
-        },
-        "id": 2,
-        "options": {
-          "legend": {
-            "displayMode": "table",
-            "placement": "right",
-            "values": [
-              "value",
-              "percent"
-            ]
-          },
-          "pieType": "pie",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "8.1.1",
-        "targets": [
-          {
-            "exemplar": true,
-            "expr": "sum(kubelet_volume_stats_used_bytes{namespace=\"$namespace\", cluster=\"$cluster\"}) by (namespace)",
-            "interval": "",
-            "legendFormat": "Used ",
-            "refId": "A"
-          },
-          {
-            "exemplar": true,
-            "expr": "sum(kubelet_volume_stats_available_bytes{namespace=\"$namespace\"}) by (namespace)",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "Available",
-            "refId": "B"
-          }
-        ],
-        "title": "Used vs Available Space (Namespace)",
-        "type": "piechart"
-      },
-      {
-        "description": "Used space by namespace\nThis is the same as the pie chart except in a different visualization",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "dark-green",
-                  "value": null
-                },
-                {
-                  "color": "green",
-                  "value": 10
-                },
-                {
-                  "color": "#EAB839",
-                  "value": 20
-                },
-                {
-                  "color": "red",
-                  "value": 30
-                }
-              ]
-            },
-            "unit": "decbytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 6,
-          "w": 6,
-          "x": 18,
-          "y": 6
-        },
-        "id": 4,
-        "options": {
-          "displayMode": "gradient",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showUnfilled": true,
-          "text": {}
-        },
-        "pluginVersion": "8.4.3",
-        "targets": [
-          {
-            "exemplar": true,
-            "expr": "sum(kubelet_volume_stats_used_bytes{namespace=\"$namespace\"}) by (namespace)",
-            "interval": "",
-            "legendFormat": "Used",
-            "refId": "A"
-          },
-          {
-            "exemplar": true,
-            "expr": "sum(kubelet_volume_stats_available_bytes{namespace=\"$namespace\"}) by (namespace)",
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
             "hide": true,
-            "interval": "",
-            "legendFormat": "Avail",
-            "refId": "B"
-          },
-          {
-            "exemplar": true,
-            "expr": "sum(kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"}) by (namespace)",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "Capacity/Total",
-            "refId": "C"
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
           }
-        ],
-        "title": "Used Space by Namespace",
-        "transformations": [
-          {
-            "id": "configFromData",
-            "options": {
-              "configRefId": "C",
-              "mappings": [
-                {
-                  "fieldName": "Capacity/Total",
-                  "handlerKey": "max"
-                }
-              ]
-            }
-          }
-        ],
-        "type": "bargauge"
+        ]
       },
-      {
-        "description": "Total percentage of space free on existing mounted PVC's\n(Note: Percentage of free space by PVC, note that PVC may show up or be removed. It depends if the PVC is bounded by a pod)",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "custom": {
-              "align": "left",
-              "displayMode": "color-text",
-              "filterable": false
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "text",
-                  "value": null
-                },
-                {
-                  "color": "dark-red",
-                  "value": 0.1
-                },
-                {
-                  "color": "red",
-                  "value": 0.25
-                },
-                {
-                  "color": "orange",
-                  "value": 0.4
-                },
-                {
-                  "color": "#EAB839",
-                  "value": 0.5
-                },
-                {
-                  "color": "green",
-                  "value": 0.65
-                },
-                {
-                  "color": "dark-green",
-                  "value": 0.85
-                }
-              ]
-            },
-            "unit": "percentunit"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 13,
-          "w": 10,
-          "x": 0,
-          "y": 12
-        },
-        "id": 17,
-        "options": {
-          "footer": {
-            "fields": "",
-            "reducer": [
-              "sum"
-            ],
-            "show": false
-          },
-          "showHeader": true,
-          "sortBy": [
-            {
-              "desc": true,
-              "displayName": "Value"
-            }
-          ]
-        },
-        "pluginVersion": "8.4.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PF0BA5EC94FCB9BBE"
-            },
-            "exemplar": false,
-            "expr": "kubelet_volume_stats_available_bytes{namespace=\"$namespace\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"}",
-            "format": "table",
-            "instant": true,
-            "interval": "",
-            "legendFormat": "{{persistentvolumeclaim}}",
-            "refId": "A"
-          }
-        ],
-        "title": "% of Free Space by PVC",
-        "transformations": [
-          {
-            "id": "organize",
-            "options": {
-              "excludeByName": {
-                "Time": true,
-                "cluster": true,
-                "endpoint": true,
-                "instance": true,
-                "job": true,
-                "metrics_path": true,
-                "namespace": true,
-                "node": true,
-                "prometheus": true,
-                "service": true,
-                "tenant_id": true
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": 49,
+      "iteration": 1646861099630,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "description": "Shows total free space left in the namespace",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
               },
-              "indexByName": {},
-              "renameByName": {
-                "persistentvolumeclaim": "Persistent Volume Claim",
-                "prometheus": "",
-                "service": ""
-              }
-            }
-          }
-        ],
-        "type": "table"
-      },
-      {
-        "description": "This panel displays the top 10 pods which the most amount of memory by namespace",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-red",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.25
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.4
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "green",
+                    "value": 0.7
+                  },
+                  {
+                    "color": "dark-green",
+                    "value": 0.85
+                  }
+                ]
+              },
+              "unit": "percentunit"
             },
-            "custom": {
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              }
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 3,
+            "w": 7,
+            "x": 0,
+            "y": 0
+          },
+          "id": 18,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
             },
-            "mappings": [],
-            "min": 0,
-            "unit": "decbytes"
+            "text": {},
+            "textMode": "auto"
           },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 13,
-          "w": 14,
-          "x": 10,
-          "y": 12
-        },
-        "id": 15,
-        "options": {
-          "legend": {
-            "displayMode": "table",
-            "placement": "right",
-            "values": [
-              "value",
-              "percent"
-            ]
-          },
-          "pieType": "pie",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "targets": [
-          {
-            "exemplar": true,
-            "expr": "sort_desc(topk(10, sum by (pod)(container_memory_working_set_bytes{container=\"\",pod!=\"\",namespace=\"$namespace\"})))",
-            "interval": "",
-            "legendFormat": "{{pod}}",
-            "refId": "A"
-          }
-        ],
-        "title": "Memory Usage by Pod (Top 10)",
-        "type": "piechart"
-      }
-    ],
-    "schemaVersion": 35,
-    "style": "dark",
-    "tags": [],
-    "templating": {
-      "list": [
-        {
-          "current": {
-            "selected": false,
-            "text": "thanos-frontend",
-            "value": "thanos-frontend"
-          },
-          "hide": 0,
-          "includeAll": false,
-          "multi": false,
-          "name": "datasource",
-          "options": [],
-          "query": "prometheus",
-          "queryValue": "",
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "type": "datasource"
-        },
-        {
-          "current": {
-            "selected": false,
-            "text": "moc/smaug",
-            "value": "moc/smaug"
-          },
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "definition": "label_values(kubelet_node_name, cluster)",
-          "hide": 0,
-          "includeAll": false,
-          "multi": false,
-          "name": "cluster",
-          "options": [],
-          "query": {
-            "query": "label_values(kubelet_node_name, cluster)",
-            "refId": "StandardVariableQuery"
-          },
-          "refresh": 2,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
-        },
-        {
-          "current": {
-            "selected": false,
-            "text": "opf-jupyterhub",
-            "value": "opf-jupyterhub"
-          },
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "definition": "label_values(namespace)",
-          "hide": 0,
-          "includeAll": false,
-          "multi": false,
-          "name": "namespace",
-          "options": [],
-          "query": {
-            "query": "label_values(namespace)",
-            "refId": "StandardVariableQuery"
-          },
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF0BA5EC94FCB9BBE"
-          },
-          "filters": [
+          "pluginVersion": "8.4.3",
+          "targets": [
             {
-              "condition": "",
-              "key": "persistentvolumeclaim",
-              "operator": "!=",
-              "value": "all"
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_available_bytes{namespace=\"$namespace\"}) / sum(kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"})",
+              "interval": "",
+              "legendFormat": "{{persistentvolumeclaim}}",
+              "refId": "A"
             }
           ],
-          "hide": 0,
-          "name": "Filters",
-          "skipUrlSync": false,
-          "type": "adhoc"
+          "title": "% of Free Space of Namespace",
+          "type": "stat"
+        },
+        {
+          "description": "Available space and Total Capacity of cluster\n(These metrics are aggregated by querying Persistent Volumes.)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "blue",
+                "mode": "fixed"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "dark-green",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 10
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 20
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 5,
+            "x": 7,
+            "y": 0
+          },
+          "id": 8,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "8.4.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PF0BA5EC94FCB9BBE"
+              },
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_available_bytes{cluster=\"$cluster\"})",
+              "interval": "",
+              "legendFormat": "Available Space",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PF0BA5EC94FCB9BBE"
+              },
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Capacity",
+              "refId": "B"
+            }
+          ],
+          "title": "Total Space on Cluster",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PDD709D2516BFAE8A"
+          },
+          "description": "Used vs Available Space by cluster",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "orange",
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 12,
+            "y": 0
+          },
+          "id": 9,
+          "options": {
+            "displayLabels": [],
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "values": [
+                "value",
+                "percent"
+              ]
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.1.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_used_bytes{cluster=\"$cluster\"})",
+              "interval": "",
+              "legendFormat": "Used {{ namespace }}",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_available_bytes{cluster=\"$cluster\"})",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Available {{ namespace }}",
+              "refId": "B"
+            }
+          ],
+          "title": "Used vs Available Space (Cluster)",
+          "type": "piechart"
+        },
+        {
+          "description": "Used space by cluster,\nThis is the same as the pie chart except in a different visualization",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "dark-green",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 10
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 20
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 18,
+            "y": 0
+          },
+          "id": 10,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
+          },
+          "pluginVersion": "8.4.3",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_used_bytes{cluster=\"$cluster\"})",
+              "interval": "",
+              "legendFormat": "Used",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Capacity/Total",
+              "refId": "B"
+            }
+          ],
+          "title": "Used Space by Cluster",
+          "transformations": [
+            {
+              "id": "configFromData",
+              "options": {
+                "configRefId": "B",
+                "mappings": [
+                  {
+                    "fieldName": "Capacity/Total",
+                    "handlerKey": "max"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "bargauge"
+        },
+        {
+          "description": "A time series-graph which visualizes memory usage throughout time",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 26,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 7,
+            "x": 0,
+            "y": 3
+          },
+          "id": 13,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull"
+              ],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum by(namespace) (container_memory_working_set_bytes{namespace=\"$namespace\",container=\"\",pod!=\"\"})",
+              "interval": "",
+              "legendFormat": "{{namespace}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory Usage by Namespace",
+          "type": "timeseries"
+        },
+        {
+          "description": "Available and total capacity by selected namespace. \n(These metrics are aggregated by querying Persistent Volumes.)\nAvailable: How much you space you have to your disposal\nTotal: Total capacity given to your project/namespace",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "blue",
+                "mode": "fixed"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "dark-green",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 10
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 20
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 5,
+            "x": 7,
+            "y": 6
+          },
+          "id": 11,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "8.4.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PF0BA5EC94FCB9BBE"
+              },
+              "exemplar": false,
+              "expr": "sum(kubelet_volume_stats_available_bytes{namespace=\"$namespace\", cluster=\"$cluster\"})",
+              "interval": "",
+              "legendFormat": "Available Space",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PF0BA5EC94FCB9BBE"
+              },
+              "exemplar": false,
+              "expr": "sum(kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"})",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total Capacity",
+              "refId": "B"
+            }
+          ],
+          "title": "Total Space on Namespace",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PDD709D2516BFAE8A"
+          },
+          "description": "Used Vs Available by the specific namespace\nUsed: How much has been used\nAvailable: How much space you have left (to use)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 12,
+            "y": 6
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "values": [
+                "value",
+                "percent"
+              ]
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.1.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_used_bytes{namespace=\"$namespace\", cluster=\"$cluster\"}) by (namespace)",
+              "interval": "",
+              "legendFormat": "Used ",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_available_bytes{namespace=\"$namespace\"}) by (namespace)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Available",
+              "refId": "B"
+            }
+          ],
+          "title": "Used vs Available Space (Namespace)",
+          "type": "piechart"
+        },
+        {
+          "description": "Used space by namespace\nThis is the same as the pie chart except in a different visualization",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "dark-green",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 10
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 20
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 18,
+            "y": 6
+          },
+          "id": 4,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
+          },
+          "pluginVersion": "8.4.3",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_used_bytes{namespace=\"$namespace\"}) by (namespace)",
+              "interval": "",
+              "legendFormat": "Used",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_available_bytes{namespace=\"$namespace\"}) by (namespace)",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "Avail",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"}) by (namespace)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Capacity/Total",
+              "refId": "C"
+            }
+          ],
+          "title": "Used Space by Namespace",
+          "transformations": [
+            {
+              "id": "configFromData",
+              "options": {
+                "configRefId": "C",
+                "mappings": [
+                  {
+                    "fieldName": "Capacity/Total",
+                    "handlerKey": "max"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "bargauge"
+        },
+        {
+          "description": "Total percentage of space free on existing mounted PVC's\n(Note: Percentage of free space by PVC, note that PVC may show up or be removed. It depends if the PVC is bounded by a pod)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "left",
+                "displayMode": "color-text",
+                "filterable": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 0.1
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.25
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.4
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "green",
+                    "value": 0.65
+                  },
+                  {
+                    "color": "dark-green",
+                    "value": 0.85
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 10,
+            "x": 0,
+            "y": 12
+          },
+          "id": 17,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Value"
+              }
+            ]
+          },
+          "pluginVersion": "8.4.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PF0BA5EC94FCB9BBE"
+              },
+              "exemplar": false,
+              "expr": "kubelet_volume_stats_available_bytes{namespace=\"$namespace\"} / kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"}",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{persistentvolumeclaim}}",
+              "refId": "A"
+            }
+          ],
+          "title": "% of Free Space by PVC",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "cluster": true,
+                  "endpoint": true,
+                  "instance": true,
+                  "job": true,
+                  "metrics_path": true,
+                  "namespace": true,
+                  "node": true,
+                  "prometheus": true,
+                  "service": true,
+                  "tenant_id": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "persistentvolumeclaim": "Persistent Volume Claim",
+                  "prometheus": "",
+                  "service": ""
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "description": "This panel displays the top 10 pods which the most amount of memory by namespace",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": [],
+              "min": 0,
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 14,
+            "x": 10,
+            "y": 12
+          },
+          "id": 15,
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "values": [
+                "value",
+                "percent"
+              ]
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sort_desc(topk(10, sum by (pod)(container_memory_working_set_bytes{container=\"\",pod!=\"\",namespace=\"$namespace\"})))",
+              "interval": "",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory Usage by Pod (Top 10)",
+          "type": "piechart"
         }
-      ]
-    },
-    "time": {
-      "from": "now-1h",
-      "to": "now"
-    },
-    "timepicker": {},
-    "timezone": "",
-    "title": "Storage Overview by Namespace",
-    "uid": "zkg-tWLnk",
-    "version": 0,
-    "weekStart": ""
+      ],
+      "schemaVersion": 35,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "thanos-frontend",
+              "value": "thanos-frontend"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "queryValue": "",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          },
+          {
+            "current": {
+              "selected": false,
+              "text": "moc/smaug",
+              "value": "moc/smaug"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "definition": "label_values(kubelet_node_name, cluster)",
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "cluster",
+            "options": [],
+            "query": {
+              "query": "label_values(kubelet_node_name, cluster)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          },
+          {
+            "current": {
+              "selected": false,
+              "text": "opf-jupyterhub",
+              "value": "opf-jupyterhub"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "definition": "label_values(namespace)",
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": {
+              "query": "label_values(namespace)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PF0BA5EC94FCB9BBE"
+            },
+            "filters": [
+              {
+                "condition": "",
+                "key": "persistentvolumeclaim",
+                "operator": "!=",
+                "value": "all"
+              }
+            ],
+            "hide": 0,
+            "name": "Filters",
+            "skipUrlSync": false,
+            "type": "adhoc"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Storage Overview by Namespace",
+      "uid": "zkg-tWLnk",
+      "version": 0,
+      "weekStart": ""
     }


### PR DESCRIPTION
## Issues:
Related [#445](https://github.com/operate-first/support/issues/682)
- A portion of my co-op project (expand storage monitoring, specifically through dashboards)

Related [Workload Overview Dashboard](https://github.com/orgs/operate-first/projects/50)
- This dashboard will be linked in the Workload Overview dashboard, for a more detailed of a namespace's storage information
## Description:
This namespace-specific storage dashboard is created to show users/groups a high-level overview of their namespaces storage. 

When drafting this dashboard I've found myself overcomplicating what should be on there, thinking through an engineer/operations perspective I thought of visualizing latency, IOPS, disk utilization, etc. However, from a user perspective, the main concern is how much space you have at your disposal and how close you are to getting capped out.

This dashboard does just that by showing the percentage of free space by individual namespace and PVCs. Along with other panels with similar queries though visualized differently. If you notice there are 3 panels that show available, total, and used space by cluster and this is used to reference the namespace's space compared to the cluster your project/workload is sitting on. 

#### Dashboard Contents:
- Percentage of free space by namespace and by individual PVC
- Available, Capacity, and used space panels by cluster and namespace
- Gauges of used space by cluster and namespace
- Panel which shows top 10 pods, ordered by memory usage

#### Manifest Changes;
- Created new dashboard yaml file
- Added file to dashboard/kustomization.yaml

**Link to dashboard**: [Storage Overview by Namespace Dashboard](https://grafana.operate-first.cloud/d/zkg-tWLnk/storage-overview-by-namespace?orgId=1)

![image](https://user-images.githubusercontent.com/68972382/156801259-585493f4-627e-4ee8-a76d-5344d9b97346.png)
