### PR TITLE
Update jupyterhub kfdef to ODH v1.1.2 in osc-cl1

### DIFF
--- a/kfdefs/overlays/osc/osc-cl1/jupyterhub/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/jupyterhub/kfdef.yaml
@@ -14,6 +14,8 @@ spec:
       name: odh-common
     - kustomizeConfig:
         parameters:
+          - name: notebook_destination
+            value: "odh-jupyterhub"
           - name: s3_endpoint_url
             value: s3.odh.com
         repoRef:
@@ -34,5 +36,5 @@ spec:
       name: radanalyticsio-spark-cluster
   repos:
     - name: manifests
-      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl1-v1.1.0
+      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl1-v1.1.2
   version: v1.1.0


### PR DESCRIPTION
This change will update the Jupyterhub kfdef to point to 'operate-first/odh-manifests' branch 'osc-cl1-v1.1.2' which will bump ODH version.

Related to: https://github.com/open-services-group/devsecops/issues/9
Related to: https://github.com/operate-first/apps/pull/1723

holding for `operate-first/odh-manifests` branch `osc-cl1-v1.1.2` being created.
/hold