### PR TITLE
Fix typo in sync action.

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,4 +1,4 @@
 operate-first/hitchhikers-guide:
   - source: docs/content/notebooks/
-    destination: pages/
+    dest: pages/
     deleteOrphaned: true


### PR DESCRIPTION
As per: https://github.com/marketplace/actions/repo-file-sync-action#sync-entire-directories