### PR TITLE
Update mapping method for idp authrealm.

### DIFF
--- a/acm/overlays/moc/infra/identitatem/authrealms/primary.yaml
+++ b/acm/overlays/moc/infra/identitatem/authrealms/primary.yaml
@@ -10,7 +10,7 @@ spec:
           name: identitatem-github-client-secret
         organizations:
           - operate-first
-      mappingMethod: claim
+      mappingMethod: add
       name: identitatem-github
       type: GitHub
   # Every cluster captured by this placement will have its


### PR DESCRIPTION
We found that using the "claim" mapping method results in user identity
conflicts. Instead we'll use the "add" method which allows for the
mapping of a username to any existing user on the cluster.


Further reading: 
https://docs.openshift.com/container-platform/4.7/authentication/understanding-identity-provider.html#identity-provider-parameters_understanding-identity-provider