### PR TITLE
upgrade the ray jupyterhub instance with latest ray

### DIFF
--- a/kfdefs/base/jupyterhub/notebook-images/ray-ml-notebook.yaml
+++ b/kfdefs/base/jupyterhub/notebook-images/ray-ml-notebook.yaml
@@ -11,11 +11,9 @@ spec:
   lookupPolicy:
     local: true
   tags:
-    # This ray integration is being provided on an experimental basis
     - annotations:
         openshift.io/imported-from: quay.io/thoth-station/s2i-ray-ml-notebook
-      name: experimental
+      name: latest
       from:
         kind: DockerImage
-        # can rebuild with newer nightly SHAs periodically
-        name: 'quay.io/thoth-station/s2i-ray-ml-notebook:v0.1.0'
+        name: 'quay.io/thoth-station/s2i-ray-ml-notebook:v0.1.1'

--- a/kfdefs/overlays/moc/smaug/jupyterhub/ray-odh-integration/ray-ml-profile-cm.yaml
+++ b/kfdefs/overlays/moc/smaug/jupyterhub/ray-odh-integration/ray-ml-profile-cm.yaml
@@ -9,7 +9,7 @@ data:
     profiles:
       - name: Ray ML Notebook
         images:
-          - 'ray-ml-notebook:experimental'
+          - 'image-registry.openshift-image-registry.svc:5000/opf-jupyterhub/ray-ml-notebook:latest'
         env:
           # expose to jupyter users as a convenience
           - name: RAY_DASH_URL
@@ -26,7 +26,7 @@ data:
               - name: ray-cluster-template
                 path: rayDashboardRouteTemplate
             configuration:
-              ray_image: 'quay.io/thoth-station/ray-ml-worker:v0.1.1'
+              ray_image: 'quay.io/thoth-station/ray-ml-worker:v0.1.2'
               # number of workers currently disabled due to json/jinja bug in JH launcher
               #max_workers: 5
               memory_request: '3Gi'

--- a/kfdefs/overlays/moc/smaug/jupyterhub/ray-odh-integration/ray-operator-deployment.yaml
+++ b/kfdefs/overlays/moc/smaug/jupyterhub/ray-odh-integration/ray-operator-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
         - name: ray-operator
           imagePullPolicy: Always
-          image: 'quay.io/thoth-station/ray-operator:v0.1.1'
+          image: 'quay.io/thoth-station/ray-operator:v0.1.2'
           command: ['/bin/bash', '-c', '--', 'cd /home/ray && pipenv run ray-operator']
           env:
             - name: RAY_CONFIG_DIR


### PR DESCRIPTION
upgrade the ray jupyterhub instance with the latest ray
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


Description:

- Upgraded the image of the ray instance to get the latest ray 
- Changed the reference to the absolute path of imagestream instead of short-hand, as jupyterhub is not recognizing the short-hand https://github.com/harshad16/apps/blob/db9cec12bdc3a64d8229e506e96157004e008828/kfdefs/overlays/moc/smaug/jupyterhub/ray-odh-integration/ray-ml-profile-cm.yaml#L12

This has been tested :heavy_check_mark: 


