### PR TITLE
Add kluster addon config editor rolebinding.

### DIFF
--- a/cluster-scope/overlays/prod/moc/infra/clusterrolebindings/klusteraddonconfig-editor.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/clusterrolebindings/klusteraddonconfig-editor.yaml
@@ -1,0 +1,18 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: klusterletaddonconfig-editor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: klusterletaddonconfig-editor
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: octo-ushift-dev
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: osc-admins
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: drvbw

--- a/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
@@ -61,3 +61,4 @@ patchesStrategicMerge:
   - subscriptions/kubernetes-nmstate-operator_patch.yaml
   - groups/cluster-admins.yaml
   - clusterrolebindings/self-provisioners_patch.yaml
+  - clusterrolebindings/klusteraddonconfig-editor.yaml


### PR DESCRIPTION
These permissions are needed for teams to be able to add clusters to
acm.

Part of: https://github.com/operate-first/apps/pull/1947