### PR TITLE
Add k8s annotations exporter app 

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/emea/balrog/operate-first/k8s-annotations-exporter.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/emea/balrog/operate-first/k8s-annotations-exporter.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: k8s-annotations-exporter
+spec:
+  destination:
+    name: balrog
+    namespace: opf-monitoring
+  project: operate-first
+  source:
+    path: k8s-annotations-exporter/overlays/emea/balrog
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false

--- a/argocd/overlays/moc-infra/applications/envs/emea/balrog/operate-first/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/emea/balrog/operate-first/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - acme-operator.yaml
   - cluster-logging.yaml
+  - k8s-annotations-exporter.yaml

--- a/argocd/overlays/moc-infra/applications/envs/emea/morty/operate-first/k8s-annotations-exporter.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/emea/morty/operate-first/k8s-annotations-exporter.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: k8s-annotations-exporter
+spec:
+  destination:
+    name: morty
+    namespace: opf-monitoring
+  project: operate-first
+  source:
+    path: k8s-annotations-exporter/overlays/emea/morty
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false

--- a/argocd/overlays/moc-infra/applications/envs/emea/morty/operate-first/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/emea/morty/operate-first/kustomization.yaml
@@ -1,7 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-nameSuffix: -morty
-namespace: argocd
 resources:
-- cluster-management
-- operate-first
+- k8s-annotations-exporter.yaml

--- a/argocd/overlays/moc-infra/applications/envs/moc/infra/operate-first/k8s-annotations-exporter.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/infra/operate-first/k8s-annotations-exporter.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: k8s-annotations-exporter
+spec:
+  destination:
+    name: moc-infra
+    namespace: opf-monitoring
+  project: operate-first
+  source:
+    path: k8s-annotations-exporter/overlays/moc/infra
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false

--- a/argocd/overlays/moc-infra/applications/envs/moc/infra/operate-first/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/infra/operate-first/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - acme-operator.yaml
   - cluster-logging.yaml
+  - k8s-annotations-exporter.yaml

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/k8s-annotations-exporter.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/k8s-annotations-exporter.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: k8s-annotations-exporter
+spec:
+  destination:
+    name: smaug
+    namespace: opf-monitoring
+  project: operate-first
+  source:
+    path: k8s-annotations-exporter/overlays/moc/smaug
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - cluster-logging.yaml
   - grafana.yaml
   - jh-idle-culler.yaml
+  - k8s-annotations-exporter.yaml
   - kfp-tekton.yaml
   - meteor-shower.yaml
   - meteor-operator-pipelines.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-reader-k8s-annotations-exporter/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-reader-k8s-annotations-exporter/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: k8s-annotations-exporter
+subjects:
+  - kind: ServiceAccount
+    name: k8s-annotations-exporter
+    namespace: opf-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-reader

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-reader-k8s-annotations-exporter/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/cluster-reader-k8s-annotations-exporter/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrolebinding.yaml

--- a/cluster-scope/overlays/prod/emea/balrog/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/balrog/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
     - ../../../../base/core/configmaps/user-workload-monitoring-config
     - ../../../../base/core/namespaces/openshift-logging
     - ../../../../base/core/namespaces/opf-kafka
+    - ../../../../base/core/namespaces/opf-monitoring
     - ../../../../base/core/namespaces/thoth-amun-api-prod
     - ../../../../base/core/namespaces/thoth-amun-inspection-prod
     - ../../../../base/core/namespaces/thoth-backend-prod
@@ -22,6 +23,7 @@ resources:
     - ../../../../base/operators.coreos.com/subscriptions/cluster-logging
     - ../../../../base/operators.coreos.com/subscriptions/strimzi
     - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-monitoring-view-balrog
+    - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-reader-k8s-annotations-exporter
     - ../../../../base/user.openshift.io/groups/cluster-admins
     - ../../../../bundles/acme-operator
     - machineautoscalers.yaml

--- a/cluster-scope/overlays/prod/emea/morty/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/morty/kustomization.yaml
@@ -31,6 +31,7 @@ resources:
 - ../../../../base/core/namespaces/openshift-local-storage
 - ../../../../base/core/namespaces/openshift-storage
 - ../../../../base/core/namespaces/opf-alertreceiver
+- ../../../../base/core/namespaces/opf-monitoring
 - ../../../../base/core/namespaces/pixel-demo
 - ../../../../base/core/namespaces/pixel-secrets
 - ../../../../base/core/namespaces/rbo-builder
@@ -46,6 +47,7 @@ resources:
 - ../../../../base/operators.coreos.com/subscriptions/odf-operator
 - ../../../../base/operators.coreos.com/subscriptions/openshift-local-storage-operator
 - ../../../../base/operators.coreos.com/subscriptions/openshift-pipelines-operator-rh
+- ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-reader-k8s-annotations-exporter
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/sudoers
 - ../../../../base/user.openshift.io/groups/cluster-admins
 - ../../../../base/user.openshift.io/groups/sudoers

--- a/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - ../../../../base/core/namespaces/openshift-logging
   - ../../../../base/core/namespaces/openshift-nmstate
   - ../../../../base/core/namespaces/opf-alertreceiver
+  - ../../../../base/core/namespaces/opf-monitoring
   - ../../../../base/nmstate.io/nmstates/nmstate
   - ../../../../base/operator.openshift.io/ingresscontrollers/default
   - ../../../../base/operators.coreos.com/operatorgroups/keycloak
@@ -25,6 +26,7 @@ resources:
   - ../../../../base/operators.coreos.com/subscriptions/cluster-logging
   - ../../../../base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator
   - ../../../../base/operators.coreos.com/subscriptions/rhsso-operator
+  - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-reader-k8s-annotations-exporter
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/moc-nfs-democratic-csi-controller-rb
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/moc-nfs-democratic-csi-node-rb
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:admin:osc-cl1

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -100,6 +100,7 @@ resources:
 - ../../../../base/operators.coreos.com/subscriptions/vertical-pod-autoscaler
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-interceptor-opf-ci-pipelines
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-monitoring-view
+- ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-reader-k8s-annotations-exporter
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/jupyterhub-cluster
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/moc-nfs-democratic-csi-controller-rb
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/moc-nfs-democratic-csi-node-rb

--- a/k8s-annotations-exporter/base/deployment.yaml
+++ b/k8s-annotations-exporter/base/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8s-annotations-exporter
+  labels:
+    app: k8s-annotations-exporter
+spec:
+  selector:
+    matchLabels:
+      app: k8s-annotations-exporter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: k8s-annotations-exporter
+    spec:
+      serviceAccountName: k8s-annotations-exporter
+      containers:
+        - name: k8s-annotations-exporter
+          image: quay.io/4n4nd/k8s-annotations-exporter:latest
+          command:
+            - k8s_annotations_exporter
+          args:
+            - '-vv'
+            - '--in-cluster'
+            - '--http-server-port=8000'
+            - '--metrics-refresh-interval=300'
+            - '--resource-api-version=v1'
+            - '--resource-kind=Namespace'
+          resources:
+            limits:
+              cpu: 50m
+              memory: 100Mi
+            requests:
+              cpu: 50m
+              memory: 50Mi
+          ports:
+            - containerPort: 8000
+              name: metrics

--- a/k8s-annotations-exporter/base/kustomization.yaml
+++ b/k8s-annotations-exporter/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+- service.yaml
+- serviceaccount.yaml
+- servicemonitor.yaml

--- a/k8s-annotations-exporter/base/service.yaml
+++ b/k8s-annotations-exporter/base/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8s-annotations-exporter
+  labels:
+    app: k8s-annotations-exporter
+spec:
+  selector:
+    app: k8s-annotations-exporter
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000
+      name: metrics

--- a/k8s-annotations-exporter/base/serviceaccount.yaml
+++ b/k8s-annotations-exporter/base/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8s-annotations-exporter

--- a/k8s-annotations-exporter/base/servicemonitor.yaml
+++ b/k8s-annotations-exporter/base/servicemonitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: k8s-annotations-exporter
+spec:
+  endpoints:
+    - interval: 5m
+      path: /metrics
+      port: metrics
+      scheme: http
+  selector:
+    matchLabels:
+      app: k8s-annotations-exporter
+  namespaceSelector:
+    matchNames:
+      - opf-monitoring

--- a/k8s-annotations-exporter/overlays/emea/balrog/kustomization.yaml
+++ b/k8s-annotations-exporter/overlays/emea/balrog/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base

--- a/k8s-annotations-exporter/overlays/emea/morty/kustomization.yaml
+++ b/k8s-annotations-exporter/overlays/emea/morty/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base

--- a/k8s-annotations-exporter/overlays/moc/infra/kustomization.yaml
+++ b/k8s-annotations-exporter/overlays/moc/infra/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base

--- a/k8s-annotations-exporter/overlays/moc/smaug/kustomization.yaml
+++ b/k8s-annotations-exporter/overlays/moc/smaug/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base


### PR DESCRIPTION
This will deploy the [k8s-annotations-exporter](https://github.com/4n4nd/k8s-annotations-exporter) app on Smaug, Infra, Balrog and Morty clusters.

Resolves https://github.com/operate-first/apps/issues/1780