### PR TITLE
Include pulp backup and restore to be deployed via argocd

### DIFF
--- a/argocd/overlays/moc-infra/projects/global_project.yaml
+++ b/argocd/overlays/moc-infra/projects/global_project.yaml
@@ -164,6 +164,10 @@ spec:
       kind: PodDisruptionBudget
     - group: pulp.pulpproject.org
       kind: Pulp
+    - group: pulp.pulpproject.org
+      kind: PulpBackup
+    - group: pulp.pulpproject.org
+      kind: PulpRestore
     - group: quota.openshift.io
       kind: AppliedClusterResourceQuota
     - group: rbac.authorization.k8s.io


### PR DESCRIPTION
Include pulp backup and restore to be deployed via argocd
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>



Fixes: 
![pulp-backup](https://user-images.githubusercontent.com/14028058/159027596-059bbcfe-170e-4eb6-8300-4905865be74b.png)

Related-to: https://github.com/operate-first/support/issues/525