### PR TITLE
Revert "Set query.max-length=10M (overriding 1M default) (#1883)"

### DIFF
--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/osc_datacommons_dev.properties
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/osc_datacommons_dev.properties
@@ -14,4 +14,3 @@ hive.recursive-directories=true
 hive.non-managed-table-writes-enabled=true
 hive.s3.aws-access-key=${ENV:OSC_DATACOMMONS_DEV_AWS_ACCESS_KEY_ID}
 hive.s3.aws-secret-key=${ENV:OSC_DATACOMMONS_DEV_AWS_SECRET_ACCESS_KEY}
-query.max-length=10000000


### PR DESCRIPTION
This reverts commit 56e3a56c7d1e3c4411260a82943ede20e6c57fb8.

Resolve: 
https://github.com/operate-first/operations/issues/466