### PR TITLE
Fix the execution directories for ray operator and node

### DIFF
--- a/kfdefs/base/jupyterhub/ray-odh-integration/ray-cluster-template-cm.yaml
+++ b/kfdefs/base/jupyterhub/ray-odh-integration/ray-cluster-template-cm.yaml
@@ -49,7 +49,7 @@ data:
               # defining HOME is part of a workaround for:
               # https://github.com/ray-project/ray/issues/14155
               - name: HOME
-                value: '/opt'
+                value: '/home'
               volumeMounts:
               - mountPath: /dev/shm
                 name: dshm
@@ -91,7 +91,7 @@ data:
               args: ["trap : TERM INT; sleep infinity & wait;"]
               env:
               - name: HOME
-                value: '/opt'
+                value: '/home'
               volumeMounts:
               - mountPath: /dev/shm
                 name: dshm
@@ -105,12 +105,12 @@ data:
       # Commands to start Ray on the head node. You don't need to change this.
       # Note dashboard-host is set to 0.0.0.0 so that Kubernetes can port forward.
       headStartRayCommands:
-          - cd /opt/ray; pipenv run ray stop
-          - ulimit -n 65536; cd /opt/ray; pipenv run ray start --head --no-monitor --port=6379 --object-manager-port=8076 --dashboard-host=0.0.0.0
+          - cd /home/ray; pipenv run ray stop
+          - ulimit -n 65536; cd /home/ray; pipenv run ray start --head --no-monitor --port=6379 --object-manager-port=8076 --dashboard-host=0.0.0.0
       # Commands to start Ray on worker nodes. You don't need to change this.
       workerStartRayCommands:
-          - cd /opt/ray; pipenv run ray stop
-          - ulimit -n 65536; cd /opt/ray; pipenv run ray start --address=$RAY_HEAD_IP:6379 --object-manager-port=8076
+          - cd /home/ray; pipenv run ray stop
+          - ulimit -n 65536; cd /home/ray; pipenv run ray start --address=$RAY_HEAD_IP:6379 --object-manager-port=8076
   rayDashboardRouteTemplate: |
     kind: Route
     apiVersion: route.openshift.io/v1

--- a/kfdefs/base/jupyterhub/ray-odh-integration/ray-operator-deployment.yaml
+++ b/kfdefs/base/jupyterhub/ray-odh-integration/ray-operator-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         - name: ray-operator
           imagePullPolicy: Always
           image: 'quay.io/thoth-station/ray-operator:v0.1.1'
-          command: ['/bin/bash', '-c', '--', 'cd /opt/ray && pipenv run ray-operator']
+          command: ['/bin/bash', '-c', '--', 'cd /home/ray && pipenv run ray-operator']
           env:
             - name: RAY_CONFIG_DIR
               value: '/tmp/ray_cluster_configs'


### PR DESCRIPTION
Fix the execution directories for ray operator and node
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Fixes:  ![entry_dir_ray](https://user-images.githubusercontent.com/14028058/158985868-79b4f7f1-fe4f-4e64-aa8a-ff22b1a5341a.png)


Related-to:
https://github.com/operate-first/support/issues/102
https://github.com/thoth-station/core/issues/311
https://github.com/thoth-station/core/issues/372
https://github.com/orgs/thoth-station/projects/37