### PR TITLE
Redirect oscl1 kfdefs to oscl1 odh-manifests branch.

### DIFF
--- a/kfdefs/overlays/osc/osc-cl1/jupyterhub/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/jupyterhub/kfdef.yaml
@@ -34,5 +34,5 @@ spec:
       name: radanalyticsio-spark-cluster
   repos:
     - name: manifests
-      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl2-v1.1.0
+      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl1-v1.1.0
   version: v1.1.0

--- a/kfdefs/overlays/osc/osc-cl1/seldon/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/seldon/kfdef.yaml
@@ -20,5 +20,5 @@ spec:
       name: odhseldon
   repos:
     - name: manifests
-      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl2-v1.1.0
+      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl1-v1.1.0
   version: v1.1.0

--- a/kfdefs/overlays/osc/osc-cl1/superset/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/superset/kfdef.yaml
@@ -19,5 +19,5 @@ spec:
       name: superset
   repos:
     - name: manifests
-      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl2-v1.1.0
+      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl1-v1.1.0
   version: v1.1.0

--- a/kfdefs/overlays/osc/osc-cl1/trino/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/trino/kfdef.yaml
@@ -35,5 +35,5 @@ spec:
       name: trino
   repos:
     - name: manifests
-      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl2-v1.1.0
+      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl1-v1.1.0
   version: v1.1.0


### PR DESCRIPTION
Redirect to: https://github.com/operate-first/odh-manifests/tree/osc-cl1-v1.1.0 

We'll be keeping this cluster around for a bit longer so it's only appropriate that it points to it's own branch. 