### PR TITLE
Set query.max-length=10M (overriding 1M default)

### DIFF
--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/osc_datacommons_dev.properties
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/osc_datacommons_dev.properties
@@ -14,3 +14,4 @@ hive.recursive-directories=true
 hive.non-managed-table-writes-enabled=true
 hive.s3.aws-access-key=${ENV:OSC_DATACOMMONS_DEV_AWS_ACCESS_KEY_ID}
 hive.s3.aws-secret-key=${ENV:OSC_DATACOMMONS_DEV_AWS_SECRET_ACCESS_KEY}
+query.max-length=10000000


### PR DESCRIPTION
The default query.max-length=1000000.  For datasets such as SEC_DERA, the 1M limit allows for approx 1500 rows per insertion.  When there are millions of rows, this not only creates thousands of snapshots, but each snapshot file also references the chain of snapshots, growing these files from a few K to several MB per snapshot.

By increasing the max-length parameter to 10M, we not only cut down the number of objects in the metastore, but we also decrease the number of snapshots each of these objects needs to reference, reducing storage requirements by a factor of 100 (10*10).