### PR TITLE
Update jupyterhub kfdef in osc-cl2.

### DIFF
--- a/kfdefs/overlays/osc/osc-cl2/jupyterhub/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/jupyterhub/kfdef.yaml
@@ -14,6 +14,8 @@ spec:
       name: odh-common
     - kustomizeConfig:
         parameters:
+          - name: notebook_destination
+            value: "odh-jupyterhub"
           - name: s3_endpoint_url
             value: s3.odh.com
         repoRef:
@@ -34,5 +36,5 @@ spec:
       name: radanalyticsio-spark-cluster
   repos:
     - name: manifests
-      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl2-v1.1.0
+      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl2-v1.1.2
   version: v1.1.0


### PR DESCRIPTION
This change will update JupyterHub kfdef to deploy JH manifests using
odh version 1.1.2, upgrading from 1.1.0. No significant changes
introduced.

Dependent on: https://github.com/operate-first/odh-manifests/pull/4