### PR TITLE
Add opf-monitoring cluster-scope bundle

### DIFF
--- a/cluster-scope/bundles/opf-monitoring/grafana-serviceaccount.yaml
+++ b/cluster-scope/bundles/opf-monitoring/grafana-serviceaccount.yaml
@@ -1,0 +1,5 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: grafana-serviceaccount
+  namespace: opf-monitoring

--- a/cluster-scope/bundles/opf-monitoring/kustomization.yaml
+++ b/cluster-scope/bundles/opf-monitoring/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base/core/namespaces/opf-monitoring
+  - ../../base/rbac.authorization.k8s.io/clusterrolebindings/opf-monitoring-grafana-cluster-view
+  - grafana-serviceaccount.yaml

--- a/cluster-scope/overlays/prod/common/kustomization.yaml
+++ b/cluster-scope/overlays/prod/common/kustomization.yaml
@@ -67,4 +67,5 @@ resources:
 - ../../../base/user.openshift.io/groups/uky-redhat
 - ../../../base/user.openshift.io/groups/varangian
 - ../../../base/user.openshift.io/groups/workshops
+- ../../../bundles/opf-monitoring
 - alertmanager-main-secret.yaml

--- a/cluster-scope/overlays/prod/emea/balrog/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/balrog/kustomization.yaml
@@ -10,7 +10,6 @@ resources:
     - ../../../../base/core/configmaps/user-workload-monitoring-config
     - ../../../../base/core/namespaces/openshift-logging
     - ../../../../base/core/namespaces/opf-kafka
-    - ../../../../base/core/namespaces/opf-monitoring
     - ../../../../base/core/namespaces/thoth-amun-api-prod
     - ../../../../base/core/namespaces/thoth-amun-inspection-prod
     - ../../../../base/core/namespaces/thoth-backend-prod

--- a/cluster-scope/overlays/prod/emea/morty/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/morty/kustomization.yaml
@@ -31,7 +31,6 @@ resources:
 - ../../../../base/core/namespaces/openshift-local-storage
 - ../../../../base/core/namespaces/openshift-storage
 - ../../../../base/core/namespaces/opf-alertreceiver
-- ../../../../base/core/namespaces/opf-monitoring
 - ../../../../base/core/namespaces/pixel-demo
 - ../../../../base/core/namespaces/pixel-secrets
 - ../../../../base/core/namespaces/rbo-builder

--- a/cluster-scope/overlays/prod/emea/rick/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/rick/kustomization.yaml
@@ -14,7 +14,6 @@ resources:
     - ../../../../base/core/namespaces/openshift-operators
     - ../../../../base/core/namespaces/openshift-storage
     - ../../../../base/core/namespaces/opf-alertreceiver
-    - ../../../../base/core/namespaces/opf-monitoring
     - ../../../../base/core/namespaces/opf-kafka
     - ../../../../base/core/namespaces/thoth-website-prod
     - ../../../../base/core/namespaces/thoth-test-core

--- a/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
@@ -15,7 +15,6 @@ resources:
   - ../../../../base/core/namespaces/openshift-logging
   - ../../../../base/core/namespaces/openshift-nmstate
   - ../../../../base/core/namespaces/opf-alertreceiver
-  - ../../../../base/core/namespaces/opf-monitoring
   - ../../../../base/core/namespaces/vault
   - ../../../../base/nmstate.io/nmstates/nmstate
   - ../../../../base/operator.openshift.io/ingresscontrollers/default

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -50,7 +50,6 @@ resources:
 - ../../../../base/core/namespaces/opf-jupyterhub
 - ../../../../base/core/namespaces/opf-jupyterhub-stage
 - ../../../../base/core/namespaces/opf-kafka
-- ../../../../base/core/namespaces/opf-monitoring
 - ../../../../base/core/namespaces/opf-observatorium
 - ../../../../base/core/namespaces/opf-pulp
 - ../../../../base/core/namespaces/opf-seldon


### PR DESCRIPTION
Add opf-monitoring bundle to the common cluster directory

this `grafana-serviceaccount` will be given privileges to access the openshift-monitoring prometheus