### PR TITLE
Remove spark operator from osc-cl2 odh.

### DIFF
--- a/kfdefs/overlays/osc/osc-cl2/jupyterhub/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/jupyterhub/kfdef.yaml
@@ -30,11 +30,6 @@ spec:
           name: manifests
           path: jupyterhub/notebook-images
       name: notebook-images
-    - kustomizeConfig:
-        repoRef:
-          name: manifests
-          path: radanalyticsio/spark/cluster
-      name: radanalyticsio-spark-cluster
   repos:
     - name: manifests
       uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl2-v1.1.2


### PR DESCRIPTION
Spark operator subscribed to via ODH is not compatible with OCP 4.9

As such it's blocking the upgrade to 4.9 for osc cluster from 4.8. It
does not seem like anyone is using this operator, so we are removing it.