### PR TITLE
Adding Probe Success burn rate based Alerts for JupyterHub in Smaug

### DIFF
--- a/cluster-scope/base/core/namespaces/examples-openshift-pub/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/examples-openshift-pub/kustomization.yaml
@@ -1,0 +1,9 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+namespace: examples-openshift-pub
+resources:
+    - namespace.yaml
+components:
+    - ../../../../components/limitranges/default
+    - ../../../../components/project-admin-rolebindings/rbo
+    - ../../../../components/resourcequotas/medium

--- a/cluster-scope/base/core/namespaces/examples-openshift-pub/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/examples-openshift-pub/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: examples-openshift-pub
+    annotations:
+        openshift.io/requester: rbo

--- a/cluster-scope/overlays/prod/emea/morty/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/morty/kustomization.yaml
@@ -22,6 +22,7 @@ resources:
 - ../../../../base/core/namespaces/pixel-secrets
 - ../../../../base/core/namespaces/smartoffice
 - ../../../../base/core/namespaces/rbo-builder
+- ../../../../base/core/namespaces/examples-openshift-pub
 - ../../../../base/core/namespaces/thoth-test-core
 - ../../../../base/operators.coreos.com/operatorgroups/openshift-cnv-rn5jf
 - ../../../../base/operators.coreos.com/operatorgroups/openshift-local-storage

--- a/kfdefs/overlays/moc/smaug/opf-jupyterhub/alerts.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-jupyterhub/alerts.yaml
@@ -26,3 +26,53 @@ spec:
             < 0.1
           labels:
             severity: critical
+    - name: SLOs-probe_success
+      rules:
+        - alert: RHODS Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
+            summary: RHODS Route Error Burn Rate
+          expr: |
+            sum(probe_success:burnrate5m{instance=~"jupyterhub"}) by (instance) > (14.40 * (1-0.98000))
+            and
+            sum(probe_success:burnrate1h{instance=~"jupyterhub"}) by (instance) > (14.40 * (1-0.98000))
+          for: 2m
+          labels:
+            severity: critical
+        - alert: RHODS Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
+            summary: RHODS Route Error Burn Rate
+          expr: |
+            sum(probe_success:burnrate30m{instance=~"jupyterhub"}) by (instance) > (6.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate6h{instance=~"jupyterhub"}) by (instance) > (6.00 * (1-0.98000))
+          for: 15m
+          labels:
+            severity: critical
+        - alert: RHODS Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
+            summary: RHODS Route Error Burn Rate
+          expr: |
+            sum(probe_success:burnrate2h{instance=~"jupyterhub"}) by (instance) > (3.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate1d{instance=~"jupyterhub"}) by (instance) > (3.00 * (1-0.98000))
+          for: 1h
+          labels:
+            severity: warning
+        - alert: RHODS Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
+            summary: RHODS Route Error Burn Rate
+          expr: |
+            sum(probe_success:burnrate6h{instance=~"jupyterhub"}) by (instance) > (1.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate3d{instance=~"jupyterhub"}) by (instance) > (1.00 * (1-0.98000))
+          for: 3h
+          labels:
+            severity: warning


### PR DESCRIPTION
Introducing the burn rate based alerts for Jupyter hub in the Smaug Cluster. Related: https://github.com/operate-first/operations/issues/444

P.S This will work once the service monitor code is deployed. Thanks!

/cc @4n4nd 