### PR TITLE
Update trino kfdef in osc-cl2.

### DIFF
--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/jvm-coordinator.config
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/jvm-coordinator.config
@@ -1,5 +1,6 @@
 -server
--Xmx8G
+-XX:InitialRAMPercentage=50.0
+-XX:MaxRAMPercentage=75.0
 -XX:-UseBiasedLocking
 -XX:+UseG1GC
 -XX:G1HeapRegionSize=32M

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/jvm-worker.config
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/jvm-worker.config
@@ -1,0 +1,14 @@
+-server
+-XX:InitialRAMPercentage=50.0
+-XX:MaxRAMPercentage=75.0
+-XX:-UseBiasedLocking
+-XX:+UseG1GC
+-XX:G1HeapRegionSize=32M
+-XX:+ExplicitGCInvokesConcurrent
+-XX:+ExitOnOutOfMemoryError
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:ReservedCodeCacheSize=512M
+-XX:PerMethodRecompilationCutoff=10000
+-XX:PerBytecodeRecompilationCutoff=10000
+-Djdk.attach.allowAttachSelf=true
+-Djdk.nio.maxCachedBufferSize=2000000

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/kustomization.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/kustomization.yaml
@@ -12,7 +12,8 @@ configMapGenerator:
     files:
       - config-coordinator.properties
       - config-worker.properties
-      - jvm.config
+      - jvm-coordinator.config
+      - jvm-worker.config
       - log.properties
       - node.properties
       - password-authenticator.properties

--- a/kfdefs/overlays/osc/osc-cl2/trino/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/kfdef.yaml
@@ -35,5 +35,5 @@ spec:
       name: trino
   repos:
     - name: manifests
-      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl2-v1.1.0
+      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl2-v1.1.2
   version: v1.1.0


### PR DESCRIPTION
This update will use the odh manifests for trino from version 1.1.2.

Functionally nothing should change for trino, except that worker and
coordinator jvm configs are not separated.

Related to: https://github.com/open-services-group/devsecops/issues/9