### PR TITLE
Update group-mapping.properties

### DIFF
--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/group-mapping.properties
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/group-mapping.properties
@@ -1,2 +1,7 @@
 admins:admin,erikerlandson,caldeirav,HumairAK
 users:MichaelTiemannOSC,oindrillac,aakankshaduggal,shreyanand,michaelclifford,chauhankaranraj,sankbad,harshad16,toki8,audreyjf,khumbaeli5
+demo_dv_dev:os-climate-user1
+demo_dv_quant:os-climate-user2
+demo_dv_user:os-climate-user3
+demo_dv_licensed:os-climate-user1
+demo_dv_eval:os-climate-user1,os-climate-user2

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/rules.json
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/rules.json
@@ -32,12 +32,6 @@
             "owner": true
         },
         {
-            "group": ".*",
-            "catalog": "osc_datacommons_dev",
-            "schema": "workaround_1801",
-            "owner": true
-        },
-        {
             "catalog": ".*",
             "schema": ".*",
             "owner": false
@@ -160,26 +154,6 @@
         {
             "catalog": "osc_datacommons_dev",
             "schema": "demo_dv",
-            "table": ".*",
-            "privileges": [
-                "SELECT"
-            ]
-        },
-        {
-            "group": ".*",
-            "catalog": "osc_datacommons_dev",
-            "schema": "workaround_1801",
-            "table": ".*",
-            "privileges": [
-                "SELECT",
-                "INSERT",
-                "DELETE",
-                "OWNERSHIP"
-            ]
-        },
-        {
-            "catalog": "osc_datacommons_dev",
-            "schema": "workaround_1801",
             "table": ".*",
             "privileges": [
                 "SELECT"

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/rules.json
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/rules.json
@@ -5,7 +5,7 @@
             "allow": "all"
         },
         {
-            "group": ".*",
+            "group": "demo_.*|.*",
             "catalog": "osc_datacommons_dev",
             "allow": "all"
         },
@@ -26,6 +26,12 @@
             "owner": true
         },
         {
+            "group": ".*",
+            "catalog": "osc_datacommons_dev",
+            "schema": "demo_dv",
+            "owner": true
+        },
+        {
             "catalog": ".*",
             "schema": ".*",
             "owner": false
@@ -42,23 +48,15 @@
             ]
         },
         {
-            "group": ".*",
+            "group": "demo_dv_dev",
             "catalog": "osc_datacommons_dev",
-            "schema": "sandbox",
-            "table": ".*",
+            "schema": "demo_dv",
+            "table": "demo_dv_backend",
             "privileges": [
                 "SELECT",
                 "INSERT",
                 "DELETE",
                 "OWNERSHIP"
-            ]
-        },
-        {
-            "catalog": "osc_datacommons_dev",
-            "schema": "sandbox",
-            "table": ".*",
-            "privileges": [
-                "SELECT"
             ]
         },
         {
@@ -120,6 +118,46 @@
             "schema": "demo_dv",
             "table": "demo_dv_userfacing",
             "privileges": []
+        },
+        {
+            "group": ".*",
+            "catalog": "osc_datacommons_dev",
+            "schema": "sandbox",
+            "table": ".*",
+            "privileges": [
+                "SELECT",
+                "INSERT",
+                "DELETE",
+                "OWNERSHIP"
+            ]
+        },
+        {
+            "catalog": "osc_datacommons_dev",
+            "schema": "sandbox",
+            "table": ".*",
+            "privileges": [
+                "SELECT"
+            ]
+        },
+        {
+            "group": ".*",
+            "catalog": "osc_datacommons_dev",
+            "schema": "demo_dv",
+            "table": ".*",
+            "privileges": [
+                "SELECT",
+                "INSERT",
+                "DELETE",
+                "OWNERSHIP"
+            ]
+        },
+        {
+            "catalog": "osc_datacommons_dev",
+            "schema": "demo_dv",
+            "table": ".*",
+            "privileges": [
+                "SELECT"
+            ]
         },
         {
             "catalog": "osc_datacommons_dev",

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/rules.json
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/rules.json
@@ -32,6 +32,12 @@
             "owner": true
         },
         {
+            "group": ".*",
+            "catalog": "osc_datacommons_dev",
+            "schema": "workaround_1801",
+            "owner": true
+        },
+        {
             "catalog": ".*",
             "schema": ".*",
             "owner": false
@@ -154,6 +160,26 @@
         {
             "catalog": "osc_datacommons_dev",
             "schema": "demo_dv",
+            "table": ".*",
+            "privileges": [
+                "SELECT"
+            ]
+        },
+        {
+            "group": ".*",
+            "catalog": "osc_datacommons_dev",
+            "schema": "workaround_1801",
+            "table": ".*",
+            "privileges": [
+                "SELECT",
+                "INSERT",
+                "DELETE",
+                "OWNERSHIP"
+            ]
+        },
+        {
+            "catalog": "osc_datacommons_dev",
+            "schema": "workaround_1801",
             "table": ".*",
             "privileges": [
                 "SELECT"

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/rules.json
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/rules.json
@@ -63,6 +63,66 @@
         },
         {
             "catalog": "osc_datacommons_dev",
+            "schema": "demo_dv",
+            "table": "demo_dv_backend",
+            "privileges": []
+        },
+        {
+            "group": "demo_dv_dev",
+            "catalog": "osc_datacommons_dev",
+            "schema": "demo_dv",
+            "table": "demo_dv_userfacing",
+            "privileges": [
+                "SELECT",
+                "INSERT",
+                "DELETE",
+                "OWNERSHIP"
+            ]
+        },
+        {
+            "group": "demo_dv_quant",
+            "catalog": "osc_datacommons_dev",
+            "schema": "demo_dv",
+            "table": "demo_dv_userfacing",
+            "privileges": [
+                "SELECT"
+            ],
+            "filter": "contains(current_groups(), access) or access = 'public'",
+            "columns": [
+                {
+                    "name": "dev1",
+                    "allow": false
+                }
+            ]
+        },
+        {
+            "group": "demo_dv_user",
+            "catalog": "osc_datacommons_dev",
+            "schema": "demo_dv",
+            "table": "demo_dv_userfacing",
+            "privileges": [
+                "SELECT"
+            ],
+            "filter": "contains(current_groups(), access) or access = 'public'",
+            "columns": [
+                {
+                    "name": "dev1",
+                    "allow": false
+                },
+                {
+                    "name": "quant1",
+                    "allow": false
+                }
+            ]
+        },
+        {
+            "catalog": "osc_datacommons_dev",
+            "schema": "demo_dv",
+            "table": "demo_dv_userfacing",
+            "privileges": []
+        },
+        {
+            "catalog": "osc_datacommons_dev",
             "schema": ".*",
             "table": ".*",
             "privileges": [

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/trino-acl-dsl.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/trino-acl-dsl.yaml
@@ -11,6 +11,7 @@ catalogs:
     # admin-like privs at table or schema level: see 'allow'
     # in trino access control docs
     admin-groups:
+      - 'demo_.*'
       - '.*'
 
 schemas:
@@ -19,4 +20,29 @@ schemas:
     admin-groups: ['.*']
     public-tables: true
 
-tables: []
+  - schema: demo_dv
+    catalog: osc_datacommons_dev
+    admin-groups: ['.*']
+    public-tables: true
+
+tables:
+  - table: demo_dv_backend
+    schema: demo_dv
+    catalog: osc_datacommons_dev
+    admin-groups: [demo_dv_dev]
+    public: false
+
+  - table: demo_dv_userfacing
+    schema: demo_dv
+    catalog: osc_datacommons_dev
+    admin-groups: [demo_dv_dev]
+    public: false
+    row-acl:
+      type: filter
+      filter: "contains(current_groups(), access) or access = 'public'"
+    column-acl:
+      - groups: [demo_dv_quant]
+        hide-columns: [dev1]
+      - groups: [demo_dv_user]
+        # hide-columns are cumulative, top to bottom
+        hide-columns: [quant1]

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/trino-acl-dsl.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/trino-acl-dsl.yaml
@@ -25,6 +25,11 @@ schemas:
     admin-groups: ['.*']
     public-tables: true
 
+  - schema: workaround_1801
+    catalog: osc_datacommons_dev
+    admin-groups: ['.*']
+    public-tables: true
+
 tables:
   - table: demo_dv_backend
     schema: demo_dv

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/trino-acl-dsl.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/trino-acl-dsl.yaml
@@ -25,11 +25,6 @@ schemas:
     admin-groups: ['.*']
     public-tables: true
 
-  - schema: workaround_1801
-    catalog: osc_datacommons_dev
-    admin-groups: ['.*']
-    public-tables: true
-
 tables:
   - table: demo_dv_backend
     schema: demo_dv


### PR DESCRIPTION
Add demo_dv user types for Data Vault demo.  These user identities and group names are carried over from the CL1 group-mapping.properties file.