### PR TITLE
:city_sunrise: Include project thoth and opf-pulp on the opf workload website

### DIFF
--- a/cluster-scope/base/core/namespaces/opf-ci-pipelines/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/opf-ci-pipelines/namespace.yaml
@@ -5,6 +5,9 @@ metadata:
   annotations:
     openshift.io/display-name: "Operate First: AICoE-CI Pipelines"
     openshift.io/description: "Project for execution of continous integration aicoe-ci openshift pipelines."
-    openshift.io/requester: aicoe-thoth-devops
+    openshift.io/requester: thoth-devops
+    op1st/project-owner: thoth-devops
+    op1st/onboarding-issue: "https://github.com/operate-first/apps/pull/119"
+    op1st/docs: "https://github.com/AICoE/aicoe-ci"
   name: opf-ci-pipelines
 spec: {}

--- a/cluster-scope/base/core/namespaces/opf-ci-prow/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/opf-ci-prow/namespace.yaml
@@ -5,6 +5,9 @@ metadata:
   annotations:
     openshift.io/display-name: "Operate First: Prow"
     openshift.io/description: "Project for execution of continous integration prow jobs."
-    openshift.io/requester: aicoe-thoth-devops
+    openshift.io/requester: thoth-devops
+    op1st/project-owner: thoth-devops
+    op1st/onboarding-issue: "https://github.com/operate-first/apps/pull/119"
+    op1st/docs: "https://github.com/kubernetes/test-infra/tree/master/prow#readme"
   name: opf-ci-prow
 spec: {}

--- a/cluster-scope/base/core/namespaces/opf-pulp/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/opf-pulp/namespace.yaml
@@ -4,5 +4,8 @@ metadata:
   annotations:
     openshift.io/display-name: "opf-Pulp: Instance of the pulp (http://pulpproject.org)"
     openshift.io/requester: thoth-devops
+    op1st/project-owner: thoth-devops
+    op1st/onboarding-issue: "https://github.com/operate-first/apps/pull/1265"
+    op1st/docs: "http://pulpproject.org"
   name: opf-pulp
 spec: {}

--- a/cluster-scope/base/core/namespaces/thoth-amun-api-prod/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/thoth-amun-api-prod/namespace.yaml
@@ -3,6 +3,9 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/display-name: "Thoth-Station: Amun Namespace"
-    openshift.io/requester: aicoe-thoth-devops
+    openshift.io/requester: thoth-devops
+    op1st/project-owner: thoth-devops
+    op1st/onboarding-issue: "https://github.com/operate-first/apps/pull/118"
+    op1st/docs: "https://thoth-station.ninja/"
   name: thoth-amun-api-prod
 spec: {}

--- a/cluster-scope/base/core/namespaces/thoth-amun-inspection-prod/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/thoth-amun-inspection-prod/namespace.yaml
@@ -4,6 +4,9 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/display-name: "Thoth-Station: Amun Inspection Namespace"
-    openshift.io/requester: aicoe-thoth-devops
+    openshift.io/requester: thoth-devops
+    op1st/project-owner: thoth-devops
+    op1st/onboarding-issue: "https://github.com/operate-first/apps/pull/118"
+    op1st/docs: "https://thoth-station.ninja/"
   name: thoth-amun-inspection-prod
 spec: {}

--- a/cluster-scope/base/core/namespaces/thoth-backend-prod/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/thoth-backend-prod/namespace.yaml
@@ -4,6 +4,9 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/display-name: "Thoth-Station: Backend Namespace"
-    openshift.io/requester: aicoe-thoth-devops
+    openshift.io/requester: thoth-devops
+    op1st/project-owner: thoth-devops
+    op1st/onboarding-issue: "https://github.com/operate-first/apps/pull/118"
+    op1st/docs: "https://thoth-station.ninja/"
   name: thoth-backend-prod
 spec: {}

--- a/cluster-scope/base/core/namespaces/thoth-bots-prod/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/thoth-bots-prod/namespace.yaml
@@ -4,6 +4,9 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/display-name: "Thoth-Station: Bots Namespace"
-    openshift.io/requester: aicoe-thoth-devops
+    openshift.io/requester: thoth-devops
+    op1st/project-owner: thoth-devops
+    op1st/onboarding-issue: "https://github.com/operate-first/apps/pull/118"
+    op1st/docs: "https://thoth-station.ninja/"
   name: thoth-bots-prod
 spec: {}

--- a/cluster-scope/base/core/namespaces/thoth-deployment-examples/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/thoth-deployment-examples/namespace.yaml
@@ -3,6 +3,6 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/display-name: "Thoth-Station: Deployment Namespace"
-    openshift.io/requester: aicoe-thoth-devops
+    openshift.io/requester: thoth-devops
   name: thoth-deployment-examples
 spec: {}

--- a/cluster-scope/base/core/namespaces/thoth-frontend-prod/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/thoth-frontend-prod/namespace.yaml
@@ -4,6 +4,9 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/display-name: "Thoth-Station: Frontend Namespace"
-    openshift.io/requester: aicoe-thoth-devops
+    openshift.io/requester: thoth-devops
+    op1st/project-owner: thoth-devops
+    op1st/onboarding-issue: "https://github.com/operate-first/apps/pull/118"
+    op1st/docs: "https://thoth-station.ninja/"
   name: thoth-frontend-prod
 spec: {}

--- a/cluster-scope/base/core/namespaces/thoth-graph-prod/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/thoth-graph-prod/namespace.yaml
@@ -4,6 +4,9 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/display-name: "Thoth-Station: Graph Namespace"
-    openshift.io/requester: aicoe-thoth-devops
+    openshift.io/requester: thoth-devops
+    op1st/project-owner: thoth-devops
+    op1st/onboarding-issue: "https://github.com/operate-first/apps/pull/118"
+    op1st/docs: "https://thoth-station.ninja/"
   name: thoth-graph-prod
 spec: {}

--- a/cluster-scope/base/core/namespaces/thoth-infra-prod/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/thoth-infra-prod/namespace.yaml
@@ -4,6 +4,9 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/display-name: "Thoth-Station: Infra Namespace"
-    openshift.io/requester: aicoe-thoth-devops
+    openshift.io/requester: thoth-devops
+    op1st/project-owner: thoth-devops
+    op1st/onboarding-issue: "https://github.com/operate-first/apps/pull/118"
+    op1st/docs: "https://thoth-station.ninja/"
   name: thoth-infra-prod
 spec: {}

--- a/cluster-scope/base/core/namespaces/thoth-middletier-prod/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/thoth-middletier-prod/namespace.yaml
@@ -4,6 +4,9 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/display-name: "Thoth-Station: Middletier Namespace"
-    openshift.io/requester: aicoe-thoth-devops
+    openshift.io/requester: thoth-devops
+    op1st/project-owner: thoth-devops
+    op1st/onboarding-issue: "https://github.com/operate-first/apps/pull/118"
+    op1st/docs: "https://thoth-station.ninja/"
   name: thoth-middletier-prod
 spec: {}


### PR DESCRIPTION
Include the following projects in workload website
- project thoth 
- opf-pulp
- opf-ci-prow
- opf-ci-pipelines

Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>