### PR TITLE
Add myself to the microshift group

### DIFF
--- a/cluster-scope/base/user.openshift.io/groups/octo-ushift-dev/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/octo-ushift-dev/group.yaml
@@ -9,3 +9,4 @@ users:
     - screeley44
     - michaelclifford
     - treeinrandomforest
+    - codificat


### PR DESCRIPTION
This PR is to add myself to the `octo-ushift-dev` group.

The main goal is to get access to the resources managed through ArgoCD for the `octo-ushift` project.

Context: I was trying to troubleshoot current sync problems between Argo and the microshift clusters involved in the octo summit demo, and I am missing part of the picture without that access.