### PR TITLE
update the version of the nfd operator for 4.9 ocp cluster to use nfd…

### DIFF
--- a/cluster-scope/overlays/prod/osc/osc-cl2/operators.coreos.com/patches/nfd-sub-patch.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/operators.coreos.com/patches/nfd-sub-patch.yaml
@@ -4,5 +4,5 @@ kind: Subscription
 metadata:
   name: nfd
 spec:
-  channel: "4.8"
+  channel: "stable"
   installPlanApproval: Manual


### PR DESCRIPTION
Updated channel to stable for the NFD operator for osc-cl2 cluster use 4.9 version of the operator 