### PR TITLE
creating grafana-viewer group and adding to smaug grafana oauth

### DIFF
--- a/cluster-scope/base/user.openshift.io/groups/grafana-viewer/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/grafana-viewer/group.yaml
@@ -1,0 +1,6 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+    name: grafana-viewer
+users:
+    - riekrh

--- a/cluster-scope/base/user.openshift.io/groups/grafana-viewer/kustomization.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/grafana-viewer/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+    - group.yaml

--- a/grafana/overlays/moc/smaug/grafana-oauth.yaml
+++ b/grafana/overlays/moc/smaug/grafana-oauth.yaml
@@ -39,5 +39,6 @@ spec:
         contains(groups[*], 'prometheus-anomaly-detector') && 'Editor' ||
         contains(groups[*], 'thoth')          && 'Editor' ||
         contains(groups[*], 'opf-alerting')          && 'Admin' ||
+        contains(groups[*], 'grafana-viewer')   && 'Viewer' ||
         'Deny'
       role_attribute_strict: true


### PR DESCRIPTION
Related to slack conversation in `operate-first#support` channel. Creating `grafana-viewer` group and adding viewer permissions on the grafana-oauth for smaug overlay.

/cc @HumairAK 