### PR TITLE
Update seldon kfdef to odh 1.1.2 in osc-cl2.

### DIFF
--- a/kfdefs/overlays/osc/osc-cl2/seldon/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/seldon/kfdef.yaml
@@ -20,5 +20,5 @@ spec:
       name: odhseldon
   repos:
     - name: manifests
-      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl2-v1.1.0
+      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl2-v1.1.2
   version: v1.1.0


### PR DESCRIPTION
Related to: https://github.com/open-services-group/devsecops/issues/9