### PR TITLE
Added enhanced Cluster Storage Overview Dashboard

### DIFF
--- a/grafana/overlays/moc/smaug/dashboards/cluster-management/cluster-storage-overview.yaml
+++ b/grafana/overlays/moc/smaug/dashboards/cluster-management/cluster-storage-overview.yaml
@@ -11,774 +11,774 @@ spec:
       version: 1.6.2
   json: |
     {
-    "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": "-- Grafana --",
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "target": {
-            "limit": 100,
-            "matchAny": false,
-            "tags": [],
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
             "type": "dashboard"
-          },
-          "type": "dashboard"
-        }
-      ]
-    },
-    "editable": true,
-    "fiscalYearStartMonth": 0,
-    "graphTooltip": 0,
-    "id": 40,
-    "iteration": 1649426728385,
-    "links": [],
-    "liveNow": false,
-    "panels": [
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "description": "These metrics are from the space queried from persistent volumes (PVs)",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "dark-red",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 0.2
-                },
-                {
-                  "color": "orange",
-                  "value": 0.4
-                },
-                {
-                  "color": "yellow",
-                  "value": 0.5
-                },
-                {
-                  "color": "light-green",
-                  "value": 0.7
-                },
-                {
-                  "color": "green",
-                  "value": 0.8
-                },
-                {
-                  "color": "dark-green",
-                  "value": 0.9
-                }
-              ]
-            },
-            "unit": "percentunit"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 5,
-          "w": 6,
-          "x": 0,
-          "y": 0
-        },
-        "id": 16,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "text": {},
-          "textMode": "auto"
-        },
-        "pluginVersion": "8.4.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${datasource}"
-            },
-            "exemplar": true,
-            "expr": "sum(kubelet_volume_stats_available_bytes{cluster=\"$cluster\"}) / sum(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
-            "interval": "",
-            "legendFormat": "{{cluster}}",
-            "refId": "A"
           }
-        ],
-        "title": "% of Free Space on Cluster",
-        "type": "stat"
+        ]
       },
-      {
-        "description": "These metrics show used, available, and total space on the cluster\n(Note: These metrics are from PersistentVolumes)",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "fixedColor": "blue",
-              "mode": "fixed"
-            },
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "dark-green",
-                  "value": null
-                },
-                {
-                  "color": "green",
-                  "value": 10
-                },
-                {
-                  "color": "#EAB839",
-                  "value": 20
-                },
-                {
-                  "color": "red",
-                  "value": 30
-                }
-              ]
-            },
-            "unit": "decbytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 5,
-          "w": 7,
-          "x": 6,
-          "y": 0
-        },
-        "id": 14,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "text": {},
-          "textMode": "auto"
-        },
-        "pluginVersion": "8.4.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PF0BA5EC94FCB9BBE"
-            },
-            "exemplar": true,
-            "expr": "sum(kubelet_volume_stats_used_bytes{cluster=\"$cluster\"})",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "Used Space",
-            "refId": "C"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PF0BA5EC94FCB9BBE"
-            },
-            "exemplar": true,
-            "expr": "sum(kubelet_volume_stats_available_bytes{cluster=\"$cluster\"})",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "Available Space",
-            "refId": "B"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PF0BA5EC94FCB9BBE"
-            },
-            "exemplar": true,
-            "expr": "sum(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "Capacity",
-            "refId": "A"
-          }
-        ],
-        "title": "Space on Cluster",
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "uid": "${datasource}"
-        },
-        "description": "Shows PersistentVolumeClaims usage by namespace",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              }
-            },
-            "mappings": [],
-            "unit": "decbytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 10,
-          "w": 11,
-          "x": 13,
-          "y": 0
-        },
-        "id": 2,
-        "options": {
-          "displayLabels": [],
-          "legend": {
-            "displayMode": "table",
-            "placement": "right",
-            "values": [
-              "value"
-            ]
-          },
-          "pieType": "pie",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "8.1.1",
-        "targets": [
-          {
-            "exemplar": true,
-            "expr": "sum(kube_persistentvolumeclaim_resource_requests_storage_bytes{cluster=\"$cluster\"}) by (namespace)",
-            "interval": "",
-            "legendFormat": "{{ namespace }}",
-            "refId": "A"
-          }
-        ],
-        "title": "PVCs by Namespace",
-        "type": "piechart"
-      },
-      {
-        "description": "A bar gauge to display have storage you have used in comparison to the capacity of your storage.",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "dark-green",
-                  "value": null
-                },
-                {
-                  "color": "green",
-                  "value": 10
-                },
-                {
-                  "color": "#EAB839",
-                  "value": 20
-                },
-                {
-                  "color": "red",
-                  "value": 30
-                }
-              ]
-            },
-            "unit": "decbytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 5,
-          "w": 6,
-          "x": 0,
-          "y": 5
-        },
-        "id": 10,
-        "options": {
-          "displayMode": "gradient",
-          "orientation": "horizontal",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showUnfilled": true,
-          "text": {}
-        },
-        "pluginVersion": "8.4.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PF0BA5EC94FCB9BBE"
-            },
-            "exemplar": true,
-            "expr": "sum(kubelet_volume_stats_used_bytes{cluster=\"$cluster\"})",
-            "interval": "",
-            "legendFormat": "Used",
-            "refId": "A"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PF0BA5EC94FCB9BBE"
-            },
-            "exemplar": true,
-            "expr": "sum(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "Capacity/Total",
-            "refId": "B"
-          }
-        ],
-        "title": "Used Space by Cluster",
-        "transformations": [
-          {
-            "id": "configFromData",
-            "options": {
-              "configRefId": "B",
-              "mappings": [
-                {
-                  "fieldName": "Capacity/Total",
-                  "handlerKey": "max"
-                }
-              ]
-            }
-          }
-        ],
-        "type": "bargauge"
-      },
-      {
-        "description": "Total number of PVs per cluster",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "fixedColor": "purple",
-              "mode": "fixed"
-            },
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "dark-green",
-                  "value": null
-                },
-                {
-                  "color": "green",
-                  "value": 10
-                },
-                {
-                  "color": "yellow",
-                  "value": 20
-                },
-                {
-                  "color": "red",
-                  "value": 30
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 5,
-          "w": 7,
-          "x": 6,
-          "y": 5
-        },
-        "id": 4,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "text": {},
-          "textMode": "auto"
-        },
-        "pluginVersion": "8.4.3",
-        "targets": [
-          {
-            "exemplar": true,
-            "expr": "sum by(cluster) (pv_collector_total_pv_count)",
-            "interval": "",
-            "legendFormat": "{{ cluster }}",
-            "refId": "A"
-          }
-        ],
-        "title": "PV Total Count on Clusters",
-        "type": "stat"
-      },
-      {
-        "description": "This panel shows you the 20 worst PVC's by % of free capacity left",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "custom": {
-              "align": "left",
-              "displayMode": "color-text"
-            },
-            "mappings": [
-              {
-                "options": {
-                  "0": {
-                    "index": 0,
-                    "text": "0% EMPTY"
-                  }
-                },
-                "type": "value"
-              }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "#760613",
-                  "value": null
-                },
-                {
-                  "color": "dark-red",
-                  "value": 1e-8
-                },
-                {
-                  "color": "semi-dark-red",
-                  "value": 0.05
-                },
-                {
-                  "color": "red",
-                  "value": 0.25
-                },
-                {
-                  "color": "light-orange",
-                  "value": 0.4
-                },
-                {
-                  "color": "yellow",
-                  "value": 0.5
-                },
-                {
-                  "color": "light-green",
-                  "value": 0.65
-                },
-                {
-                  "color": "semi-dark-green",
-                  "value": 0.85
-                }
-              ]
-            },
-            "unit": "percentunit"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Namespace"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "text",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Persistent Volume Claim (PVC)"
-              },
-              "properties": [
-                {
-                  "id": "color",
-                  "value": {
-                    "fixedColor": "text",
-                    "mode": "fixed"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 12,
-          "w": 12,
-          "x": 0,
-          "y": 10
-        },
-        "id": 22,
-        "options": {
-          "footer": {
-            "fields": "",
-            "reducer": [
-              "sum"
-            ],
-            "show": false
-          },
-          "showHeader": true
-        },
-        "pluginVersion": "8.4.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PF0BA5EC94FCB9BBE"
-            },
-            "exemplar": false,
-            "expr": "bottomk(20, kubelet_volume_stats_available_bytes{cluster=\"$cluster\"} / kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
-            "format": "table",
-            "instant": true,
-            "interval": "",
-            "legendFormat": "{{namespace}}",
-            "refId": "A"
-          }
-        ],
-        "title": "Worst 20 PVCs by capacity remaining",
-        "transformations": [
-          {
-            "id": "organize",
-            "options": {
-              "excludeByName": {
-                "Time": true,
-                "cluster": true,
-                "endpoint": true,
-                "instance": true,
-                "job": true,
-                "metrics_path": true,
-                "node": true,
-                "prometheus": true,
-                "service": true,
-                "tenant_id": true
-              },
-              "indexByName": {},
-              "renameByName": {
-                "Value": "% of Free Space Left",
-                "instance": "",
-                "namespace": "Namespace",
-                "persistentvolumeclaim": "Persistent Volume Claim (PVC)"
-              }
-            }
-          }
-        ],
-        "type": "table"
-      },
-      {
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "description": "THis panel takes metrics from the containers file ssytem to display the top 20 namespaces suing Filesystem space usage",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "fixedColor": "blue",
-              "mode": "fixed"
-            },
-            "custom": {
-              "align": "left",
-              "displayMode": "auto",
-              "filterable": false
-            },
-            "mappings": [],
-            "min": 0,
-            "thresholds": {
-              "mode": "percentage",
-              "steps": [
-                {
-                  "color": "text",
-                  "value": null
-                },
-                {
-                  "color": "dark-green",
-                  "value": 5
-                }
-              ]
-            },
-            "unit": "decbytes"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 12,
-          "w": 12,
-          "x": 12,
-          "y": 10
-        },
-        "id": 20,
-        "options": {
-          "footer": {
-            "fields": "",
-            "reducer": [
-              "sum"
-            ],
-            "show": false
-          },
-          "showHeader": true,
-          "sortBy": [
-            {
-              "desc": true,
-              "displayName": "Usuage"
-            }
-          ]
-        },
-        "pluginVersion": "8.4.3",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PF0BA5EC94FCB9BBE"
-            },
-            "exemplar": false,
-            "expr": "topk(20, sort_desc(sum(avg_over_time(pod:container_fs_usage_bytes:sum{container=\"\", pod!=\"\"}[5m])) BY (namespace)))",
-            "format": "table",
-            "hide": false,
-            "instant": true,
-            "interval": "",
-            "legendFormat": "",
-            "refId": "C"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${datasource}"
-            },
-            "exemplar": true,
-            "expr": "container_fs_",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "",
-            "refId": "A"
-          }
-        ],
-        "title": "Top 20 Namespace usage on Cluster (File-system)",
-        "transformations": [
-          {
-            "id": "organize",
-            "options": {
-              "excludeByName": {
-                "Time": true
-              },
-              "indexByName": {},
-              "renameByName": {
-                "Time": "",
-                "Value": "Space Used",
-                "Value #C": "Usuage",
-                "namespace": "namespace/project"
-              }
-            }
-          }
-        ],
-        "type": "table"
-      }
-    ],
-    "schemaVersion": 35,
-    "style": "dark",
-    "tags": [],
-    "templating": {
-      "list": [
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": 40,
+      "iteration": 1649686222292,
+      "links": [],
+      "liveNow": false,
+      "panels": [
         {
-          "current": {
-            "selected": false,
-            "text": "thanos-frontend",
-            "value": "thanos-frontend"
-          },
-          "hide": 0,
-          "includeAll": false,
-          "multi": false,
-          "name": "datasource",
-          "options": [],
-          "query": "prometheus",
-          "queryValue": "",
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "type": "datasource"
-        },
-        {
-          "current": {
-            "selected": false,
-            "text": "moc/smaug",
-            "value": "moc/smaug"
-          },
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "definition": "label_values(kubelet_node_name, cluster)",
-          "hide": 0,
-          "includeAll": false,
-          "multi": false,
-          "name": "cluster",
-          "options": [],
-          "query": {
-            "query": "label_values(kubelet_node_name, cluster)",
-            "refId": "StandardVariableQuery"
+          "description": "These metrics are from the space queried from persistent volumes (PVs)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "dark-red",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.2
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.4
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "light-green",
+                    "value": 0.7
+                  },
+                  {
+                    "color": "green",
+                    "value": 0.8
+                  },
+                  {
+                    "color": "dark-green",
+                    "value": 0.9
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
           },
-          "refresh": 2,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 0,
-          "type": "query"
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 0,
+            "y": 0
+          },
+          "id": 16,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "8.4.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_available_bytes{cluster=\"$cluster\"}) / sum(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
+              "interval": "",
+              "legendFormat": "{{cluster}}",
+              "refId": "A"
+            }
+          ],
+          "title": "% of Free Space on Cluster",
+          "type": "stat"
+        },
+        {
+          "description": "These metrics show used, available, and total PVC space on the cluster. This only takes into account already allocated and bound PVCs. The total PVC space will increase if more PVC's are created on a given cluster.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "blue",
+                "mode": "fixed"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "dark-green",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 10
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 20
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 7,
+            "x": 6,
+            "y": 0
+          },
+          "id": 14,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "8.4.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PF0BA5EC94FCB9BBE"
+              },
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_used_bytes{cluster=\"$cluster\"})",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Used Space",
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PF0BA5EC94FCB9BBE"
+              },
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_available_bytes{cluster=\"$cluster\"})",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Available Space",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PF0BA5EC94FCB9BBE"
+              },
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Capacity",
+              "refId": "A"
+            }
+          ],
+          "title": "Space on Cluster",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "description": "Shows PersistentVolumeClaims usage by namespace",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": [],
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 11,
+            "x": 13,
+            "y": 0
+          },
+          "id": 2,
+          "options": {
+            "displayLabels": [],
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "values": [
+                "value"
+              ]
+            },
+            "pieType": "pie",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.1.1",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(kube_persistentvolumeclaim_resource_requests_storage_bytes{cluster=\"$cluster\"}) by (namespace)",
+              "interval": "",
+              "legendFormat": "{{ namespace }}",
+              "refId": "A"
+            }
+          ],
+          "title": "PVC usage by namespace",
+          "type": "piechart"
+        },
+        {
+          "description": "A bar gauge to display have storage you have used in comparison to the capacity of your storage.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "dark-green",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 10
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 20
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 0,
+            "y": 5
+          },
+          "id": 10,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
+          },
+          "pluginVersion": "8.4.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PF0BA5EC94FCB9BBE"
+              },
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_used_bytes{cluster=\"$cluster\"})",
+              "interval": "",
+              "legendFormat": "Used",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PF0BA5EC94FCB9BBE"
+              },
+              "exemplar": true,
+              "expr": "sum(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Capacity/Total",
+              "refId": "B"
+            }
+          ],
+          "title": "Used Space by Cluster",
+          "transformations": [
+            {
+              "id": "configFromData",
+              "options": {
+                "configRefId": "B",
+                "mappings": [
+                  {
+                    "fieldName": "Capacity/Total",
+                    "handlerKey": "max"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "bargauge"
+        },
+        {
+          "description": "Total number of PVs per cluster",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "purple",
+                "mode": "fixed"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "dark-green",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 10
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 20
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 7,
+            "x": 6,
+            "y": 5
+          },
+          "id": 4,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "8.4.3",
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum by(cluster) (pv_collector_total_pv_count)",
+              "interval": "",
+              "legendFormat": "{{ cluster }}",
+              "refId": "A"
+            }
+          ],
+          "title": "PV Total Count on Clusters",
+          "type": "stat"
+        },
+        {
+          "description": "This panel shows you the 20 PVC's with the least % of free capacity left",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "left",
+                "displayMode": "color-text"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "index": 0,
+                      "text": "0% EMPTY"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "#760613",
+                    "value": null
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 1e-8
+                  },
+                  {
+                    "color": "semi-dark-red",
+                    "value": 0.05
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.25
+                  },
+                  {
+                    "color": "light-orange",
+                    "value": 0.4
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.5
+                  },
+                  {
+                    "color": "light-green",
+                    "value": 0.65
+                  },
+                  {
+                    "color": "semi-dark-green",
+                    "value": 0.85
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Namespace"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "text",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Persistent Volume Claim (PVC)"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "text",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "id": 22,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "8.4.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PF0BA5EC94FCB9BBE"
+              },
+              "exemplar": false,
+              "expr": "bottomk(20, kubelet_volume_stats_available_bytes{cluster=\"$cluster\"} / kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{namespace}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Lowest 20 PVCs by capacity remaining",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "cluster": true,
+                  "endpoint": true,
+                  "instance": true,
+                  "job": true,
+                  "metrics_path": true,
+                  "node": true,
+                  "prometheus": true,
+                  "service": true,
+                  "tenant_id": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "Value": "% of Free Space Left",
+                  "instance": "",
+                  "namespace": "Namespace",
+                  "persistentvolumeclaim": "Persistent Volume Claim (PVC)"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "THis panel takes metrics from the containers file ssytem to display the top 20 namespaces suing Filesystem space usage",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "blue",
+                "mode": "fixed"
+              },
+              "custom": {
+                "align": "left",
+                "displayMode": "auto",
+                "filterable": false
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  },
+                  {
+                    "color": "dark-green",
+                    "value": 5
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          },
+          "id": 20,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Usuage"
+              }
+            ]
+          },
+          "pluginVersion": "8.4.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PF0BA5EC94FCB9BBE"
+              },
+              "exemplar": false,
+              "expr": "topk(20, sort_desc(sum(avg_over_time(pod:container_fs_usage_bytes:sum{container=\"\", pod!=\"\"}[5m])) BY (namespace)))",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "exemplar": true,
+              "expr": "container_fs_",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Top 20 Namespace usage on Cluster (File-system)",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "Time": "",
+                  "Value": "Space Used",
+                  "Value #C": "Usuage",
+                  "namespace": "namespace/project"
+                }
+              }
+            }
+          ],
+          "type": "table"
         }
-      ]
-    },
-    "time": {
-      "from": "now-1h",
-      "to": "now"
-    },
-    "timepicker": {},
-    "timezone": "",
-    "title": "Cluster Storage Overview",
-    "uid": "-78BTNY7k",
-    "version": 0,
-    "weekStart": ""
+      ],
+      "schemaVersion": 35,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "thanos-frontend",
+              "value": "thanos-frontend"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "queryValue": "",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          },
+          {
+            "current": {
+              "selected": false,
+              "text": "moc/smaug",
+              "value": "moc/smaug"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "definition": "label_values(kubelet_node_name, cluster)",
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "cluster",
+            "options": [],
+            "query": {
+              "query": "label_values(kubelet_node_name, cluster)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Cluster Storage Overview",
+      "uid": "-78BTNY7k",
+      "version": 0,
+      "weekStart": ""
     }

--- a/grafana/overlays/moc/smaug/dashboards/cluster-management/cluster-storage-overview.yaml
+++ b/grafana/overlays/moc/smaug/dashboards/cluster-management/cluster-storage-overview.yaml
@@ -11,143 +11,774 @@ spec:
       version: 1.6.2
   json: |
     {
-      "annotations": {
-        "list": [
-          {
-            "builtIn": 1,
-            "datasource": "-- Grafana --",
-            "enable": true,
-            "hide": true,
-            "iconColor": "rgba(0, 211, 255, 1)",
-            "name": "Annotations & Alerts",
-            "target": {
-              "limit": 100,
-              "matchAny": false,
-              "tags": [],
-              "type": "dashboard"
-            },
-            "type": "dashboard"
-          }
-        ]
-      },
-      "editable": true,
-      "gnetId": null,
-      "graphTooltip": 0,
-      "id": 8,
-      "iteration": 1633725270713,
-      "links": [],
-      "panels": [
+    "annotations": {
+      "list": [
         {
-          "aliasColors": {},
-          "breakPoint": "50%",
-          "cacheTimeout": null,
-          "combine": {
-            "label": "Others",
-            "threshold": ".01"
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
           },
-          "datasource": "$datasource",
-          "description": "This graph shows the sum of PVC storage requested by namespace.",
-          "fontSize": "80%",
-          "format": "decbytes",
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 0,
-            "y": 0
-          },
-          "id": 2,
-          "interval": null,
-          "legend": {
-            "percentage": true,
-            "show": true,
-            "sort": null,
-            "sortDesc": null,
-            "values": true
-          },
-          "legendType": "Right side",
-          "links": [],
-          "nullPointMode": "connected",
-          "pieType": "pie",
-          "pluginVersion": "7.1.1",
-          "strokeWidth": ".05",
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "sum(kube_persistentvolumeclaim_resource_requests_storage_bytes{cluster=\"$cluster\"}) by (namespace)",
-              "instant": true,
-              "interval": "",
-              "legendFormat": "{{namespace}}",
-              "refId": "A"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "PVC's by Namespace",
-          "type": "grafana-piechart-panel",
-          "valueName": "current"
+          "type": "dashboard"
         }
-      ],
-      "schemaVersion": 30,
-      "style": "dark",
-      "tags": [],
-      "templating": {
-        "list": [
-          {
-            "current": {
-              "selected": false,
-              "text": "openshift-monitoring",
-              "value": "openshift-monitoring"
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 40,
+    "iteration": 1649426728385,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "description": "These metrics are from the space queried from persistent volumes (PVs)",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
             },
-            "description": null,
-            "error": null,
-            "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "datasource",
-            "options": [],
-            "query": "prometheus",
-            "refresh": 1,
-            "regex": "",
-            "skipUrlSync": false,
-            "type": "datasource"
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "dark-red",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 0.2
+                },
+                {
+                  "color": "orange",
+                  "value": 0.4
+                },
+                {
+                  "color": "yellow",
+                  "value": 0.5
+                },
+                {
+                  "color": "light-green",
+                  "value": 0.7
+                },
+                {
+                  "color": "green",
+                  "value": 0.8
+                },
+                {
+                  "color": "dark-green",
+                  "value": 0.9
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 6,
+          "x": 0,
+          "y": 0
+        },
+        "id": 16,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "text": {},
+          "textMode": "auto"
+        },
+        "pluginVersion": "8.4.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "exemplar": true,
+            "expr": "sum(kubelet_volume_stats_available_bytes{cluster=\"$cluster\"}) / sum(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
+            "interval": "",
+            "legendFormat": "{{cluster}}",
+            "refId": "A"
+          }
+        ],
+        "title": "% of Free Space on Cluster",
+        "type": "stat"
+      },
+      {
+        "description": "These metrics show used, available, and total space on the cluster\n(Note: These metrics are from PersistentVolumes)",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "blue",
+              "mode": "fixed"
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "dark-green",
+                  "value": null
+                },
+                {
+                  "color": "green",
+                  "value": 10
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 20
+                },
+                {
+                  "color": "red",
+                  "value": 30
+                }
+              ]
+            },
+            "unit": "decbytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 7,
+          "x": 6,
+          "y": 0
+        },
+        "id": 14,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "text": {},
+          "textMode": "auto"
+        },
+        "pluginVersion": "8.4.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PF0BA5EC94FCB9BBE"
+            },
+            "exemplar": true,
+            "expr": "sum(kubelet_volume_stats_used_bytes{cluster=\"$cluster\"})",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Used Space",
+            "refId": "C"
           },
           {
-            "allValue": null,
-            "current": {
-              "selected": false,
-              "text": "moc/smaug",
-              "value": "moc/smaug"
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PF0BA5EC94FCB9BBE"
             },
-            "datasource": "${datasource}",
-            "definition": "label_values(kubelet_node_name, cluster)",
-            "description": null,
-            "error": null,
-            "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "cluster",
-            "options": [],
-            "query": {
-              "query": "label_values(kubelet_node_name, cluster)",
-              "refId": "StandardVariableQuery"
+            "exemplar": true,
+            "expr": "sum(kubelet_volume_stats_available_bytes{cluster=\"$cluster\"})",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Available Space",
+            "refId": "B"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PF0BA5EC94FCB9BBE"
             },
-            "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 0,
-            "type": "query"
+            "exemplar": true,
+            "expr": "sum(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Capacity",
+            "refId": "A"
           }
-        ]
+        ],
+        "title": "Space on Cluster",
+        "type": "stat"
       },
-      "time": {
-        "from": "now-6h",
-        "to": "now"
+      {
+        "datasource": {
+          "uid": "${datasource}"
+        },
+        "description": "Shows PersistentVolumeClaims usage by namespace",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": [],
+            "unit": "decbytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 10,
+          "w": 11,
+          "x": 13,
+          "y": 0
+        },
+        "id": 2,
+        "options": {
+          "displayLabels": [],
+          "legend": {
+            "displayMode": "table",
+            "placement": "right",
+            "values": [
+              "value"
+            ]
+          },
+          "pieType": "pie",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "8.1.1",
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "sum(kube_persistentvolumeclaim_resource_requests_storage_bytes{cluster=\"$cluster\"}) by (namespace)",
+            "interval": "",
+            "legendFormat": "{{ namespace }}",
+            "refId": "A"
+          }
+        ],
+        "title": "PVCs by Namespace",
+        "type": "piechart"
       },
-      "timepicker": {},
-      "timezone": "",
-      "title": "Cluster Storage Overview",
-      "uid": "Z7hD22v7k",
-      "version": 8
+      {
+        "description": "A bar gauge to display have storage you have used in comparison to the capacity of your storage.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "dark-green",
+                  "value": null
+                },
+                {
+                  "color": "green",
+                  "value": 10
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 20
+                },
+                {
+                  "color": "red",
+                  "value": 30
+                }
+              ]
+            },
+            "unit": "decbytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 6,
+          "x": 0,
+          "y": 5
+        },
+        "id": 10,
+        "options": {
+          "displayMode": "gradient",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "text": {}
+        },
+        "pluginVersion": "8.4.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PF0BA5EC94FCB9BBE"
+            },
+            "exemplar": true,
+            "expr": "sum(kubelet_volume_stats_used_bytes{cluster=\"$cluster\"})",
+            "interval": "",
+            "legendFormat": "Used",
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PF0BA5EC94FCB9BBE"
+            },
+            "exemplar": true,
+            "expr": "sum(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Capacity/Total",
+            "refId": "B"
+          }
+        ],
+        "title": "Used Space by Cluster",
+        "transformations": [
+          {
+            "id": "configFromData",
+            "options": {
+              "configRefId": "B",
+              "mappings": [
+                {
+                  "fieldName": "Capacity/Total",
+                  "handlerKey": "max"
+                }
+              ]
+            }
+          }
+        ],
+        "type": "bargauge"
+      },
+      {
+        "description": "Total number of PVs per cluster",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "purple",
+              "mode": "fixed"
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "dark-green",
+                  "value": null
+                },
+                {
+                  "color": "green",
+                  "value": 10
+                },
+                {
+                  "color": "yellow",
+                  "value": 20
+                },
+                {
+                  "color": "red",
+                  "value": 30
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 7,
+          "x": 6,
+          "y": 5
+        },
+        "id": 4,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "text": {},
+          "textMode": "auto"
+        },
+        "pluginVersion": "8.4.3",
+        "targets": [
+          {
+            "exemplar": true,
+            "expr": "sum by(cluster) (pv_collector_total_pv_count)",
+            "interval": "",
+            "legendFormat": "{{ cluster }}",
+            "refId": "A"
+          }
+        ],
+        "title": "PV Total Count on Clusters",
+        "type": "stat"
+      },
+      {
+        "description": "This panel shows you the 20 worst PVC's by % of free capacity left",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "left",
+              "displayMode": "color-text"
+            },
+            "mappings": [
+              {
+                "options": {
+                  "0": {
+                    "index": 0,
+                    "text": "0% EMPTY"
+                  }
+                },
+                "type": "value"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "#760613",
+                  "value": null
+                },
+                {
+                  "color": "dark-red",
+                  "value": 1e-8
+                },
+                {
+                  "color": "semi-dark-red",
+                  "value": 0.05
+                },
+                {
+                  "color": "red",
+                  "value": 0.25
+                },
+                {
+                  "color": "light-orange",
+                  "value": 0.4
+                },
+                {
+                  "color": "yellow",
+                  "value": 0.5
+                },
+                {
+                  "color": "light-green",
+                  "value": 0.65
+                },
+                {
+                  "color": "semi-dark-green",
+                  "value": 0.85
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Namespace"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "text",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Persistent Volume Claim (PVC)"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "text",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 12,
+          "w": 12,
+          "x": 0,
+          "y": 10
+        },
+        "id": 22,
+        "options": {
+          "footer": {
+            "fields": "",
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": true
+        },
+        "pluginVersion": "8.4.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PF0BA5EC94FCB9BBE"
+            },
+            "exemplar": false,
+            "expr": "bottomk(20, kubelet_volume_stats_available_bytes{cluster=\"$cluster\"} / kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\"})",
+            "format": "table",
+            "instant": true,
+            "interval": "",
+            "legendFormat": "{{namespace}}",
+            "refId": "A"
+          }
+        ],
+        "title": "Worst 20 PVCs by capacity remaining",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "Time": true,
+                "cluster": true,
+                "endpoint": true,
+                "instance": true,
+                "job": true,
+                "metrics_path": true,
+                "node": true,
+                "prometheus": true,
+                "service": true,
+                "tenant_id": true
+              },
+              "indexByName": {},
+              "renameByName": {
+                "Value": "% of Free Space Left",
+                "instance": "",
+                "namespace": "Namespace",
+                "persistentvolumeclaim": "Persistent Volume Claim (PVC)"
+              }
+            }
+          }
+        ],
+        "type": "table"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "description": "THis panel takes metrics from the containers file ssytem to display the top 20 namespaces suing Filesystem space usage",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "blue",
+              "mode": "fixed"
+            },
+            "custom": {
+              "align": "left",
+              "displayMode": "auto",
+              "filterable": false
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "text",
+                  "value": null
+                },
+                {
+                  "color": "dark-green",
+                  "value": 5
+                }
+              ]
+            },
+            "unit": "decbytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 12,
+          "w": 12,
+          "x": 12,
+          "y": 10
+        },
+        "id": 20,
+        "options": {
+          "footer": {
+            "fields": "",
+            "reducer": [
+              "sum"
+            ],
+            "show": false
+          },
+          "showHeader": true,
+          "sortBy": [
+            {
+              "desc": true,
+              "displayName": "Usuage"
+            }
+          ]
+        },
+        "pluginVersion": "8.4.3",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PF0BA5EC94FCB9BBE"
+            },
+            "exemplar": false,
+            "expr": "topk(20, sort_desc(sum(avg_over_time(pod:container_fs_usage_bytes:sum{container=\"\", pod!=\"\"}[5m])) BY (namespace)))",
+            "format": "table",
+            "hide": false,
+            "instant": true,
+            "interval": "",
+            "legendFormat": "",
+            "refId": "C"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "exemplar": true,
+            "expr": "container_fs_",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "title": "Top 20 Namespace usage on Cluster (File-system)",
+        "transformations": [
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "Time": true
+              },
+              "indexByName": {},
+              "renameByName": {
+                "Time": "",
+                "Value": "Space Used",
+                "Value #C": "Usuage",
+                "namespace": "namespace/project"
+              }
+            }
+          }
+        ],
+        "type": "table"
+      }
+    ],
+    "schemaVersion": 35,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "selected": false,
+            "text": "thanos-frontend",
+            "value": "thanos-frontend"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "multi": false,
+          "name": "datasource",
+          "options": [],
+          "query": "prometheus",
+          "queryValue": "",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "type": "datasource"
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": "moc/smaug",
+            "value": "moc/smaug"
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "definition": "label_values(kubelet_node_name, cluster)",
+          "hide": 0,
+          "includeAll": false,
+          "multi": false,
+          "name": "cluster",
+          "options": [],
+          "query": {
+            "query": "label_values(kubelet_node_name, cluster)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "type": "query"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-1h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Cluster Storage Overview",
+    "uid": "-78BTNY7k",
+    "version": 0,
+    "weekStart": ""
     }


### PR DESCRIPTION
## Description
With this PR we'll now have a more detailed and *enhanced* Cluster Storage Overview Dashboard

**New Panels/Content**
- Percentage of Free space left on cluster
- PV space metrics (Used, Available, and Capacity in the context of space)
- Bar gauge which displays space remaining
- PV Count metrics, number of PVs (for all clusters)
- Table of 20 worst PVCs by capacity remaining (per cluster)
- Top 20 namespaces by file system usage 


## Preview
*Previous Version*
![image](https://user-images.githubusercontent.com/68972382/162464325-d1c7ac37-f46d-4ee8-94f1-8dd86c175a52.png)

*New Version*
![image](https://user-images.githubusercontent.com/68972382/162464373-fcd999a3-7369-47a3-913c-f4f903b08c19.png)

## Note
All comments and feedback is greatly appreciated!
