### PR TITLE
Introduce sudoers on morty

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/sudoers/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/sudoers/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sudoers-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sudoer
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: sudoers

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/sudoers/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/sudoers/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrolebinding.yaml

--- a/cluster-scope/base/user.openshift.io/groups/sudoers/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/sudoers/group.yaml
@@ -1,7 +1,6 @@
+---
 apiVersion: user.openshift.io/v1
 kind: Group
 metadata:
-  name: cluster-admins
-users:
-  - humairak
-  - 4n4nd
+  name: sudoers
+users: []

--- a/cluster-scope/base/user.openshift.io/groups/sudoers/kustomization.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/sudoers/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- group.yaml

--- a/cluster-scope/overlays/prod/emea/morty/groups/sudoers.yaml
+++ b/cluster-scope/overlays/prod/emea/morty/groups/sudoers.yaml
@@ -1,7 +1,6 @@
 apiVersion: user.openshift.io/v1
 kind: Group
 metadata:
-  name: cluster-admins
+  name: sudoers
 users:
-  - humairak
-  - 4n4nd
+  - rbo

--- a/cluster-scope/overlays/prod/emea/morty/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/morty/kustomization.yaml
@@ -4,6 +4,7 @@ generators:
 kind: Kustomization
 patchesStrategicMerge:
 - groups/cluster-admins.yaml
+- groups/sudoers.yaml
 - oauths/cluster_patch.yaml
 - subscriptions/local-storage-operator_patch.yaml
 - subscriptions/odf-operator_patch.yaml
@@ -29,6 +30,8 @@ resources:
 - ../../../../base/operators.coreos.com/subscriptions/kubevirt-hyperconverged
 - ../../../../base/operators.coreos.com/subscriptions/openshift-pipelines-operator-rh
 - ../../../../base/user.openshift.io/groups/cluster-admins
+- ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/sudoers
+- ../../../../base/user.openshift.io/groups/sudoers
 - ../../../../base/core/persistentvolumeclaims/image-registry-storage
 - ../../../../base/imageregistry.operator.openshift.io/configs/cluster
 - ../../../../bundles/nfd


### PR DESCRIPTION
- Add group sudoers and clusterrolebinding to clusterrole sudoer
- Remove  rbo from cluster-admins
- Add rbo to sudoers

I don't want to be a cluster admin all the time. Next week in sig-ops meeting I will present and show how it works.