### PR TITLE
Remove oauths inherited from base for idp clusters

### DIFF
--- a/cluster-scope/overlays/prod/emea/rick/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/rick/kustomization.yaml
@@ -4,7 +4,6 @@ resources:
     - ../common
     - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/workflow.argoproj.io
     - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/workflowtemplate.argoproj.io
-    - ../../../../base/config.openshift.io/oauths/cluster
     - ../../../../base/core/configmaps/cluster-monitoring-config
     - ../../../../base/core/configmaps/user-workload-monitoring-config
     - ../../../../base/core/namespaces/openshift-cnv

--- a/cluster-scope/overlays/prod/moc/curator/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/curator/kustomization.yaml
@@ -3,7 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../../../base/config.openshift.io/oauths/cluster
   - ../../../../base/core/namespaces/hostpath-provisioner
   - ../../../../base/core/namespaces/openshift-cnv
   - ../../../../base/core/namespaces/openshift-storage

--- a/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
@@ -5,7 +5,6 @@ kind: Kustomization
 resources:
   - ../common
   - ../../../../bundles/klusterletaddonconfig-editor/
-  - ../../../../base/config.openshift.io/oauths/cluster
   - ../../../../base/core/configmaps/cluster-monitoring-config
   - ../../../../base/core/configmaps/user-workload-monitoring-config
   - ../../../../base/core/namespaces/acm


### PR DESCRIPTION
This should have been a part of commit
f8d52e7.

See commit message for above for more details.