### PR TITLE
Add External Secrets instance to smaug.

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/external-secrets.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/external-secrets.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets
+spec:
+  destination:
+    name: smaug
+    namespace: external-secrets-operator
+  project: cluster-management
+  source:
+    path: external-secrets/overlays/moc/smaug
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - cert-manager.yaml
   - cluster-resources.yaml
   - dex.yaml
+  - external-secrets.yaml
   - kfdefs.yaml
   - moc-nfs-democratic-csi.yaml
   - node-labeler.yaml

--- a/cluster-scope/base/core/namespaces/external-secrets-operator/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/external-secrets-operator/kustomization.yaml
@@ -1,0 +1,7 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+namespace: external-secrets-operator
+resources:
+    - namespace.yaml
+components:
+    - ../../../../components/project-admin-rolebindings/operate-first

--- a/cluster-scope/base/core/namespaces/external-secrets-operator/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/external-secrets-operator/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: external-secrets-operator
+    annotations:
+        openshift.io/requester: operate-first

--- a/cluster-scope/bundles/external-secrets-operator/kustomization.yaml
+++ b/cluster-scope/bundles/external-secrets-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base/core/namespaces/external-secrets-operator
+  - ../../base/operators.coreos.com/subscriptions/external-secrets-operator

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -91,7 +91,6 @@ resources:
 - ../../../../base/operators.coreos.com/subscriptions/camel-k
 - ../../../../base/operators.coreos.com/subscriptions/cert-manager
 - ../../../../base/operators.coreos.com/subscriptions/cluster-logging
-- ../../../../base/operators.coreos.com/subscriptions/external-secrets-operator
 - ../../../../base/operators.coreos.com/subscriptions/grafana-operator
 - ../../../../base/operators.coreos.com/subscriptions/koku-metrics-operator
 - ../../../../base/operators.coreos.com/subscriptions/kubevirt-hyperconverged
@@ -125,6 +124,7 @@ resources:
 - ../../../../bundles/acme-operator
 - ../../../../bundles/b4mad-racing
 - ../../../../bundles/curator
+- ../../../../bundles/external-secrets-operator
 - ../../../../bundles/fybrik
 - ../../../../bundles/jaeger-operator
 - ../../../../bundles/kfp-tekton

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -36,6 +36,11 @@ parts:
           - file: content/argocd-gitops/update_gpg_key.md
           - file: content/argocd-gitops/argocd_notifications.md
 
+      # ESO
+      - file: content/external-secrets/README.md
+        sections:
+          - file: content/external-secrets/add_eso_to_cluster.md
+
       # Cluster Scope
       - file: content/cluster-scope/README.md
         sections:

--- a/docs/content/external-secrets/README.md
+++ b/docs/content/external-secrets/README.md
@@ -1,0 +1,7 @@
+# External Secrets Operator
+
+We use [External Secrets Operator (ESO)][external secrets] to manage our secrets declaratively in git.
+
+ESO allows us to store our K8S / OCP secrets in git declaratively without compromising on the security of the platform.
+
+[external secrets]: https://external-secrets.io

--- a/docs/content/external-secrets/add_eso_to_cluster.md
+++ b/docs/content/external-secrets/add_eso_to_cluster.md
@@ -1,0 +1,29 @@
+# Add External Secrets Operator to an OPF cluster
+
+## Deploy the operator:
+
+Add the [ESO bundle][eso] to the `cluster-scope/overlay/prod/$ENV/$CLUSTER/kustomization.yaml`.
+
+The OLM operator is a helm chart deployer, and lives in the openshift-operators namespace. We use this operator to
+deploy the _actual_ operator via an `OperatorConfig` resource, which essentially allows us to specify the helm chart values
+via an OCP resource. The bundle above creates the namespace where this resource will live. We deploy this resource
+separately via an argocd app.
+
+# Add OperatorConfig resource
+
+> Note: For details on this resource see OLM page for ESO [here][olm]
+
+Add your `OperatorConfig` to the target cluster's overlay found at the root of the `operate-first/apps` repo
+here: `operate-first/apps/external-secrets/overlays/$ENV/$CLUSTER`. If you prefer the default config, feel free to just
+leverage the one in `base` directory.
+
+# Add the ArgoCD app
+
+Follow the instructions [here][add-app] to add your ArgoCD app. In general we recommend adding it to the
+`cluster-managerment` ArgoCD Project.
+
+Commit your changes and create a PR.
+
+[eso]: https://github.com/operate-first/apps/tree/master/cluster-scope/bundles/external-secrets-operator
+[olm]: https://operatorhub.io/operator/external-secrets-operator
+[add-app]: ../argocd-gitops/add_application.md

--- a/external-secrets/base/eso.yaml
+++ b/external-secrets/base/eso.yaml
@@ -1,0 +1,114 @@
+kind: OperatorConfig
+apiVersion: operator.external-secrets.io/v1alpha1
+metadata:
+  name: opf
+  namespace: external-secrets-operator
+spec:
+  affinity: {}
+  certController:
+    affinity: {}
+    create: true
+    deploymentAnnotations: {}
+    extraArgs: {}
+    extraEnv: []
+    fullnameOverride: ''
+    image:
+      pullPolicy: IfNotPresent
+      repository: ghcr.io/external-secrets/external-secrets
+      tag: ''
+    imagePullSecrets: []
+    nameOverride: ''
+    nodeSelector: {}
+    podAnnotations: {}
+    podLabels: {}
+    podSecurityContext: {}
+    priorityClassName: ''
+    prometheus:
+      enabled: false
+      service:
+        port: 8080
+    rbac:
+      create: true
+    requeueInterval: 5m
+    resources: {}
+    securityContext: {}
+    serviceAccount:
+      annotations: {}
+      create: true
+      name: ''
+    tolerations: []
+  concurrent: 1
+  controllerClass: ''
+  crds:
+    createClusterExternalSecret: true
+    createClusterSecretStore: true
+  createOperator: true
+  deploymentAnnotations: {}
+  extraArgs: {}
+  extraEnv: []
+  fullnameOverride: ''
+  image:
+    pullPolicy: IfNotPresent
+    repository: ghcr.io/external-secrets/external-secrets
+    tag: ''
+  imagePullSecrets: []
+  installCRDs: false
+  leaderElect: false
+  nameOverride: ''
+  nodeSelector: {}
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  priorityClassName: ''
+  processClusterExternalSecret: true
+  processClusterStore: true
+  prometheus:
+    enabled: false
+    service:
+      port: 8080
+  rbac:
+    create: true
+  replicaCount: 1
+  resources: {}
+  scopedNamespace: ''
+  scopedRBAC: false
+  securityContext: {}
+  serviceAccount:
+    annotations: {}
+    create: true
+    name: ''
+  tolerations: []
+  webhook:
+    affinity: {}
+    certCheckInterval: 5m
+    certDir: /tmp/certs
+    create: true
+    deploymentAnnotations: {}
+    extraArgs: {}
+    extraEnv: []
+    fullnameOverride: ''
+    image:
+      pullPolicy: IfNotPresent
+      repository: ghcr.io/external-secrets/external-secrets
+      tag: ''
+    imagePullSecrets: []
+    nameOverride: ''
+    nodeSelector: {}
+    podAnnotations: {}
+    podLabels: {}
+    podSecurityContext: {}
+    priorityClassName: ''
+    prometheus:
+      enabled: false
+      service:
+        port: 8080
+    rbac:
+      create: true
+    replicaCount: 1
+    resources: {}
+    securityContext: {}
+    serviceAccount:
+      annotations: {}
+      create: true
+      name: ''
+    tolerations: []

--- a/external-secrets/base/kustomization.yaml
+++ b/external-secrets/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - eso.yaml

--- a/external-secrets/overlay/moc/smaug/kustomization.yaml
+++ b/external-secrets/overlay/moc/smaug/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: external-secrets-operator
+resources:
+  - ../../../base


### PR DESCRIPTION
This commit addes an operator config + namespace to the smaug cluster.
The addition will result in an instance of external secrets being
deployed and managed via argocd.