### PR TITLE
manage the kafka for balrog cluster via operate-first

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/emea/balrog/operate-first/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/emea/balrog/operate-first/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - acme-operator.yaml
   - cluster-logging.yaml
   - k8s-annotations-exporter.yaml
+  - opf-kafka.yaml

--- a/argocd/overlays/moc-infra/applications/envs/emea/balrog/operate-first/opf-kafka.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/emea/balrog/operate-first/opf-kafka.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: opf-kafka
+spec:
+  destination:
+    name: balrog
+    namespace: opf-kafka
+  project: operate-first
+  source:
+    path: kafka/overlays/balrog
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/cluster-scope/overlays/prod/emea/balrog/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/balrog/kustomization.yaml
@@ -34,3 +34,18 @@ patchesStrategicMerge:
     - groups/cluster-admins.yaml
     - subscriptions/cluster-logging-operator_patch.yaml
     - clusterautoscaler.yaml
+patches:
+    - patch: |-
+        - op: replace
+          path: /spec/hard
+          value:
+            limits.cpu: '16'
+            limits.memory: 32Gi
+            requests.cpu: '8'
+            requests.memory: 16Gi
+            requests.storage: 60Gi
+      target:
+          group: ""
+          version: v1
+          kind: ResourceQuota
+          name: opf-kafka-custom

--- a/kafka/overlays/balrog/kafka-podmonitors.yaml
+++ b/kafka/overlays/balrog/kafka-podmonitors.yaml
@@ -1,0 +1,102 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: cluster-operator-metrics
+  labels:
+    app: strimzi
+    team: opendatahub
+spec:
+  selector:
+    matchLabels:
+      strimzi.io/kind: cluster-operator
+  podMetricsEndpoints:
+  - path: /metrics
+    port: http
+  namespaceSelector:
+    matchNames:
+      - opf-kafka
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: entity-operator-metrics
+  labels:
+    app: strimzi
+    team: opendatahub
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: entity-operator
+  podMetricsEndpoints:
+  - path: /metrics
+    port: healthcheck
+  namespaceSelector:
+    matchNames:
+      - opf-kafka
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: bridge-metrics
+  labels:
+    app: strimzi
+    team: opendatahub
+spec:
+  selector:
+    matchLabels:
+      strimzi.io/kind: KafkaBridge
+  podMetricsEndpoints:
+  - path: /metrics
+    port: rest-api
+  namespaceSelector:
+    matchNames:
+      - opf-kafka
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: kafka-metrics
+  labels:
+    app: strimzi
+    team: opendatahub
+spec:
+  selector:
+    matchExpressions:
+      - key: "strimzi.io/kind"
+        operator: In
+        values: ["Kafka", "KafkaConnect"]
+  podMetricsEndpoints:
+  - path: /metrics
+    port: tcp-prometheus
+    relabelings:
+    - separator: ;
+      regex: __meta_kubernetes_pod_label_(.+)
+      replacement: $1
+      action: labelmap
+    - sourceLabels: [__meta_kubernetes_namespace]
+      separator: ;
+      regex: (.*)
+      targetLabel: namespace
+      replacement: $1
+      action: replace
+    - sourceLabels: [__meta_kubernetes_pod_name]
+      separator: ;
+      regex: (.*)
+      targetLabel: kubernetes_pod_name
+      replacement: $1
+      action: replace
+    - sourceLabels: [__meta_kubernetes_pod_node_name]
+      separator: ;
+      regex: (.*)
+      targetLabel: node_name
+      replacement: $1
+      action: replace
+    - sourceLabels: [__meta_kubernetes_pod_host_ip]
+      separator: ;
+      regex: (.*)
+      targetLabel: node_ip
+      replacement: $1
+      action: replace
+  namespaceSelector:
+    matchNames:
+      - opf-kafka

--- a/kafka/overlays/balrog/kustomization.yaml
+++ b/kafka/overlays/balrog/kustomization.yaml
@@ -1,0 +1,37 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+- topics
+- users
+- kafka-podmonitors.yaml
+patchesStrategicMerge:
+  - opf-kafdrop.yaml
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/kafka/replicas
+        value: 3
+      - op: replace
+        path: /spec/kafka/storage/size
+        value: 5Gi
+      - op: replace
+        path: /spec/kafka/resources
+        value:
+          limits:
+            cpu: 500m
+            memory: 2Gi
+          requests:
+            cpu: 200m
+            memory: 1Gi
+      - op: replace
+        path: /spec/zookeeper/replicas
+        value: 3
+      - op: replace
+        path: /spec/zookeeper/storage/size
+        value: 5Gi
+    target:
+      group: kafka.strimzi.io
+      version: v1beta2
+      kind: Kafka
+      name: odh-message-bus

--- a/kafka/overlays/balrog/opf-kafdrop.yaml
+++ b/kafka/overlays/balrog/opf-kafdrop.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: kafka-kafdrop
+  labels:
+    name: kafdrop
+spec:
+  replicas: 1
+  selector:
+    name: kafdrop-up
+  template:
+    metadata:
+      labels:
+        name: kafdrop-up
+    spec:
+      containers:
+        - name: kafdrop
+          image: 'quay.io/thoth-station/kafdrop:latest'
+          imagePullPolicy: Always
+          env:
+            - name: KAFKA_BROKERCONNECT
+              value: >-
+               odh-message-bus-kafka-bootstrap-opf-kafka.apps.balrog.aws.operate-first.cloud:443
+            - name: KAFKA_TRUSTSTORE_FILE
+              value: /mnt/secrets/truststore.jks
+            - name: KAFKA_KEYSTORE_FILE
+              value: /mnt/keystore/keystore.jks
+            - name: KAFKA_PROPERTIES_FILE
+              value: /tmp/kafka.properties
+            - name: USE_KAFKA_PROPS
+              value: '1'
+            - name: KAFKA_PROPS_SECURITY_PROTOCOL
+              value: SSL
+            - name: KAFKA_PROPS_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM
+              value: ' '
+            - name: KAFKA_PROPS_SSL_TRUSTSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: odh-message-bus-cluster-ca-cert
+                  key: ca.password
+            - name: KAFKA_PROPS_SSL_KEYSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: odh-message-bus-cluster-ca-cert
+                  key: ca.password
+            - name: JVM_OPTS
+              value: '-Xms32M -Xmx64M'
+            - name: JMX_PORT
+              value: '8686'
+            - name: SERVER_PORT
+              value: '9000'
+            - name: CMD_ARGS
+              value: '--verbose'
+          resources:
+            requests:
+              cpu: 20m
+              memory: 256Mi
+          volumeMounts:
+            - name: secrets
+              mountPath: /mnt/secrets
+              readOnly: true
+            - name: keystore
+              mountPath: /mnt/keystore
+              readOnly: true
+      volumes:
+        - name: secrets
+          secret:
+            secretName: odh-message-bus-cluster-ca-cert
+            items:
+              - key: ca.p12
+                path: truststore.jks
+        - name: keystore
+          secret:
+            secretName: odh-message-bus-cluster-ca-cert
+            items:
+              - key: ca.p12
+                path: keystore.jks

--- a/kafka/overlays/balrog/topics/kustomization.yaml
+++ b/kafka/overlays/balrog/topics/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  strimzi.io/cluster: odh-message-bus
+resources:
+- thoth-advise-justification.yaml
+- thoth-adviser-trigger.yaml
+- thoth-build-analysis-trigger.yaml
+- thoth-cve-provided.yaml
+- thoth-hash-mismatch.yaml
+- thoth-kebechet-run-url.yaml
+- thoth-kebechet-trigger.yaml
+- thoth-missing-package-version.yaml
+- thoth-missing-package.yaml
+- thoth-package-extract-trigger.yaml
+- thoth-package-released.yaml
+- thoth-provenance-checker-trigger.yaml
+- thoth-qebhwt-trigger.yaml
+- thoth-si-unanalyzed-package.yaml
+- thoth-solved-package.yaml
+- thoth-unresolved-package.yaml
+- thoth-unrevsolved-package.yaml
+- thoth-update-provides-source-distro.yaml

--- a/kafka/overlays/balrog/topics/thoth-advise-justification.yaml
+++ b/kafka/overlays/balrog/topics/thoth-advise-justification.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: aws-prod.thoth.advise-reporter.advise-justification
+  labels:
+    strimzi.io/cluster: odh-message-bus
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 14400000

--- a/kafka/overlays/balrog/topics/thoth-adviser-trigger.yaml
+++ b/kafka/overlays/balrog/topics/thoth-adviser-trigger.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: aws-prod.thoth.adviser-trigger
+  labels:
+    strimzi.io/cluster: odh-message-bus
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 14400000

--- a/kafka/overlays/balrog/topics/thoth-build-analysis-trigger.yaml
+++ b/kafka/overlays/balrog/topics/thoth-build-analysis-trigger.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: aws-prod.thoth.build-analysis-trigger
+  labels:
+    strimzi.io/cluster: odh-message-bus
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 14400000

--- a/kafka/overlays/balrog/topics/thoth-cve-provided.yaml
+++ b/kafka/overlays/balrog/topics/thoth-cve-provided.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: aws-prod.thoth.cve-update.cve-provided
+  labels:
+    strimzi.io/cluster: odh-message-bus
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 14400000

--- a/kafka/overlays/balrog/topics/thoth-hash-mismatch.yaml
+++ b/kafka/overlays/balrog/topics/thoth-hash-mismatch.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: aws-prod.thoth.package-update.hash-mismatch
+  labels:
+    strimzi.io/cluster: odh-message-bus
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 14400000

--- a/kafka/overlays/balrog/topics/thoth-kebechet-run-url.yaml
+++ b/kafka/overlays/balrog/topics/thoth-kebechet-run-url.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: aws-prod.thoth.kebechet-run-url-trigger
+  labels:
+    strimzi.io/cluster: odh-message-bus
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 14400000

--- a/kafka/overlays/balrog/topics/thoth-kebechet-trigger.yaml
+++ b/kafka/overlays/balrog/topics/thoth-kebechet-trigger.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: aws-prod.thoth.kebechet-trigger
+  labels:
+    strimzi.io/cluster: odh-message-bus
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 14400000

--- a/kafka/overlays/balrog/topics/thoth-missing-package-version.yaml
+++ b/kafka/overlays/balrog/topics/thoth-missing-package-version.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: aws-prod.thoth.package-update.missing-package-version
+  labels:
+    strimzi.io/cluster: odh-message-bus
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 14400000

--- a/kafka/overlays/balrog/topics/thoth-missing-package.yaml
+++ b/kafka/overlays/balrog/topics/thoth-missing-package.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: aws-prod.thoth.package-update.missing-package
+  labels:
+    strimzi.io/cluster: odh-message-bus
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 14400000

--- a/kafka/overlays/balrog/topics/thoth-package-extract-trigger.yaml
+++ b/kafka/overlays/balrog/topics/thoth-package-extract-trigger.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: aws-prod.thoth.package-extract-trigger
+  labels:
+    strimzi.io/cluster: odh-message-bus
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 14400000

--- a/kafka/overlays/balrog/topics/thoth-package-released.yaml
+++ b/kafka/overlays/balrog/topics/thoth-package-released.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: aws-prod.thoth.package-release.package-released
+  labels:
+    strimzi.io/cluster: odh-message-bus
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 14400000

--- a/kafka/overlays/balrog/topics/thoth-provenance-checker-trigger.yaml
+++ b/kafka/overlays/balrog/topics/thoth-provenance-checker-trigger.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: aws-prod.thoth.provenance-checker-trigger
+  labels:
+    strimzi.io/cluster: odh-message-bus
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 14400000

--- a/kafka/overlays/balrog/topics/thoth-qebhwt-trigger.yaml
+++ b/kafka/overlays/balrog/topics/thoth-qebhwt-trigger.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: aws-prod.thoth.qebhwt-trigger
+  labels:
+    strimzi.io/cluster: odh-message-bus
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 14400000

--- a/kafka/overlays/balrog/topics/thoth-si-unanalyzed-package.yaml
+++ b/kafka/overlays/balrog/topics/thoth-si-unanalyzed-package.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: aws-prod.thoth.investigator.si-unanalyzed-package
+  labels:
+    strimzi.io/cluster: odh-message-bus
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 14400000

--- a/kafka/overlays/balrog/topics/thoth-solved-package.yaml
+++ b/kafka/overlays/balrog/topics/thoth-solved-package.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: aws-prod.thoth.solver.solved-package
+  labels:
+    strimzi.io/cluster: odh-message-bus
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 14400000

--- a/kafka/overlays/balrog/topics/thoth-unresolved-package.yaml
+++ b/kafka/overlays/balrog/topics/thoth-unresolved-package.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: aws-prod.thoth.investigator.unresolved-package
+  labels:
+    strimzi.io/cluster: odh-message-bus
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 14400000

--- a/kafka/overlays/balrog/topics/thoth-unrevsolved-package.yaml
+++ b/kafka/overlays/balrog/topics/thoth-unrevsolved-package.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: aws-prod.thoth.investigator.unrevsolved-package
+  labels:
+    strimzi.io/cluster: odh-message-bus
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 14400000

--- a/kafka/overlays/balrog/topics/thoth-update-provides-source-distro.yaml
+++ b/kafka/overlays/balrog/topics/thoth-update-provides-source-distro.yaml
@@ -1,0 +1,11 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: aws-prod.thoth.update-provides-source-distro
+  labels:
+    strimzi.io/cluster: odh-message-bus
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 14400000

--- a/kafka/overlays/balrog/users/kustomization.yaml
+++ b/kafka/overlays/balrog/users/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  strimzi.io/cluster: odh-message-bus
+resources:
+- thoth.yaml

--- a/kafka/overlays/balrog/users/thoth.yaml
+++ b/kafka/overlays/balrog/users/thoth.yaml
@@ -1,0 +1,25 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: thoth
+spec:
+  authentication:
+    type: tls
+  authorization:
+    acls:
+      - host: '*'
+        operation: All
+        resource:
+          # this user has access to all topics with "smaug-prod.thoth." prefix
+          name: aws-prod.thoth.
+          patternType: prefix
+          type: topic
+        type: allow
+      - host: '*'
+        operation: All
+        resource:
+          name: thoth.
+          patternType: prefix
+          type: group
+        type: allow
+    type: simple


### PR DESCRIPTION
manage the kafka for balrog cluster via operate-first
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


- Reduced the resource for opf-kafka, as it not being to its capacity as of now.
- set all the manifest for kafka w.r.t balrog setup