### PR TITLE
Add kfp-tekton app to osc-cl2.

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/cluster-management/kfp-tekton.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/cluster-management/kfp-tekton.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kfp-tekton
+spec:
+  destination:
+    name: osc-cl2
+    namespace: kubeflow
+  project: operate-first
+  source:
+    path: kfp-tekton/overlays/osc/osc-cl2
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false

--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/cluster-management/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/cluster-management/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - das.yaml
   - dex.yaml
   - kfdefs.yaml
+  - kfp-tekton.yaml

--- a/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../../../base/core/configmaps/user-workload-monitoring-config
   - ../../../../base/core/namespaces/acme-operator
   - ../../../../base/core/namespaces/dex
+  - ../../../../base/core/namespaces/kubeflow
   - ../../../../base/core/namespaces/odh-jupyterhub
   - ../../../../base/core/namespaces/odh-seldon
   - ../../../../base/core/namespaces/odh-superset

--- a/kfp-tekton/overlays/osc/osc-cl2/kustomization.yaml
+++ b/kfp-tekton/overlays/osc/osc-cl2/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+
+resources:
+  - ../../../base
+
+patchesStrategicMerge:
+  - params.yaml
+generators:
+  - secret-generator.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kfp-tekton/overlays/osc/osc-cl2/params.yaml
+++ b/kfp-tekton/overlays/osc/osc-cl2/params.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+data:
+  artifact_secret_name: mlpipeline-ceph-artifact-custom
+kind: ConfigMap
+metadata:
+  name: kfp-tekton-params-config

--- a/kfp-tekton/overlays/osc/osc-cl2/secret-generator.yaml
+++ b/kfp-tekton/overlays/osc/osc-cl2/secret-generator.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: secret-generator
+files:
+  - ./secrets/mlpipeline-ceph-artifact.enc.yaml

--- a/kfp-tekton/overlays/osc/osc-cl2/secrets/mlpipeline-ceph-artifact.enc.yaml
+++ b/kfp-tekton/overlays/osc/osc-cl2/secrets/mlpipeline-ceph-artifact.enc.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    labels:
+        application-crd-id: kubeflow-pipelines
+    name: mlpipeline-ceph-artifact-custom
+    namespace: kubeflow
+stringData:
+    OBJECTSTORECONFIG_HOST: ENC[AES256_GCM,data:yVNPNEodDJzK32O/GpTVjE+63zhc/FiNFmGc/A1Rx/Fl8DP9UBC+VPoi0hju4tqc9XDQceKW,iv:DcpaIpX254m1HUgLEk6L2fuIGvVYx1i6RVdeDiAcN6I=,tag:ra0ndnEXl1x9JWDJJ+4iPw==,type:str]
+    OBJECTSTORECONFIG_PORT: ENC[AES256_GCM,data:qiNk,iv:QlhtX1wT61/YO8FP5oWOaOrwrcN+ileRgu9UB5eIaf0=,tag:09i3zcCb4r2gqpjq9rJ0QA==,type:str]
+    OBJECTSTORECONFIG_SECURE: ENC[AES256_GCM,data:NuxLyg==,iv:dGMc12Yb2n0J8bd8k+eUm9/wejCWhUkBfBd8hJH0VSs=,tag:bwG2rMpLekT9GoiL/jVJdg==,type:str]
+    OBJECTSTORECONFIG_BUCKETNAME: ENC[AES256_GCM,data:2BTbj8zyjQE9XCPsDTpuitnz,iv:s5HGEhtZDBDArojbBubxzbbbviEEFlW0kYbsyChGAwI=,tag:Xl7yUph4bdV+lnovxNm/lA==,type:str]
+    OBJECTSTORECONFIG_ACCESSKEY: ENC[AES256_GCM,data:wovk9jv1decueWTsQuED7HAbg9c=,iv:LzsII5iNA/hkghWk6d2viIm/GWb9+0u8NG2S42VonkI=,tag:sOSRuMfh5G+l+7NlH+2pCQ==,type:str]
+    OBJECTSTORECONFIG_SECRETACCESSKEY: ENC[AES256_GCM,data:pL/T4Jfu3B6aZfO6fxX4PR5HEPJtylcZD/2iTvKjxGkT8G8tXdj+Iw==,iv:qkYY0BxPoDWZCBRIsUbBoeEglo+EsHakHH4djomtDmA=,tag:JKJ9bINOfnST2vwPapD+IA==,type:str]
+    OBJECTSTORECONFIG_PIPELINEPATH: ENC[AES256_GCM,data:OaSnE3skDIamww==,iv:I6Jd3kk1rlLvImVKh1IYwTj9o4TUAe/23OGQGl0SvhQ=,tag:PbaHNTNfhVAH7rkTHsyYbw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2022-03-22T18:19:56Z'
+    mac: ENC[AES256_GCM,data:uFwpPljtYTdPGBPzjg17cgG4/BeYXBJyf2zM+IrP2+UiYoLycnt2IUiCkcV3U8urzCGdYvfpvalSgbCmC04w/akzrjO0lCdWpAaR49Evr8Bkt06VIqgBIm1uMonjIdDSifYhdtjkgve47BD3WXqMpiJxlXGmVmJBSzZxUjPPrRg=,iv:kw7CVM8xEPJDmVs6QuE3LLkkgc+fpbA7rQhBbWAKM88=,tag:5BmhuWtG6ABw3G/bdM6AbA==,type:str]
+    pgp:
+    -   created_at: '2022-03-22T18:19:55Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA9aKBcudqifiARAAldI7UqzUSYiDWaMPS7zTTYXd7lXl2fEv1G+6K9nLnH0T
+            UvZJ+BbiYJ4oNNr+n70sMYFDlES051iEqmL1ekgCJzsQs+okjA1weDBGl0bOkebO
+            u9aDJ/ObgK8oEKy6dBsTVBwB0ylOZ6jNjJD5zw9jZwmYwbU2/o73DDA1GmQDzyqu
+            NwWqkatOJ4iWVXn6dVI/wj2Xy31Fz0wVyMiQhQyW2spLtfPgO07dSWq2U7UdIsUT
+            GT76jsDdzm2x0Rdh6LrQz9Mv0IHS2YCycvNS/Lkb/fXi2OuhnnqCKwqe7S0W35i5
+            JxX0fb+t9KtBNz8M+ekWI5XkdSZ+UoxD/w9jzvEUfa3XDzqE+mIYyQkdNfIGQtzZ
+            Cd/p7qxQsK1ci/IH8m0phaqJEdbBiJ6AT1592gT2pRcaMeEpUOFn+OnFr0gDZGkd
+            YnOxdJhHD3wv7YMqtjwKG7bTnbqhK1W81j5Whz6x+gf+h9U2aE/thZr11AYNiDm4
+            yJoGik2xske2O0V59ZLx8+JfrvFxPlgHfbIeFpHItaVRVbIM9ldYRxwbNeS3Uvcq
+            H/iL9MokDHSZfBjalP4cD4rtmamEi7BJEU4w8GhIUldUZMytFfc/C+8SlYPiNY+1
+            4kWgmMTV8HUnpcfu1ZtDrhTifxYNdGBEWXTO8k23Awwzlq//36tNJfxP761PnpPS
+            4AHktTiupYOh7mC610WbcsOdrOE9XeAA4Lfh+4fg++LAQ46p4FjlM62mwh2F8PhZ
+            ZQNPRYxnQr7FMQiSV9EMCqiVDJa/B2Hgu+SFX8nQejZBCDqkX5IaaIIn4h4ysEbh
+            tMkA
+            =kMdP
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^(users|data|stringData)$
+    version: 3.6.1


### PR DESCRIPTION
This emulates the kfp-tekton deployment from smaug onto osc-cl2.
The bucket being used is one created in the smaug cluster via odf. Once confirmed working we can switch to a more permanent solution. 