### PR TITLE
Adding recording rules to blackbox exporter and adding more services to service monitor in blackbox

### DIFF
--- a/grafana/overlays/moc/smaug/blackbox-exporter/recording-rules.yaml
+++ b/grafana/overlays/moc/smaug/blackbox-exporter/recording-rules.yaml
@@ -1,0 +1,29 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: recording-rules
+spec:
+  groups:
+    - name: SLOs-probe_success
+      rules:
+      - expr: |
+          1 - avg_over_time(probe_success[1d])
+        record: probe_success:burnrate1d
+      - expr: |
+          1 - avg_over_time(probe_success[1h])
+        record: probe_success:burnrate1h
+      - expr: |
+          1 - avg_over_time(probe_success[2h])
+        record: probe_success:burnrate2h
+      - expr: |
+          1 - avg_over_time(probe_success[30m])
+        record: probe_success:burnrate30m
+      - expr: |
+          1 - avg_over_time(probe_success[3d])
+        record: probe_success:burnrate3d
+      - expr: |
+          1 - avg_over_time(probe_success[5m])
+        record: probe_success:burnrate5m
+      - expr: |
+          1 - avg_over_time(probe_success[6h])
+        record: probe_success:burnrate6h

--- a/grafana/overlays/moc/smaug/blackbox-exporter/service-monitor.yaml
+++ b/grafana/overlays/moc/smaug/blackbox-exporter/service-monitor.yaml
@@ -4,7 +4,7 @@ metadata:
   name: blackbox-service-monitor
 spec:
   endpoints:
-    - interval: 30s
+    - interval: 60s
       metricRelabelings:
         - sourceLabels:
             - __address__
@@ -21,6 +21,75 @@ spec:
           - 'https://jupyterhub-opf-jupyterhub.apps.smaug.na.operate-first.cloud/'
       path: /probe
       targetPort: 9115
+    - interval: 60s
+      metricRelabelings:
+        - sourceLabels:
+            - __address__
+          targetLabel: __param_target
+        - sourceLabels:
+            - __param_target
+          targetLabel: instance
+        - replacement: 'https://www.operate-first.cloud/'
+          targetLabel: target
+      params:
+        module:
+          - http_2xx
+        target:
+          - 'https://www.operate-first.cloud/'
+      path: /probe
+      targetPort: 9115
+    - interval: 60s
+      metricRelabelings:
+        - sourceLabels:
+            - __address__
+          targetLabel: __param_target
+        - sourceLabels:
+            - __param_target
+          targetLabel: instance
+        - replacement: 'https://thanos-query-frontend-opf-observatorium.apps.smaug.na.operate-first.cloud/'
+          targetLabel: target
+      params:
+        module:
+          - http_2xx
+        target:
+          - 'https://thanos-query-frontend-opf-observatorium.apps.smaug.na.operate-first.cloud/'
+      path: /probe
+      targetPort: 9115
+    - interval: 60s
+      metricRelabelings:
+        - sourceLabels:
+            - __address__
+          targetLabel: __param_target
+        - sourceLabels:
+            - __param_target
+          targetLabel: instance
+        - replacement: 'https://trino.operate-first.cloud/'
+          targetLabel: target
+      params:
+        module:
+          - http_2xx
+        target:
+          - 'https://trino.operate-first.cloud/'
+      path: /probe
+      targetPort: 9115
+    - interval: 60s
+      metricRelabelings:
+        - sourceLabels:
+            - __address__
+          targetLabel: __param_target
+        - sourceLabels:
+            - __param_target
+          targetLabel: instance
+        - replacement: 'http://cloudbeaver-opf-trino.apps.smaug.na.operate-first.cloud/'
+          targetLabel: target
+      params:
+        module:
+          - http_2xx
+        target:
+          - 'http://cloudbeaver-opf-trino.apps.smaug.na.operate-first.cloud/'
+      path: /probe
+      targetPort: 9115
+  selector: {}
   namespaceSelector:
     matchNames:
       - opf-monitoring


### PR DESCRIPTION
Adding operate first, thanos, trino, cloudbeaver to the service monitor to check the liveness probe with the help of blackbox exporter. Also, adding the recording rules for different periods of time (1h, 2h, and so on). Related to this issue: https://github.com/operate-first/operations/issues/444 and https://github.com/operate-first/apps/