### PR TITLE
Add cluster authprimary label to cur/infra/rick.

### DIFF
--- a/acm/overlays/moc/infra/managedclusters/kustomization.yaml
+++ b/acm/overlays/moc/infra/managedclusters/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - balrog.yaml
 - curator.yaml
+- local-cluster.yaml
 - ocp-prod.yaml
 - ocp-staging.yaml
 - osc-cl1.yaml

--- a/acm/overlays/moc/infra/managedclusters/local-cluster.yaml
+++ b/acm/overlays/moc/infra/managedclusters/local-cluster.yaml
@@ -1,7 +1,6 @@
 apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
-  name: curator
+  name: local-cluster
   labels:
-    cluster.open-cluster-management.io/clusterset: argocd-managed
     authdeployment: primary

--- a/acm/overlays/moc/infra/managedclusters/rick.yaml
+++ b/acm/overlays/moc/infra/managedclusters/rick.yaml
@@ -4,3 +4,4 @@ metadata:
   name: rick
   labels:
     cluster.open-cluster-management.io/clusterset: argocd-managed
+    authdeployment: primary


### PR DESCRIPTION
This should have been a part of commit
f8d52e7016bf85c09da97b374c017eba39342888.

See commit message for above for more details.
Corresponding PR: https://github.com/operate-first/apps/pull/1943

Note that `local-cluster` refers to infra. 