### PR TITLE
feat(osc-cl1): Fix BYON deployment

### DIFF
--- a/kfdefs/overlays/osc/osc-cl1/dashboard/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/dashboard/kfdef.yaml
@@ -14,5 +14,5 @@ spec:
       name: odh-dashboard
   repos:
     - name: manifests
-      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl1-byon
+      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl1-v1.1.2
   version: v1.1.0

--- a/kfdefs/overlays/osc/osc-cl1/jupyterhub-stage/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/jupyterhub-stage/kfdef.yaml
@@ -18,6 +18,8 @@ spec:
             value: "opf-jupyterhub-stage"
           - name: s3_endpoint_url
             value: s3.odh.com
+        overlays:
+          - byon
         repoRef:
           name: manifests
           path: jupyterhub/jupyterhub
@@ -32,8 +34,8 @@ spec:
     - kustomizeConfig:
         repoRef:
           name: manifests
-          path: jupyterhub/byon
-      name: byon
+          path: odh-dashboard
+      name: odh-dashboard
   repos:
     - name: manifests
       uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl1-byon


### PR DESCRIPTION
Related to: https://github.com/open-services-group/byon/issues/20
Requires: https://github.com/operate-first/odh-manifests/pull/19


- Deploying ODH Dashboard to `jupyterhub-stage`: Upstream of ODH Dashboard has no notion of namespaces and treats everything like it's in the same namespace, that means BYON pipelines needs to live in the same namespace as JupyterHub and Dashboard, that's the only way how Dashboard is able to trigger the pipelines and JH to see the resulting imagestreams.
- Reverting the `odh-dashboard` namespace to `v1.1.2` tag.
- Deploying BYON from JH overlay

/cc @harshad16 