### PR TITLE
Adding service monitor to the grafana/blackbox-exporter kustomization file in Smaug

### DIFF
--- a/grafana/overlays/moc/smaug/blackbox-exporter/kustomization.yaml
+++ b/grafana/overlays/moc/smaug/blackbox-exporter/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - deployment.yaml
   - route.yaml
   - service.yaml
+  - service-monitor.yaml


### PR DESCRIPTION
Adding the service monitor to the kustomization file. Related http://operate-first/operations#444

/cc @4n4nd 

Continuation of https://github.com/operate-first/apps/pull/1701