### PR TITLE
Upping cpu request and limit in vault custom resourcequota

### DIFF
--- a/cluster-scope/base/core/namespaces/vault/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/vault/resourcequota.yaml
@@ -4,9 +4,9 @@ metadata:
   name: vault-custom
 spec:
   hard:
-    requests.cpu: '500m'
+    requests.cpu: '1'
     requests.memory: 2Gi
-    limits.cpu: '500m'
+    limits.cpu: '1'
     limits.memory: 2Gi
     requests.storage: 60Gi
     count/objectbucketclaims.objectbucket.io: 1


### PR DESCRIPTION
Hit cpu limit which prevented pods from initializing. Upped the cpu quota from 500m to 1 core. 