### PR TITLE
adding opf-instance label in blackbox-service monitor

### DIFF
--- a/grafana/overlays/moc/smaug/blackbox-exporter/service-monitor.yaml
+++ b/grafana/overlays/moc/smaug/blackbox-exporter/service-monitor.yaml
@@ -14,6 +14,8 @@ spec:
           targetLabel: instance
         - replacement: 'https://jupyterhub-opf-jupyterhub.apps.smaug.na.operate-first.cloud/'
           targetLabel: target
+        - replacement: jupyterhub
+          targetLabel: opf-instance
       params:
         module:
           - http_2xx
@@ -31,6 +33,8 @@ spec:
           targetLabel: instance
         - replacement: 'https://www.operate-first.cloud/'
           targetLabel: target
+        - replacement: operate-first.cloud
+          targetLabel: opf-instance
       params:
         module:
           - http_2xx
@@ -48,6 +52,8 @@ spec:
           targetLabel: instance
         - replacement: 'https://thanos-query-frontend-opf-observatorium.apps.smaug.na.operate-first.cloud/'
           targetLabel: target
+        - replacement: thanos-query-frontend
+          targetLabel: opf-instance
       params:
         module:
           - http_2xx
@@ -65,6 +71,8 @@ spec:
           targetLabel: instance
         - replacement: 'https://trino.operate-first.cloud/'
           targetLabel: target
+        - replacement: trino
+          targetLabel: opf-instance
       params:
         module:
           - http_2xx
@@ -82,6 +90,8 @@ spec:
           targetLabel: instance
         - replacement: 'http://cloudbeaver-opf-trino.apps.smaug.na.operate-first.cloud/'
           targetLabel: target
+        - replacement: cloudbeaver
+          targetLabel: opf-instance
       params:
         module:
           - http_2xx


### PR DESCRIPTION
This commit adds the opf-instance label in the service monitor of blackbox in the smaug cluster. Re: https://github.com/operate-first/operations/issues/444