### PR TITLE
Adding Probe Success burn rate based Alerts for JupyterHub in Smaug

### DIFF
--- a/kfdefs/overlays/moc/smaug/opf-jupyterhub/alerts.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-jupyterhub/alerts.yaml
@@ -26,3 +26,53 @@ spec:
             < 0.1
           labels:
             severity: critical
+    - name: SLOs-probe_success
+      rules:
+        - alert: RHODS Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
+            summary: RHODS Route Error Burn Rate
+          expr: |
+            sum(probe_success:burnrate5m{instance=~"jupyterhub"}) by (instance) > (14.40 * (1-0.98000))
+            and
+            sum(probe_success:burnrate1h{instance=~"jupyterhub"}) by (instance) > (14.40 * (1-0.98000))
+          for: 2m
+          labels:
+            severity: critical
+        - alert: RHODS Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
+            summary: RHODS Route Error Burn Rate
+          expr: |
+            sum(probe_success:burnrate30m{instance=~"jupyterhub"}) by (instance) > (6.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate6h{instance=~"jupyterhub"}) by (instance) > (6.00 * (1-0.98000))
+          for: 15m
+          labels:
+            severity: critical
+        - alert: RHODS Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
+            summary: RHODS Route Error Burn Rate
+          expr: |
+            sum(probe_success:burnrate2h{instance=~"jupyterhub"}) by (instance) > (3.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate1d{instance=~"jupyterhub"}) by (instance) > (3.00 * (1-0.98000))
+          for: 1h
+          labels:
+            severity: warning
+        - alert: RHODS Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
+            summary: RHODS Route Error Burn Rate
+          expr: |
+            sum(probe_success:burnrate6h{instance=~"jupyterhub"}) by (instance) > (1.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate3d{instance=~"jupyterhub"}) by (instance) > (1.00 * (1-0.98000))
+          for: 3h
+          labels:
+            severity: warning


### PR DESCRIPTION
Introducing the burn rate based alerts for Jupyter hub in the Smaug Cluster. Related: https://github.com/operate-first/operations/issues/444

P.S This should work once the service monitor code  ( in this PR: https://github.com/operate-first/apps/pull/1727) is deployed. Thanks!



/cc @4n4nd 