### PR TITLE
[idm] Add Pep to the data-science group

### DIFF
--- a/cluster-scope/base/user.openshift.io/groups/data-science/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/data-science/group.yaml
@@ -6,6 +6,7 @@ users:
   - aakankshaduggal
   - antter
   - chauhankaranraj
+  - codificat
   - durandom
   - goern
   - michaelclifford


### PR DESCRIPTION
This PR adds myself to the `data-science` user group.

The trigger for this is to have access to relevant namespace(s) in the [SP metrics](https://github.com/open-services-group/community/tree/main/sig-data-science#metrics) subproject.

The immediate need is about working on https://github.com/open-services-group/metrics/issues/18#issuecomment-1086026726 which points to a [cron job](https://console-openshift-console.apps.smaug.na.operate-first.cloud/k8s/ns/ds-ml-workflows-ws/cronjobs/osg-metrics) in the `ds-ml-workflows-ws` namespace.