### PR TITLE
Remove opf-kafka from smaug kfdef root kustomization.

### DIFF
--- a/kfdefs/overlays/moc/smaug/kustomization.yaml
+++ b/kfdefs/overlays/moc/smaug/kustomization.yaml
@@ -9,7 +9,6 @@ resources:
   - opf-google-spark-operator
   - opf-jupyterhub
   - opf-jupyterhub-stage
-  - opf-kafka
   - opf-seldon
   - opf-superset
   - opf-trino


### PR DESCRIPTION
Part of: https://github.com/operate-first/apps/pull/1675
Breaking build of kfdef app: 

```
rpc error: code = Unknown desc = Manifest generation error (cached): `kustomize build /tmp/https___github.com_operate-first_apps/kfdefs/overlays/moc/smaug --enable-alpha-plugins` failed exit status 1: Error: accumulating resources: accumulation err='accumulating resources from 'opf-kafka': evalsymlink failure on '/tmp/https___github.com_operate-first_apps/kfdefs/overlays/moc/smaug/opf-kafka' : lstat /tmp/https___github.com_operate-first_apps/kfdefs/overlays/moc/smaug/opf-kafka: no such file or directory': evalsymlink failure on '/tmp/https___github.com_operate-first_apps/kfdefs/overlays/moc/smaug/opf-kafka' : lstat /tmp/https___github.com_operate-first_apps/kfdefs/overlays/moc/smaug/opf-kafka: no such file or directory
```


@margarethaley 