### PR TITLE
pointing kfdefs to odh-manifests migration

### DIFF
--- a/kfdefs/overlays/moc/smaug/opf-dashboard/kfdef.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-dashboard/kfdef.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  annotations:
+    kfctl.kubeflow.io/force-delete: "false"
+  name: opendatahub
+spec:
+  applications:
+    - kustomizeConfig:
+        overlays:
+          - custom-image
+          - cluster-role
+        repoRef:
+          name: manifests
+          path: odh-dashboard
+      name: odh-dashboard
+  repos:
+    - name: manifests
+      uri: "https://github.com/operate-first/odh-manifests/tarball/smaug-v1.1.1"
+  version: v1.1.1

--- a/kfdefs/overlays/moc/smaug/opf-dashboard/kustomization.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-dashboard/kustomization.yaml
@@ -4,5 +4,5 @@ kind: Kustomization
 namespace: opf-dashboard
 
 resources:
-  - ../../../../base/dashboard
+  - kfdef.yaml
   - route.yaml

--- a/kfdefs/overlays/moc/smaug/opf-jupyterhub/kfdef.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-jupyterhub/kfdef.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  annotations:
+    kfctl.kubeflow.io/force-delete: "false"
+  name: opendatahub
+spec:
+  applications:
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-common
+      name: odh-common
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: jupyterhub/jupyterhub
+      name: jupyterhub
+    - kustomizeConfig:
+        overlays: []
+        parameters:
+        - name: notebook_destination
+          value: opf-jupyterhub
+        - name: s3_endpoint_url
+          value: s3.odh.com
+      name: notebook-images
+  repos:
+    - name: manifests
+      uri: "https://github.com/operate-first/odh-manifests/tarball/smaug-v1.1.1"
+  version: v1.1.1

--- a/kfdefs/overlays/moc/smaug/opf-jupyterhub/kustomization.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-jupyterhub/kustomization.yaml
@@ -2,28 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: opf-jupyterhub
 resources:
-  - ../../../../base/jupyterhub
   - ../../../../base/jupyterhub/ray-odh-integration
+  - ../../../../base/jupyterhub/notebook-images
   - ./pvcs/
   - alerts.yaml
-patchesJson6902:
-  - patch: |
-      - op: add
-        path: /spec/applications/-
-        value:
-          kustomizeConfig:
-            overlays: []
-            parameters:
-              - name: notebook_destination
-                value: "opf-jupyterhub"
-              - name: s3_endpoint_url
-                value: s3.odh.com
-            repoRef:
-              name: opf-manifests
-              path: odh-manifests/smaug/jupyterhub
-          name: jupyterhub
-    target:
-      group: kfdef.apps.kubeflow.org
-      kind: KfDef
-      name: opendatahub
-      version: v1
+  - kfdef.yaml
+  - servicemonitor.yaml

--- a/kfdefs/overlays/moc/smaug/opf-jupyterhub/servicemonitor.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-jupyterhub/servicemonitor.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    team: opendatahub
+  name: opf-jupyterhub-servicemonitor
+spec:
+  endpoints:
+    - port: 8080-tcp        # Jupyterhub
+      path: "/metrics"
+  selector: {}
+  namespaceSelector:
+    matchNames:
+      - opf-jupyterhub

--- a/kfdefs/overlays/moc/smaug/opf-seldon/kfdef.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-seldon/kfdef.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  annotations:
+    kfctl.kubeflow.io/force-delete: "false"
+  name: opendatahub
+spec:
+  applications:
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-common
+      name: odh-common
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odhseldon/cluster
+      name: odhseldon
+  repos:
+    - name: manifests
+      uri: https://github.com/operate-first/odh-manifests/tarball/smaug-v1.1.1
+  version: v1.1.1

--- a/kfdefs/overlays/moc/smaug/opf-seldon/kustomization.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-seldon/kustomization.yaml
@@ -4,27 +4,4 @@ kind: Kustomization
 namespace: opf-seldon
 
 resources:
-  - ../../../../base/seldon
-
-# TODO: Remove this patch and associated files once this is merged:
-# https://github.com/opendatahub-io/odh-manifests/pull/521
-patchesJson6902:
-  - patch: |
-      - op: add
-        path: /spec/applications/-
-        value:
-          kustomizeConfig:
-            repoRef:
-              name: opf
-              path: odh-manifests/smaug/odhseldon
-          name: odhseldon
-      - op: add
-        path: /spec/repos/-
-        value:
-          name: opf
-          uri: https://github.com/operate-first/apps/tarball/master
-    target:
-      group: kfdef.apps.kubeflow.org
-      kind: KfDef
-      name: opendatahub
-      version: v1
+  - kfdef.yaml

--- a/kfdefs/overlays/moc/smaug/opf-superset/kfdef.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-superset/kfdef.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  annotations:
+    kfctl.kubeflow.io/force-delete: "false"
+  name: opendatahub
+spec:
+  applications:
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-common
+      name: odh-common
+    - kustomizeConfig:
+        parameters:
+        # Note: The admin username is admin
+        - name: superset_memory_requests
+          value: 6Gi
+        - name: superset_memory_limits
+          value: 8Gi
+        - name: superset_secret
+          value: superset-custom
+        - name: superset_db_secret
+          value: superset-db-custom
+        repoRef:
+          name: manifests
+          path: superset
+      name: superset
+  repos:
+    - name: manifests
+      uri: "https://github.com/operate-first/odh-manifests/tarball/smaug-v1.1.1"
+  version: v1.1.1

--- a/kfdefs/overlays/moc/smaug/opf-superset/kustomization.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-superset/kustomization.yaml
@@ -4,35 +4,5 @@ kind: Kustomization
 namespace: opf-superset
 
 resources:
-  - ../../../../base/superset
+  - kfdef.yaml
   - secrets
-
-patchesJson6902:
-  - patch: |
-      - op: add
-        path: /spec/applications/-
-        value:
-          kustomizeConfig:
-            parameters:
-              - name: superset_memory_requests
-                value: "6Gi"
-              - name: superset_memory_limits
-                value: "8Gi"
-              - name: superset_secret
-                value: "superset-custom"
-              - name: superset_db_secret
-                value: "superset-db-custom"
-            repoRef:
-              name: opf
-              path: odh-manifests/smaug/superset
-          name: superset
-      - op: add
-        path: /spec/repos/-
-        value:
-          name: opf
-          uri: https://github.com/operate-first/apps/tarball/master
-    target:
-      group: kfdef.apps.kubeflow.org
-      kind: KfDef
-      name: opendatahub
-      version: v1

--- a/kfdefs/overlays/moc/smaug/opf-trino/kfdef.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-trino/kfdef.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  annotations:
+    kfctl.kubeflow.io/force-delete: "false"
+  name: opendatahub
+spec:
+  applications:
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-common
+      name: odh-common
+    - kustomizeConfig:
+        parameters:
+        - name: trino_memory_request
+          value: 8Gi
+        - name: trino_memory_limit
+          value: 16Gi
+        - name: trino_cpu_request
+          value: "4"
+        - name: trino_cpu_limit
+          value: "8"
+        repoRef:
+          name: manifests
+          path: trino
+      name: trino
+  repos:
+    - name: manifests
+      uri: "https://github.com/operate-first/odh-manifests/tarball/smaug-v1.1.1"
+  version: v1.1.1

--- a/kfdefs/overlays/moc/smaug/opf-trino/kustomization.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-trino/kustomization.yaml
@@ -3,40 +3,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: opf-trino
 resources:
-  - ../../../../base/trino
   - configs
   - hive-metastores
+  - kfdef.yaml
   - obcs
   - secrets
   - vpa
 generatorOptions:
   disableNameSuffixHash: true
-patchesJson6902:
-  - patch: |
-      - op: add
-        path: /spec/applications/-
-        value:
-          kustomizeConfig:
-            parameters:
-              - name: trino_memory_request
-                value: "8Gi"
-              - name: trino_memory_limit
-                value: "16Gi"
-              - name: trino_cpu_request
-                value: "4"
-              - name: trino_cpu_limit
-                value: "8"
-            repoRef:
-              name: opf
-              path: odh-manifests/smaug/trino
-          name: trino
-      - op: add
-        path: /spec/repos/-
-        value:
-          name: opf
-          uri: https://github.com/operate-first/apps/tarball/master
-    target:
-      group: kfdef.apps.kubeflow.org
-      kind: KfDef
-      name: opendatahub
-      version: v1


### PR DESCRIPTION
Removed old kfdefs for smaug, as they have been migrated instead to operate-first/odh-manifests. 
Updating the kfdef overlay for smaug to include the kfdefs themselves and any supporting manifests.
Modifying the kfdefs directly rather than patching them with kustomization now that they live in the same overlay.

Related to: https://github.com/operate-first/odh-manifests/pull/7
Addresses: #1745 

/cc @HumairAK @4n4nd 
