### PR TITLE
Added missing display names to Namespace manifests

### DIFF
--- a/cluster-scope/base/core/namespaces/aicoe-meteor/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/aicoe-meteor/namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
     name: aicoe-meteor
     annotations:
+        openshift.io/display-name: "AICoE Meteor Operator"
         openshift.io/requester: operate-first
         op1st/project-owner: operate-first
         op1st/onboarding-issue: "https://github.com/AICoE/meteor/issues/46"

--- a/cluster-scope/base/core/namespaces/boatrockers/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/boatrockers/namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
     name: boatrockers
     annotations:
+        openshift.io/display-name: "Boatrockers"
         openshift.io/requester: boatroackers
         op1st/project-owner: boatroackers
         op1st/onboarding-issue: https://github.com/operate-first/support/issues/524

--- a/cluster-scope/base/core/namespaces/chrisproject/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/chrisproject/namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
     name: chrisproject
     annotations:
+        openshift.io/display-name: "ChRIS"
         openshift.io/requester: redhat-impact
         op1st/project-owner: redhat-impact
         op1st/onboarding-issue: "https://github.com/operate-first/support/issues/527"

--- a/cluster-scope/base/core/namespaces/curator-engine/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/curator-engine/namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
     name: curator-engine
     annotations:
+        openshift.io/display-name: "Curator Engine"
         openshift.io/requester: curator
         op1st/project-owner: curator
         op1st/onboarding-issue: "https://github.com/operate-first/support/issues/265"


### PR DESCRIPTION
## Description:
As per recent PR #1784 , 15 namespaces have been given meta-labels to be displayed in the Workload Overview dashboard. This PR adds missing `openshift.io/display-name` tag to namespaces that didn't have one