### PR TITLE
Fix the crd of extension tekton dashboard

### DIFF
--- a/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/extensions.dashboard.tekton.dev/customresourcedefinition.yaml
+++ b/cluster-scope/base/apiextensions.k8s.io/customresourcedefinitions/extensions.dashboard.tekton.dev/customresourcedefinition.yaml
@@ -19,7 +19,6 @@ metadata:
   name: extensions.dashboard.tekton.dev
   labels:
     app.kubernetes.io/component: dashboard
-    app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-dashboard
 spec:
   group: dashboard.tekton.dev


### PR DESCRIPTION
Fix the crd of extension tekton dashboard
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Fixes: https://github.com/operate-first/apps/issues/1936


The openshift-pipelines operator is not creating the dashboard CRD.
The CRD itself was added in the repo with label `app.kubernetes.io/instance: default` which is checked by agrocd for instance duplication.