### PR TITLE
Added display-name to namespaces

### DIFF
--- a/cluster-scope/base/core/namespaces/democratic-csi/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/democratic-csi/namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
     name: democratic-csi
     annotations:
+        openshift.io/display-name: "Democratic-csi"
         op1st/project-owner: operate-first
         op1st/onboarding-issue: "https://github.com/operate-first/operations/issues/280"
         op1st/docs: "https://github.com/democratic-csi/democratic-csi"

--- a/cluster-scope/base/core/namespaces/fedora/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/fedora/namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
     name: fedora
     annotations:
+        openshift.io/display-name: "Fedora"
         openshift.io/requester: fedora
         op1st/project-owner: fedora
         op1st/onboarding-issue: "https://github.com/operate-first/support/issues/500"

--- a/cluster-scope/base/core/namespaces/fybrik-applications/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/fybrik-applications/namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
     name: fybrik-applications
     annotations:
+        openshift.io/display-name: "Fybrik"
         openshift.io/requester: fybrik
         op1st/project-owner: fybrik
         op1st/onboarding-issue: "https://github.com/operate-first/support/issues/41"


### PR DESCRIPTION
## Description
This commit addresses the issue where some namespaces shown in the **Workload Overview dashboard** have an empty **project title**. This is fixed by adding `openshift.io/display-name` annotation to these namespaces