### PR TITLE
Adding service monitors for Trino and seldon to expose their metrics to prometheus.

### DIFF
--- a/kfdefs/overlays/moc/smaug/seldon/kustomization.yaml
+++ b/kfdefs/overlays/moc/smaug/seldon/kustomization.yaml
@@ -5,3 +5,4 @@ namespace: opf-seldon
 
 resources:
   - kfdef.yaml
+  - servicemonitor.yaml

--- a/kfdefs/overlays/moc/smaug/seldon/servicemonitor.yaml
+++ b/kfdefs/overlays/moc/smaug/seldon/servicemonitor.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: seldon-metrics
+spec:
+  endpoints:
+  - port: http
+  selector: {}
+  namespaceSelector:
+    matchNames:
+      - opf-seldon

--- a/kfdefs/overlays/moc/smaug/trino/kustomization.yaml
+++ b/kfdefs/overlays/moc/smaug/trino/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - kfdef.yaml
   - obcs
   - secrets
+  - servicemonitor.yaml
   - vpa
 generatorOptions:
   disableNameSuffixHash: true

--- a/kfdefs/overlays/moc/smaug/trino/servicemonitor.yaml
+++ b/kfdefs/overlays/moc/smaug/trino/servicemonitor.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: trino-metrics
+spec:
+  endpoints:
+  - port: metrics
+  selector: {}
+  namespaceSelector:
+    matchNames:
+      - opf-trino


### PR DESCRIPTION
Introducing the servicemonitors for Trino and Seldon that expose their metrics to prometheus. Re: https://github.com/operate-first/apps/issues/1677

