### PR TITLE
Remove unsupported crd fields in kfdef crd.

### DIFF
--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/kfdefs.kfdef.apps.kubeflow.org/customresourcedefinition.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/kfdefs.kfdef.apps.kubeflow.org/customresourcedefinition.yaml
@@ -10,32 +10,6 @@ spec:
     plural: kfdefs
     singular: kfdef
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: KfDef is the Schema for the kfdefs API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: KfDefSpec defines the desired state of KfDef
-          type: object
-        status:
-          description: KfDefStatus defines the observed state of KfDef
-          type: object
-      type: object
-  version: v1
   versions:
     - name: v1
       served: true


### PR DESCRIPTION
Kfdef pulled from here:  https://github.com/opendatahub-io/opendatahub-operator/blob/master/deploy/crds/kfdef.apps.kubeflow.org_kfdefs_crd.yaml

Has fields that don't seem supported by the [current api spec](https://docs.openshift.com/container-platform/4.9/rest_api/extension_apis/customresourcedefinition-apiextensions-k8s-io-v1.html#apisapiextensions-k8s-iov1customresourcedefinitionsname), namely `subresources` , `validation`, `version`. 

We should follow up once this is remedied upstream. 