### PR TITLE
removing opf-kafka from dev kfdefs overlay

### DIFF
--- a/kfdefs/overlays/dev/kustomization.yaml
+++ b/kfdefs/overlays/dev/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - opf-dashboard
   - opf-datacatalog
   - opf-jupyterhub
-  - opf-kafka
   - opf-monitoring
   - opf-seldon
   - opf-superset


### PR DESCRIPTION
Related to: https://github.com/operate-first/apps/pull/1675

/cc @HumairAK 