### PR TITLE
Update seldon kfdef to odh 1.1.2 in osc-cl1

### DIFF
--- a/kfdefs/overlays/osc/osc-cl1/seldon/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/seldon/kfdef.yaml
@@ -20,5 +20,5 @@ spec:
       name: odhseldon
   repos:
     - name: manifests
-      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl1-v1.1.0
+      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl1-v1.1.2
   version: v1.1.0


### PR DESCRIPTION
Related to: https://github.com/open-services-group/devsecops/issues/9
Related to: https://github.com/operate-first/apps/pull/1724

Holding for `operate-first/odh-manifests` branch `osc-cl1-v1.1.2` to exist.
/hold