### PR TITLE
Add pool to default bucket class

### DIFF
--- a/cluster-scope/overlays/prod/moc/smaug/bucketclasses/noobaa-default-bucket-class.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/bucketclasses/noobaa-default-bucket-class.yaml
@@ -1,0 +1,14 @@
+apiVersion: noobaa.io/v1alpha1
+kind: BucketClass
+metadata:
+  labels:
+    app: noobaa
+  name: noobaa-default-bucket-class
+  namespace: openshift-storage
+spec:
+  placementPolicy:
+    tiers:
+    - backingStores:
+      - noobaa-default-backing-store
+      - noobaa-pool-01
+      placement: Spread

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -140,7 +140,7 @@ resources:
 - ../common
 - apiserver/api_server_cert.yaml
 - backingstores/noobaa-pool-01.yaml
-- bucketclasses/noobaa-pool-01-bucket-class.yaml
+- bucketclasses/noobaa-default-bucket-class.yaml
 - clusterversion.yaml
 - ingresscontrollers/default.yaml
 - nodenetworkconfigurationpolicies/vlan-210-nfs.yaml


### PR DESCRIPTION
Rather than adding a new bucketclass, it makes more sense to add a new
backing store to the existing default bucket class. With a "Spread"
configuration [1], noobaa will start allocating space for existing buckets
from the new pool.

This removes the bucketclass created in 19f2b87566.

[1]: https://github.com/noobaa/noobaa-operator/blob/master/doc/bucket-class-crd.md
