### PR TITLE
Remove oauth base resource from morty cluster.

### DIFF
--- a/cluster-scope/overlays/prod/emea/morty/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/morty/kustomization.yaml
@@ -21,7 +21,6 @@ patchesStrategicMerge:
 - subscriptions/nfd_patch.yaml
 - subscriptions/openshift-pipelines-operator-rh_patch.yaml
 resources:
-- ../../../../base/config.openshift.io/oauths/cluster
 - ../../../../base/core/configmaps/cluster-monitoring-config
 - ../../../../base/core/namespaces/examples-openshift-pub
 - ../../../../base/core/namespaces/openshift-cnv


### PR DESCRIPTION
This is a leftover from a previous pr where we switched over to using
identitatem to manage auth for morty cluster. #1835 