### PR TITLE
Add auto sync of notebooks to hitchhiker repo.

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,0 +1,4 @@
+operate-first/hitchhikers-guide:
+  - source: docs/content/notebooks/
+    destination: pages/
+    deleteOrphaned: true

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,18 @@
+name: Sync Files
+on:
+  push:
+    paths:
+      - 'docs/notebooks/**'
+    branches:
+      - master
+  workflow_dispatch:
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@master
+      - name: Run GitHub File Sync
+        uses: BetaHuhn/repo-file-sync-action@v1
+        with:
+          GH_PAT: ${{ secrets.OP1ST_TOKEN }}


### PR DESCRIPTION
This will enable automated syncs via gh actions whenever a notebook is
updated. This is because we can only configure one image build per repo,
and it does not make sense to dedicate the apps repo for a notebook
image build. So instead we'll have a separate repo where we initiate our
builds from, and this action will ensure that while notebooks can be
committed to this repo, they will continue to initiate new image builds
by auto syncing with the build repository.

Alternative to: https://github.com/operate-first/apps/pull/1446