### PR TITLE
Deploy ray operator and images on smaug jupyterhub

### DIFF
--- a/kfdefs/overlays/moc/smaug/opf-jupyterhub/kustomization.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-jupyterhub/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: opf-jupyterhub
 resources:
   - ../../../../base/jupyterhub
+  - ../../../../base/jupyterhub/ray-odh-integration
   - ./pvcs/
   - alerts.yaml
 patchesJson6902:


### PR DESCRIPTION
Deploy ray operator and images on smaug jupyterhub
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Related-to:
https://github.com/operate-first/support/issues/102
https://github.com/thoth-station/core/issues/311
https://github.com/thoth-station/core/issues/372
https://github.com/orgs/thoth-station/projects/37

This would get ray operator and image get deployed on smaug jupyterhub. 