### PR TITLE
[grafana] Add the pulp-metrics dashboard

### DIFF
--- a/grafana/overlays/moc/smaug/dashboards/kustomization.yaml
+++ b/grafana/overlays/moc/smaug/dashboards/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - operate-first
   - prometheus
   - prometheus-anomaly-detector
+  - pulp
   - thanos
   - thoth-station
   - kubeflow

--- a/grafana/overlays/moc/smaug/dashboards/pulp/kustomization.yaml
+++ b/grafana/overlays/moc/smaug/dashboards/pulp/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pulp-metrics.yaml

--- a/grafana/overlays/moc/smaug/dashboards/pulp/pulp-metrics.yaml
+++ b/grafana/overlays/moc/smaug/dashboards/pulp/pulp-metrics.yaml
@@ -1,0 +1,10 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  labels:
+    version: v1
+    app: grafana
+  name: pulp-metrics
+spec:
+  customFolderName: Pulp
+  url: https://raw.githubusercontent.com/thoth-station/thoth-application/master/grafana-dashboard/base/pulp-metrics.json


### PR DESCRIPTION
This is to add a `GrafanaDashboard` CR for the pulp metrics dashboard.

I was looking at https://github.com/thoth-station/pulp-metrics-exporter/issues/17#issuecomment-1031244059 and could not find the dashboard that is mentioned in that comment.

Looking at the instructions on https://github.com/thoth-station/thoth-application/tree/master/grafana-dashboard#create-new-dashboards I believe that steps 1 and 2 of dashboard creation (i.e. create a JSON file for the dashboard) were implemented in https://github.com/thoth-station/thoth-application/pull/2326, but step 3 (the grafana CR) is still missing. This PR is to add that.

I am not fully sure of the proper location for the dashboard, or if I missed something else.