### PR TITLE
Upgrade api version for grafana viewer crb.

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/opf-monitoring-grafana-cluster-view/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/opf-monitoring-grafana-cluster-view/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: opf-monitoring-grafana-cluster-view


### PR DESCRIPTION
v1beta1 is deprecated in 4.9