### PR TITLE
Add cuda buildchain to osc-cl2 jupyterhub.

### DIFF
--- a/kfdefs/overlays/osc/osc-cl2/jupyterhub/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/jupyterhub/kfdef.yaml
@@ -25,6 +25,7 @@ spec:
     - kustomizeConfig:
         overlays:
           - additional
+          - cuda-11.0.3
         repoRef:
           name: manifests
           path: jupyterhub/notebook-images


### PR DESCRIPTION
This change will instruct ODH on osc-cl2 to intiate cuda image builds
which will produce GPU enabled Jupyterhub images, and display them in
the JH spawner.