### PR TITLE
Remove invalid argocd cluster secret.

### DIFF
--- a/argocd/overlays/moc-infra/secrets/clusters/secret-generator.yaml
+++ b/argocd/overlays/moc-infra/secrets/clusters/secret-generator.yaml
@@ -5,4 +5,3 @@ metadata:
 files:
 - secrets/clusters/moc-infra.enc.yaml
 - secrets/clusters/octo-gohan.enc.yaml
-- secrets/clusters/octo-summit-cl1.enc.yaml


### PR DESCRIPTION
The secret is breaking the build, this is a quick fix. We should update the secret if we still need it and re-encrypt.