### PR TITLE
Remove unneeded trino connector property in osc-cl2.

### DIFF
--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/osc_datacommons_dev.properties
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/osc_datacommons_dev.properties
@@ -9,7 +9,6 @@ hive.s3.path-style-access=true
 hive.s3.staging-directory=/tmp
 hive.s3.ssl.enabled=false
 hive.s3.sse.enabled=false
-hive.allow-drop-table=true
 hive.parquet.use-column-names=true
 hive.recursive-directories=true
 hive.non-managed-table-writes-enabled=true


### PR DESCRIPTION
Not needed for iceberg connector (causes deployment to fail).