### PR TITLE
:recycle: upgrade pulp image pull policy to always

### DIFF
--- a/pulp/overlays/moc/smaug/opf-pulp.yaml
+++ b/pulp/overlays/moc/smaug/opf-pulp.yaml
@@ -24,7 +24,7 @@ spec:
   file_storage_access_mode: ReadWriteOnce
   ingress_type: Route
   image: 'quay.io/pulp/pulp'
-  image_pull_policy: IfNotPresent
+  image_pull_policy: Always
   image_web: 'quay.io/pulp/pulp-web'
   loadbalancer_protocol: http
   loadbalancer_port: 80


### PR DESCRIPTION
upgrade pulp image pull policy to always
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

This is for having  upgrade of component whenever operator upgrades.