### PR TITLE
Add shared secret to trino.

### DIFF
--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/config-coordinator.properties
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/config-coordinator.properties
@@ -1,4 +1,5 @@
 coordinator=true
+internal-communication.shared-secret=${ENV:TRINO_INTERNAL_SHARED_SECRET}
 node-scheduler.include-coordinator=false
 discovery.uri=http://localhost:8080
 web-ui.authentication.type=oauth2

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/config-worker.properties
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/config-worker.properties
@@ -1,4 +1,5 @@
 coordinator=false
+internal-communication.shared-secret=${ENV:TRINO_INTERNAL_SHARED_SECRET}
 http-server.http.port=8080
 discovery.uri=http://trino-service:8080
 query.max-length=10000000

--- a/kfdefs/overlays/osc/osc-cl2/trino/secrets/secret-generator.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/secrets/secret-generator.yaml
@@ -5,3 +5,4 @@ metadata:
 files:
   - trino-oauth.yaml
   - s3buckets.yaml
+  - shared-secret.yaml

--- a/kfdefs/overlays/osc/osc-cl2/trino/secrets/shared-secret.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/secrets/shared-secret.yaml
@@ -1,0 +1,38 @@
+kind: Secret
+apiVersion: v1
+metadata:
+    name: shared-secret
+    namespace: odh-trino
+stringData:
+    TRINO_INTERNAL_SHARED_SECRET: ENC[AES256_GCM,data:a2crIvV8s/zipHGkfD8hs23QOwGLtL3v1SPUDPs/fSzyum56II/w0f9bs6kfR6KPM6X69zDMHA+3YGjqUf7CbdF4bRufEYZvNTZYFUciur5R8hFEb63zdnbrfCrm9OCnER18FsfXc5AlTFHTiPa4oif+ZC3toXPbiQfikkq3P8izjwvbA6toAnmoWOazvLW4+BJCYjDb2Pi4N5B88xIH5agUv5NlZSVm067IrkniUupuNMERKSuK8I2g2i2X+BsyYZZk0TD0O+6Wx+VWDH5sumkk+vAC8LWMWeVFo1V5U7lBmmDgjgolqxAnIIuwGST+SrNDGE1L6Z0Xw8zaImNiOv2fWRWMVdAvXAKkS4KDZhCvfPxxo7xdejRNcx7/GKvbZX0cH19OGvAY0GKY195tfszKgsIS/5MjMxtvpiLP9t+/TzZFvVfPB2mQpQB3eGMbENfEJ064NjSokC/MVnVKD4yjHYj/h0hVtci83Htqnky4sKHICHMizO33t9cWRdEujq4ll31UzMif4aF2/YM4SgGraTJvZslc0zFNqv0N74s75rfdKX2grKhXGZqPoKbRzAXjQQBwBNq9oYk+fWre8wkQiyhGM+vSJRAACZ/uPtX69kN9RxthBBRla1fqvItT4J621FhjbpQAc+Ng4I0XN0O3aLTAknqkrZ5jYWnwiYkIC0LVTQW4sJuEUm/a0wOIvSscC6NFE5yGfoU1byTJ3DZeSeeSQtT1hKwoZZm4j8aS8nDxeKqqCyOoSocqiXZEYOA76xl2frK/bIQQox/Y/RF7N9Hsn3l67d/buL+w7X5FlgC2hHF8m83bpwko2oKwfLd7s0UqJ6NAed8j18T6WT+vk1B2aMQp7QsRXplZXkdS4GsKssfoeVnsIU/knqgHA2PMsOL8xK2ATBDozzsIOJbvWw/x,iv:fqRIV4Z8S/3x1Xz4PxzJwYdcc/uxI/HyeltbV7H2p2A=,tag:NB+K4pAwOloyRK4j0q87XQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-05-13T18:35:04Z"
+    mac: ENC[AES256_GCM,data:yimolPFF8PjGueTQgxaETBxY8o+5KUNGxlKq9mOt02FIbl7qFPPZVszxOi8+kOmidqjErYfyBkGh+8ChsvqMFYtcIo06GxonG9us5yQ+Hka61LebZIChkxfsU++yKZHA3XmMelobZvbVt0NwQlvWE4tsdAtQfGhIMLi8+Eczs0M=,iv:wK2UUsvNT9nFxFeQURzMxZp3RpFQ1Gkmt3cZaa9K1zY=,tag:SoA/8vx9F3xH/94hyiLL2A==,type:str]
+    pgp:
+        - created_at: "2022-05-13T18:35:04Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA9aKBcudqifiARAAtcXYg2B4t1Tn+q0GBYorC17q7xqhZeU8Gqe0bn3ZFVAi
+            l969YIw8BNB1d/mRnucCTg3tMjmuj3Dn8YsExRIuMlRrTq0wmBmw9+qPPcRZ9QJD
+            oqycZQp51bOsev5rOnCPqAku0bxxutW684qjOnzNJKQ25xBCOLFokL0QS8w6Xc9k
+            BYpAqsArPmjcS6IF/5VgSOkLgh1+EYYkh1aSFAHTyD1SRA2JxTRyWI05kpz6kYuB
+            dJNgdNNDbGXGmmIG3IN3C/lMNcia0j+Fde4QKCZqaSD825udfs6qWcsDIiPDoorM
+            Ht5ZDSS/qwmpggGcapajwoWb8hibZFKRz+hW0/ud2O5Yh/ZSDhhpESutQDn8F4+F
+            Hv025G6usbUMZgo6Ydf2sqxsglavcvsvEn8w6i1g14G8HUCRu9zM6cDZegaqeagW
+            Yv1g+FlEpIvN4ZyfuyKreWm4KmDMtDoWgRATVIp8bP4e2m1p7WGVBeOnbA2liQBM
+            856crz/01GeWn/LDXzga5nY1+9kelSb/it4lWK66fg260K5/8u/xZshQJcv5HCoo
+            DXmeVjsupER9dI7pI1Dzb+Gwo6zwOyfcI1dRk8HtmI1xLKz1w8QsUVilF+G4gS1d
+            jFvawMcZEmNzvQ0MMdFoBE7WtUnyrkNZz0mi2sq7qioqOcIu0p2lcMZV4yT5sv/S
+            5gHql2G3sHo4CWqOfDh8vDXjQ59X1QoJVt0HRbEW14YHWpmjCnpPPCOksGQ1ZiKV
+            1TKp2FG5KUtOFRPFfpzDq8PkNKxvHDtopJ1V8fpeC8DUluJl7AgHAA==
+            =NFS9
+            -----END PGP MESSAGE-----
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.2


### PR DESCRIPTION
The osc-cl2 trino update to v380 required a shared secret to be shared
between all nodes on the trino cluster. This commit adds this secret for
the deployments for both coordinator and worker nodes to leverage.



Related: 

- https://github.com/operate-first/odh-manifests/pull/23
- https://github.com/operate-first/odh-manifests/pull/22

Docs: 
https://trino.io/docs/current/security/internal-communication.html