### PR TITLE
Add oc pipelines as a bundle to os-cl2.

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/openshift-pipelines-operator-rh/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/openshift-pipelines-operator-rh/subscription.yaml
@@ -4,7 +4,7 @@ kind: Subscription
 metadata:
   name: openshift-pipelines-operator-rh
 spec:
-  channel: DEFINED_IN_OVERLAY
+  channel: stable
   installPlanApproval: Automatic
   name: openshift-pipelines-operator-rh
   source: redhat-operators

--- a/cluster-scope/bundles/openshift-pipelines/kustomization.yaml
+++ b/cluster-scope/bundles/openshift-pipelines/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base/core/namespaces/openshift-pipelines
+  - ../../base/operators.coreos.com/subscriptions/openshift-pipelines-operator-rh
+  - ../../base/core/configmaps/openshift-pipelines-feature-flags

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -10,7 +10,6 @@ patchesStrategicMerge:
 - subscriptions/cluster-logging-operator_patch.yaml
 - subscriptions/nfd_patch.yaml
 - subscriptions/vpa_patch.yaml
-- subscriptions/openshift-pipelines-operator-rh_patch.yaml
 - subscriptions/kubevirt-hyperconverged_patch.yaml
 resources:
 - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/extensions.dashboard.tekton.dev
@@ -18,7 +17,6 @@ resources:
 - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/reports.batch.curator.openshift.io
 - ../../../../base/config.openshift.io/oauths/cluster
 - ../../../../base/core/configmaps/cluster-monitoring-config
-- ../../../../base/core/configmaps/openshift-pipelines-feature-flags
 - ../../../../base/core/configmaps/user-workload-monitoring-config
 - ../../../../base/core/namespaces/ai-services-thanos-grpc
 - ../../../../base/core/namespaces/aicoe-meteor
@@ -39,7 +37,6 @@ resources:
 - ../../../../base/core/namespaces/openshift-cnv
 - ../../../../base/core/namespaces/openshift-logging
 - ../../../../base/core/namespaces/openshift-operators
-- ../../../../base/core/namespaces/openshift-pipelines
 - ../../../../base/core/namespaces/openshift-vertical-pod-autoscaler
 - ../../../../base/core/namespaces/opf-alertreceiver
 - ../../../../base/core/namespaces/opf-argo
@@ -95,7 +92,6 @@ resources:
 - ../../../../base/operators.coreos.com/subscriptions/cluster-logging
 - ../../../../base/operators.coreos.com/subscriptions/koku-metrics-operator
 - ../../../../base/operators.coreos.com/subscriptions/kubevirt-hyperconverged
-- ../../../../base/operators.coreos.com/subscriptions/openshift-pipelines-operator-rh
 - ../../../../base/operators.coreos.com/subscriptions/opf-grafana
 - ../../../../base/operators.coreos.com/subscriptions/ovms-operator
 - ../../../../base/operators.coreos.com/subscriptions/pulp-operator
@@ -127,6 +123,7 @@ resources:
 - ../../../../bundles/kfp-tekton
 - ../../../../bundles/meteor-operator
 - ../../../../bundles/nfd
+- ../../../../bundles/openshift-pipelines
 - ../../../../bundles/reloader
 - ../../../../bundles/seraph
 - ../../../../bundles/tekton-chains

--- a/cluster-scope/overlays/prod/moc/smaug/subscriptions/openshift-pipelines-operator-rh_patch.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/subscriptions/openshift-pipelines-operator-rh_patch.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: openshift-pipelines-operator-rh
-  namespace: openshift-operators
-spec:
-  # https://docs.openshift.com/container-platform/4.8/cicd/pipelines/installing-pipelines.html#op-installing-pipelines-operator-using-the-cli_installing-pipelines
-  channel: stable

--- a/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
   - ../../../../base/user.openshift.io/groups/odh-admin
   - ../../../../base/user.openshift.io/groups/odh-users
   - ../../../../base/user.openshift.io/groups/seldon-admin
+  - ../../../../bundles/openshift-pipelines
   - apiserver
   - ingresscontroller
   - machinesets


### PR DESCRIPTION
Add oc pipelines to osc-cl2. This commit also bundles the manifests that
currently exist in the base dir and switches to bundle reference in the
smaug cluster as well. No change to live deployment to the smaug cluster
is introduced here. The patch for the subscription was removed since the
channel remains the same for both clusters, it just adds an unecessary
step otherwise.