### PR TITLE
Switch to manual odh deploy on osc clusters.

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl1/cluster-management/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl1/cluster-management/kustomization.yaml
@@ -1,10 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cluster-resources.yaml
   - acme-operator.yaml
-  - dex.yaml
   - cloudbeaver.yaml
+  - cluster-resources.yaml
+  - dex.yaml
   - k8s-annotations-exporter.yaml
   - kfdefs.yaml
+  - odh-operator.yaml
   - training-operator.yaml

--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl1/cluster-management/odh-operator.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl1/cluster-management/odh-operator.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: opendatahub-operator
+spec:
+  destination:
+    name: osc-cl1
+    namespace: opendatahub-operator
+  project: os-climate
+  source:
+    path: odh-operator/overlays/osc/osc-cl1
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false

--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/cluster-management/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/cluster-management/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
   - k8s-annotations-exporter.yaml
   - kfdefs.yaml
   - kfp-tekton.yaml
+  - odh-operator.yaml
   - pachyderm.yaml
   - reloader.yaml

--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/cluster-management/odh-operator.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/cluster-management/odh-operator.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: opendatahub-operator
+spec:
+  destination:
+    name: osc-cl2
+    namespace: opendatahub-operator
+  project: os-climate
+  source:
+    path: odh-operator/overlays/osc/osc-cl2
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false

--- a/cluster-scope/bundles/opendatahub-operator-manual/kustomization.yaml
+++ b/cluster-scope/bundles/opendatahub-operator-manual/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base/core/namespaces/opendatahub-operator
+  - ../../base/apiextensions.k8s.io/customresourcedefinitions/kfdefs.kfdef.apps.kubeflow.org

--- a/cluster-scope/overlays/prod/osc/osc-cl1/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/kustomization.yaml
@@ -10,7 +10,6 @@ patchesStrategicMerge:
 - groups/pachyderm-admins.yaml
 - groups/seldon-admin.yaml
 resources:
-- ../../../../base/apiextensions.k8s.io/customresourcedefinitions/kfdefs.kfdef.apps.kubeflow.org
 - ../../../../base/core/configmaps/cluster-monitoring-config
 - ../../../../base/core/configmaps/user-workload-monitoring-config
 - ../../../../base/core/namespaces/acme-operator
@@ -28,7 +27,6 @@ resources:
 - ../../../../base/core/namespaces/sandbox
 - ../../../../base/core/namespaces/sostrades-namespace
 - ../../../../base/operators.coreos.com/subscriptions/cert-manager
-- ../../../../base/operators.coreos.com/subscriptions/opendatahub-operator
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-rb
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-reader-k8s-annotations-exporter
@@ -42,6 +40,7 @@ resources:
 - ../../../../base/user.openshift.io/groups/pachyderm-admins
 - ../../../../base/user.openshift.io/groups/seldon-admin
 - ../../../../base/user.openshift.io/groups/sostrades
+- ../../../../bundles/opendatahub-operator-manual
 - ../../../../bundles/training-operator
 - apiserver
 - ingresscontroller

--- a/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
@@ -16,7 +16,6 @@ resources:
   - ../../../../base/core/namespaces/nvidia-gpu-operator
   - ../../../../base/operators.coreos.com/operatorgroups/openshift-nfd
   - ../../../../base/operators.coreos.com/subscriptions/nfd
-  - ../../../../base/operators.coreos.com/subscriptions/opendatahub-operator
   - ../../../../base/config.openshift.io/oauths/cluster
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-rb
@@ -30,6 +29,7 @@ resources:
   - ../../../../base/user.openshift.io/groups/pachyderm-admins
   - ../../../../base/user.openshift.io/groups/seldon-admin
   - ../../../../bundles/kfp-tekton
+  - ../../../../bundles/opendatahub-operator-manual
   - ../../../../bundles/openshift-pipelines
   - ../../../../bundles/pachyderm-operator
   - ../../../../bundles/reloader

--- a/odh-operator/overlays/osc/osc-cl1/kustomization.yaml
+++ b/odh-operator/overlays/osc/osc-cl1/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base

--- a/odh-operator/overlays/osc/osc-cl2/kustomization.yaml
+++ b/odh-operator/overlays/osc/osc-cl2/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base


### PR DESCRIPTION
In this cluster we have handed out project admin permissions to some
users so we are forced to remove odh from olm management due to security
reasons. Otherwise these users will be able to deploy kfdefs.