### PR TITLE
Set query.max-length=10M in correct files

### DIFF
--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/config-coordinator.properties
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/config-coordinator.properties
@@ -15,3 +15,4 @@ http-server.authentication.oauth2.client-secret=${ENV:TRINO_OAUTH_SECRET}
 http-server.authentication.oauth2.scopes=openid,groups,email
 http-server.authentication.oauth2.principal-field=email
 http-server.authentication.oauth2.additional-audiences=das
+query.max-length=10000000

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/config-worker.properties
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/config-worker.properties
@@ -1,3 +1,4 @@
 coordinator=false
 http-server.http.port=8080
 discovery.uri=http://trino-service:8080
+query.max-length=10000000


### PR DESCRIPTION
Per guidance from Trino slack channel:

"Everything unless mentioned needs to be set in both coordinators and workers. Only things like security configs and global system level things (like overall cluster memory) are required only on coordinator."