### PR TITLE
Add reporef to smaug jh kfdef.

### DIFF
--- a/kfdefs/overlays/moc/smaug/opf-jupyterhub/kfdef.yaml
+++ b/kfdefs/overlays/moc/smaug/opf-jupyterhub/kfdef.yaml
@@ -26,6 +26,9 @@ spec:
     - kustomizeConfig:
         overlays:
           - additional
+        repoRef:
+          name: manifests
+          path: jupyterhub/notebook-images
       name: notebook-images
   repos:
     - name: manifests


### PR DESCRIPTION
kfdef is missing the repo ref for this entry. 