### PR TITLE
Add a second noobaa backing store and associated bucketclass

### DIFF
--- a/cluster-scope/overlays/prod/moc/smaug/backingstores/noobaa-pool-01.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/backingstores/noobaa-pool-01.yaml
@@ -1,0 +1,15 @@
+apiVersion: noobaa.io/v1alpha1
+kind: BackingStore
+metadata:
+  labels:
+    app: noobaa
+    app.kubernetes.io/instance: cluster-resources-smaug
+  name: noobaa-pool-01
+  namespace: openshift-storage
+spec:
+  pvPool:
+    numVolumes: 10
+    resources:
+      requests:
+        storage: 100Gi
+  type: pv-pool

--- a/cluster-scope/overlays/prod/moc/smaug/bucketclasses/noobaa-pool-01-bucket-class.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/bucketclasses/noobaa-pool-01-bucket-class.yaml
@@ -1,0 +1,12 @@
+apiVersion: noobaa.io/v1alpha1
+kind: BucketClass
+metadata:
+  labels:
+    app: noobaa
+  name: noobaa-pool-01-bucket-class
+  namespace: openshift-storage
+spec:
+  placementPolicy:
+    tiers:
+    - backingStores:
+      - noobaa-pool-01

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -139,6 +139,8 @@ resources:
 - ../../../../bundles/volsync
 - ../common
 - apiserver/api_server_cert.yaml
+- backingstores/noobaa-pool-01.yaml
+- bucketclasses/noobaa-pool-01-bucket-class.yaml
 - clusterversion.yaml
 - ingresscontrollers/default.yaml
 - nodenetworkconfigurationpolicies/vlan-210-nfs.yaml


### PR DESCRIPTION
Create noobaa-pool-01 backing store with an initial 10 * 100GB allocation
(can grow up to 20 * 100GB). Include an associated BucketClass
(noobaa-pool-01-bucket-class) that can be used to place buckets on this
pool explicitly, e.g:

    apiVersion: objectbucket.io/v1alpha1
    kind: ObjectBucketClaim
    metadata:
      name: example-obc
    spec:
      generateBucketName: example-obc
      storageClassName: openshift-storage.noobaa.io
      additionalConfig:
        bucketclass: noobaa-pool-01-bucket-class

Part of operate-first/operations#474