### PR TITLE
Add rbo to sre group

### DIFF
--- a/cluster-scope/base/user.openshift.io/groups/sre/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/sre/group.yaml
@@ -18,3 +18,4 @@ users:
   - suppathak
   - mubariskhan96
   - carlosgimeno
+  - rbo


### PR DESCRIPTION
Add rbo to sre group to get access to grafana dashboards.

https://operatefirst.slack.com/archives/C01TLUB9X6Y/p1647010862350739
https://github.com/operate-first/support/issues/342