### PR TITLE
Include jim into the octo-ushift-dev group

### DIFF
--- a/cluster-scope/base/user.openshift.io/groups/octo-ushift-dev/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/octo-ushift-dev/group.yaml
@@ -3,10 +3,11 @@ kind: Group
 metadata:
     name: octo-ushift-dev
 users:
-    - fzdarsky
+    - codificat
     - cooktheryan
+    - fzdarsky
+    - jimcadden
+    - michaelclifford
     - oglok
     - screeley44
-    - michaelclifford
     - treeinrandomforest
-    - codificat


### PR DESCRIPTION
Include jim into the octo-ushift-dev group
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


- Incuded jim into the octo group
- Re-ordered based on alphabetical order

Fixes: `Failed to authenticate: openshift: user "jimcadden" is not in any of the required groups`