### PR TITLE
Add minio artifact secret to osc-cl2 kfptekton.

### DIFF
--- a/kfp-tekton/overlays/osc/osc-cl2/secret-generator.yaml
+++ b/kfp-tekton/overlays/osc/osc-cl2/secret-generator.yaml
@@ -5,3 +5,4 @@ metadata:
   name: secret-generator
 files:
   - ./secrets/mlpipeline-ceph-artifact.enc.yaml
+  - ./secrets/mlpipeline-minio-artifact.enc.yaml

--- a/kfp-tekton/overlays/osc/osc-cl2/secrets/mlpipeline-minio-artifact.enc.yaml
+++ b/kfp-tekton/overlays/osc/osc-cl2/secrets/mlpipeline-minio-artifact.enc.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: mlpipeline-minio-artifact
+    namespace: kubeflow
+    annotations:
+        description: |
+            This secret is a workaround for the hardcoding of env secret ref during the archival step.
+            Reference: https://github.com/kubeflow/kfp-tekton/blob/559f8b6df04629cd2be43935f30268b406385001/backend/src/apiserver/template/tekton_template.go#L319
+            The container that is created to copy artifacts will require a secret named "mlpipeline-minio-artifact" exist
+            with the keys "accesskey" and "secretkey".
+
+            We should match the values for these with the "mlpipeline-ceph-artifact-custom" secret.
+stringData:
+    accesskey: ENC[AES256_GCM,data:IiMMVJXeBeCRDA6NDvFK5AvqldU=,iv:MuPam4gzCnu1LcXZEvBMmzPa/CyYjhTlQ26LMnHn4wU=,tag:vnULQxFO9z/AjaQ9rt2GPA==,type:str]
+    secretkey: ENC[AES256_GCM,data:UdJcjmaBOF9b8R25200/dbwDwalWtRvAbBvrLQpzyazM+Q4SYVHEaw==,iv:/8GKFqIgD17T6GISLlHwQp15DWgJaAj1Iw32HpdL5uA=,tag:AjVPdYr3Lx4WH3BCsxvxJA==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2022-03-23T14:14:57Z'
+    mac: ENC[AES256_GCM,data:AJPBsHM/rQTQ/TglBBN5fXaYDpjU2b+R+bjgCuS1A8m5EphtWnuKltQ4l7BnRVMHB+sRxmi3oBlU9s0HLt6uUxzsr5hnqImjtFSAHfHKqak9CJ90FoieKFy23JzZT6+NZtc7ta0MOzm/od9SNBIcYw6lWPrPUmJoPLUeF5nR3iA=,iv:v+gU5dLcW41P2M01ZMvXBuXVv55hu9MV/r2GIzSfNm0=,tag:ITPXF/Em4eeZKxXwzmUong==,type:str]
+    pgp:
+    -   created_at: '2022-03-23T14:14:56Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA9aKBcudqifiARAANdYxCY5A1L1vyLtd9R3NssyOs7iMeKSJFO7ELtnvWU30
+            DS1AcDXZqywZvjpMzZfy6+Chlpj8MBTtNkndxAdt4pXNd6USif2twMBottS1j7tF
+            322BsvYm14rT45Y5+YdK5V/BJ9MZoA3cIYT0dHaQ8BbNXu/glllMvYPQJW26b9vQ
+            0A4WRv+TWKRenG/8I+NtgE3qkrL6xIlmR874ra4sCqjSa1O9etv1XAdnj5XfBiMl
+            KlxDVOrMnEWzgesHcSNvn410m307x/ChQb9ZVq2HIx7degTleDNqcMO1zYwrI6js
+            698MPaEtJShnwzL79GO2cZ19xtoU2GMF4xVYLqIv9dSqq2ysGKBg4OTyWJnFsgHF
+            OhRk6O5i7eRC3aBGHVSrsGUkOAq/+dPuN+6ialst2wh0APnA4WRDuS8uEEaf2Vmt
+            C1OxN6Qfg1G49M6eDDRK0i/8L6BOmGKrBM6MaYdmEcJtihA2IxKW0uziBYvwiHv0
+            067pm9IFIobTQ1Sees0zTxxB4o1PdjBnE7Yoo243/Ln13Shp+uCJLLy6RUOgPut0
+            bJLhiu9mNdCARNpkDh01OtI6nKyPIA+DgvjBDi6iEToF2DRpQiHyuF2gGTERDh80
+            GcaoJ5gQcI7eDfGZF1bk2GWT3BQyn72/OPGpYyfuPeelQtC+y7sGpzHtsI0vYLDS
+            4AHkymCmuIX2bA/z0mEgBX/jHOFK/+B94O/h9m7gx+K/+7GO4MTlueUwKQ+qRuRK
+            AYaLyC59vk0fANwAxpLQIViFd8VkIOrgvuRh/2DBZZuokN3zaRGD5vS34pmHyFLh
+            v1oA
+            =3JNa
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^(users|data|stringData)$
+    version: 3.6.1


### PR DESCRIPTION
The copy artifact archival step in kfp-tekton requires the existence of
this secret. For more details read the description annotation included
in this commit. Description is added as an annotation since sops will
purge yaml comments upon encryption/decryption.