### PR TITLE
Fixing vault statefulset.yaml to include missing volume claims

### DIFF
--- a/vault/base/statefulsets/statefulset.yaml
+++ b/vault/base/statefulsets/statefulset.yaml
@@ -115,12 +115,28 @@ spec:
           - emptyDir: {}
   updateStrategy:
     type: OnDelete
-    volumeClaimTemplates:
-      - metadata:
-          name: data
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 10Gi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+    - metadata:
+        name: config
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+    - metadata:
+        name: home
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi


### PR DESCRIPTION
Some of the volume claim templates got cut off at some point causing the vault deployment to fail in smaug. I've added the necessary volume claim templates so that the deployment should complete successfully.