### PR TITLE
add: Reloader deployment to osc-cl2 cluster

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/cluster-management/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/cluster-management/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - kfdefs.yaml
   - kfp-tekton.yaml
   - pachyderm.yaml
+  - reloader.yaml

--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/cluster-management/reloader.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/cluster-management/reloader.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: reloader
+spec:
+  project: os-climate
+  source:
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+    path: reloader/overlays/osc/osc-cl2
+  destination:
+    name: osc-cl2
+    namespace: reloader
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
@@ -13,13 +13,16 @@ resources:
   - ../../../../base/core/namespaces/odh-trino
   - ../../../../base/core/namespaces/openshift-nfd
   - ../../../../base/core/namespaces/nvidia-gpu-operator
+  - ../../../../base/core/namespaces/reloader
   - ../../../../base/operators.coreos.com/operatorgroups/openshift-nfd
   - ../../../../base/operators.coreos.com/subscriptions/nfd
   - ../../../../base/operators.coreos.com/subscriptions/opendatahub-operator
   - ../../../../base/config.openshift.io/oauths/cluster
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-rb
+  - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/reloader-reloader-role-binding
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/acme-operator
+  - ../../../../base/rbac.authorization.k8s.io/clusterroles/reloader-reloader-role
   - ../../../../base/user.openshift.io/groups/cluster-admins
   - ../../../../base/user.openshift.io/groups/odh-admin
   - ../../../../base/user.openshift.io/groups/odh-users

--- a/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
@@ -13,16 +13,13 @@ resources:
   - ../../../../base/core/namespaces/odh-trino
   - ../../../../base/core/namespaces/openshift-nfd
   - ../../../../base/core/namespaces/nvidia-gpu-operator
-  - ../../../../base/core/namespaces/reloader
   - ../../../../base/operators.coreos.com/operatorgroups/openshift-nfd
   - ../../../../base/operators.coreos.com/subscriptions/nfd
   - ../../../../base/operators.coreos.com/subscriptions/opendatahub-operator
   - ../../../../base/config.openshift.io/oauths/cluster
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-rb
-  - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/reloader-reloader-role-binding
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/acme-operator
-  - ../../../../base/rbac.authorization.k8s.io/clusterroles/reloader-reloader-role
   - ../../../../base/user.openshift.io/groups/cluster-admins
   - ../../../../base/user.openshift.io/groups/odh-admin
   - ../../../../base/user.openshift.io/groups/odh-users
@@ -30,6 +27,7 @@ resources:
   - ../../../../bundles/kfp-tekton
   - ../../../../bundles/openshift-pipelines
   - ../../../../bundles/pachyderm-operator
+  - ../../../../bundles/reloader
   - apiserver
   - ingresscontroller
   - machinesets

--- a/reloader/overlays/osc/osc-cl2/kustomization.yaml
+++ b/reloader/overlays/osc/osc-cl2/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../base
+namespace: reloader


### PR DESCRIPTION
In response to #1778 adding reloader deployment to osc-cl2 cluster to track trino pods.