### PR TITLE
Fix the version typo for pulp backup

### DIFF
--- a/pulp/overlays/moc/smaug/opf-pulp-backup.yaml
+++ b/pulp/overlays/moc/smaug/opf-pulp-backup.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: pulp.pulpproject.org/v1beta
+apiVersion: pulp.pulpproject.org/v1beta1
 kind: PulpBackup
 metadata:
   name: opf-pulp-backup


### PR DESCRIPTION
Fix the version typo for pulp backup
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Related-to: https://github.com/operate-first/support/issues/525