### PR TITLE
Remove highlight-text fragment from docs link

### DIFF
--- a/cluster-scope/base/core/namespaces/acme-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/acme-operator/namespace.yaml
@@ -7,6 +7,6 @@ metadata:
     openshift.io/requester: operate-first
     op1st/project-owner: operate-first
     op1st/onboarding-issue: "https://github.com/operate-first/support/issues/237"
-    op1st/docs: "https://www.operate-first.cloud/apps/content/acme/README.html?highlight=acme"
+    op1st/docs: "https://www.operate-first.cloud/apps/content/acme/README.html"
   name: acme-operator
 spec: {}


### PR DESCRIPTION
This PR is a quick fix to recent PR #1687 
The `op1st/docs` link for acme-operator had a scroll to [text fragment](https://chromestatus.com/feature/4733392803332096) attached to it. This PR removes that fragment
## Resolves Comment:
https://github.com/operate-first/apps/pull/1687#discussion_r829198891