### PR TITLE
Point the osc-cl1 jupyterhub-stage to byon tag of manifests

### DIFF
--- a/kfdefs/overlays/osc/osc-cl1/jupyterhub-stage/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/jupyterhub-stage/kfdef.yaml
@@ -29,7 +29,12 @@ spec:
           name: manifests
           path: jupyterhub/notebook-images
       name: notebook-images
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: jupyterhub/byon
+      name: byon
   repos:
     - name: manifests
-      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl1-v1.1.2
+      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl1-byon
   version: v1.1.0


### PR DESCRIPTION
Point the osc-cl1 jupyterhub-stage to byon tag of manifests
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Related-to: https://github.com/open-services-group/byon/issues/20