### PR TITLE
add grafana operator to b4mad-racing namespace

### DIFF
--- a/cluster-scope/base/operators.coreos.com/operatorgroups/b4mad-racing/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/b4mad-racing/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: b4mad-racing
+resources:
+- operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/b4mad-racing/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/b4mad-racing/operatorgroup.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: b4mad-racing
+spec:
+  targetNamespaces:
+    - b4mad-racing

--- a/cluster-scope/bundles/b4mad-racing/kustomization.yaml
+++ b/cluster-scope/bundles/b4mad-racing/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: b4mad-racing
+resources:
+  - ../../base/core/namespaces/b4mad-racing
+  - ../../base/operators.coreos.com/operatorgroups/b4mad-racing
+  - ../../base/operators.coreos.com/subscriptions/grafana-operator

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -21,7 +21,6 @@ resources:
 - ../../../../base/core/namespaces/ai-services-thanos-grpc
 - ../../../../base/core/namespaces/aicoe-meteor
 - ../../../../base/core/namespaces/apicurio-apicurio-registry
-- ../../../../base/core/namespaces/b4mad-racing
 - ../../../../base/core/namespaces/boatrockers
 - ../../../../base/core/namespaces/bu-scsaol
 - ../../../../base/core/namespaces/chrisproject
@@ -124,6 +123,7 @@ resources:
 - ../../../../base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd
 - ../../../../base/user.openshift.io/groups/cluster-admins
 - ../../../../bundles/acme-operator
+- ../../../../bundles/b4mad-racing
 - ../../../../bundles/curator
 - ../../../../bundles/fybrik
 - ../../../../bundles/kfp-tekton


### PR DESCRIPTION
@4n4nd @HumairAK I'm trying to install a grafana instance in my namespace and would like to use the operator for that.

Are there any reasons for making it not cluster wide?