### PR TITLE
Fix the labels of cm feature flags

### DIFF
--- a/cluster-scope/base/core/configmaps/openshift-pipelines-feature-flags/configmap.yaml
+++ b/cluster-scope/base/core/configmaps/openshift-pipelines-feature-flags/configmap.yaml
@@ -4,7 +4,6 @@ metadata:
   name: feature-flags
   namespace: openshift-pipelines
   labels:
-    app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
 data:
   running-in-environment-with-injected-sidecars: 'true'


### PR DESCRIPTION
Fix the labels of cm feature flags and patch strategy
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


Related-to: https://github.com/operate-first/apps/issues/1958



- the cm feature flag is already installed via openshift pipeline operator https://github.com/tektoncd/pipeline/blob/main/config/config-feature-flags.yaml, it need to be patched
- the label instance is to be patched by the argocd