### PR TITLE
[Smaug][Grafana] Add instance label to grafana-serviceaccount smaug

### DIFF
--- a/grafana/overlays/moc/smaug/grafana-oauth.yaml
+++ b/grafana/overlays/moc/smaug/grafana-oauth.yaml
@@ -19,6 +19,9 @@ spec:
       root_url: https://grafana.operate-first.cloud
     dashboards:
       default_home_dashboard_path: "/etc/grafana-configmaps/grafana-landing-page/landingpage.json"
+    serviceAccount:
+      labels:
+        app.kubernetes.io/instance: cluster-resources-smaug
     auth.generic_oauth:
       enabled: true
       scopes: openid email groups profile


### PR DESCRIPTION
This will prevent argocd and grafana-operator in smaug to fight over adding the instance label to `grafana-serviceaccount` in `opf-monitoring` namespace

A better fix would be to change the name of the serviceaccount being created in the opf-monitoring bundle, but because we are adding that bundle to all the clusters we manage, we would need to update credentials (oauth tokens) for all the renamed serviceaccounts. And this issue is seen only in smaug. So to save engineering effort I made this quick fix.