### PR TITLE
adjust vault pod volume claims and namespace resource quota

### DIFF
--- a/cluster-scope/base/core/namespaces/vault/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/vault/resourcequota.yaml
@@ -8,5 +8,5 @@ spec:
     requests.memory: 2Gi
     limits.cpu: '500m'
     limits.memory: 2Gi
-    requests.storage: 30Gi
+    requests.storage: 60Gi
     count/objectbucketclaims.objectbucket.io: 1

--- a/vault/base/statefulsets/statefulset.yaml
+++ b/vault/base/statefulsets/statefulset.yaml
@@ -131,7 +131,7 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 10Gi
+            storage: 5Gi
     - metadata:
         name: home
       spec:
@@ -139,4 +139,4 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 10Gi
+            storage: 5Gi


### PR DESCRIPTION
I didn't account for the deployment being HA so I did not designate enough storage in the resource quota initially. I've also scaled down the volume claims a bit. 