### PR TITLE
Update ray image with thoth-station org images

### DIFF
--- a/kfdefs/base/jupyterhub/notebook-images/ray-ml-notebook.yaml
+++ b/kfdefs/base/jupyterhub/notebook-images/ray-ml-notebook.yaml
@@ -13,9 +13,9 @@ spec:
   tags:
     # This ray integration is being provided on an experimental basis
     - annotations:
-        openshift.io/imported-from: quay.io/erikerlandson/ray-ml-notebook
+        openshift.io/imported-from: quay.io/thoth-station/s2i-ray-ml-notebook
       name: experimental
       from:
         kind: DockerImage
         # can rebuild with newer nightly SHAs periodically
-        name: 'quay.io/erikerlandson/ray-ml-notebook:py-3.8-ray-1.4.0'
+        name: 'quay.io/thoth-station/s2i-ray-ml-notebook:v0.1.0'

--- a/kfdefs/base/jupyterhub/ray-odh-integration/ray-ml-node-imagestream.yaml
+++ b/kfdefs/base/jupyterhub/ray-odh-integration/ray-ml-node-imagestream.yaml
@@ -11,4 +11,4 @@ spec:
       from:
         kind: DockerImage
         # can rebuild with newer nightly SHAs periodically
-        name: 'quay.io/erikerlandson/ray-ml-ubi:py-3.8-ray-1.4.0'
+        name: 'quay.io/thoth-station/ray-ml-worker:v0.1.1'

--- a/kfdefs/base/jupyterhub/ray-odh-integration/ray-operator-imagestream.yaml
+++ b/kfdefs/base/jupyterhub/ray-odh-integration/ray-operator-imagestream.yaml
@@ -10,4 +10,4 @@ spec:
       from:
         kind: DockerImage
         # can rebuild with newer nightly SHAs periodically
-        name: 'quay.io/erikerlandson/ray-operator-ubi:py-3.8-ray-1.4.0'
+        name: 'quay.io/thoth-station/ray-operator:v0.1.1'


### PR DESCRIPTION
Update ray image with thoth-station org images
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Related-to: 
https://github.com/operate-first/support/issues/102
https://github.com/thoth-station/core/issues/311
https://github.com/orgs/thoth-station/projects/37

This would upgrade the ray images with thoth-station images.