### PR TITLE
Kafka: Add user and topic for od-demo project

### DIFF
--- a/odh-manifests/smaug/kafka/overlays/topics/emea-sa-od-demo-images.yaml
+++ b/odh-manifests/smaug/kafka/overlays/topics/emea-sa-od-demo-images.yaml
@@ -1,7 +1,7 @@
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: od-demo-images
+  name: emea-sa.od-demo.images
   labels:
     strimzi.io/cluster: odh-message-bus
 spec:

--- a/odh-manifests/smaug/kafka/overlays/topics/emea-sa-od-demo-images.yaml
+++ b/odh-manifests/smaug/kafka/overlays/topics/emea-sa-od-demo-images.yaml
@@ -1,0 +1,12 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: od-demo-images
+  labels:
+    strimzi.io/cluster: odh-message-bus
+spec:
+  partitions: 2
+  replicas: 3
+  config:
+    # message retention period is 6 hours
+    retention.ms: 21600000

--- a/odh-manifests/smaug/kafka/overlays/topics/emea-sa-od-demo-objects.yaml
+++ b/odh-manifests/smaug/kafka/overlays/topics/emea-sa-od-demo-objects.yaml
@@ -1,7 +1,7 @@
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
-  name: od-demo-objects
+  name: emea-sa.od-demo.objects
   labels:
     strimzi.io/cluster: odh-message-bus
 spec:

--- a/odh-manifests/smaug/kafka/overlays/topics/emea-sa-od-demo-objects.yaml
+++ b/odh-manifests/smaug/kafka/overlays/topics/emea-sa-od-demo-objects.yaml
@@ -1,0 +1,12 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: od-demo-objects
+  labels:
+    strimzi.io/cluster: odh-message-bus
+spec:
+  partitions: 2
+  replicas: 3
+  config:
+    # message retention period is 6 hours
+    retention.ms: 21600000

--- a/odh-manifests/smaug/kafka/overlays/topics/kustomization.yaml
+++ b/odh-manifests/smaug/kafka/overlays/topics/kustomization.yaml
@@ -35,3 +35,5 @@ resources:
 - thoth-unresolved-package.yaml
 - thoth-unrevsolved-package.yaml
 - thoth-update-provides-source-distro.yaml
+- emea-sa-od-demo-objects.yaml
+- emea-sa-od-demo-images.yaml

--- a/odh-manifests/smaug/kafka/overlays/users/emea-sa-od-demo.yaml
+++ b/odh-manifests/smaug/kafka/overlays/users/emea-sa-od-demo.yaml
@@ -1,0 +1,24 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: emea-sa.od-demo
+spec:
+  authentication:
+    type: tls
+  authorization:
+    acls:
+      - host: '*'
+        operation: All
+        resource:
+          name: emea-sa.od-demo.
+          patternType: prefix
+          type: topic
+        type: allow
+      - host: '*'
+        operation: All
+        resource:
+          name: emea-sa.od-demo
+          patternType: prefix
+          type: group
+        type: allow
+    type: simple

--- a/odh-manifests/smaug/kafka/overlays/users/kustomization.yaml
+++ b/odh-manifests/smaug/kafka/overlays/users/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - cluster-logging.yaml
 - opf-public-demo.yaml
 - thoth.yaml
+- emea-sa-od-demo.yaml


### PR DESCRIPTION
Enabling Kafka integration for [object detection demo application](https://github.com/operate-first/support/issues/538). 