### PR TITLE
Change path for slack api url in smaug.

### DIFF
--- a/cluster-scope/overlays/prod/moc/smaug/externalsecrets/alert-manager.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/externalsecrets/alert-manager.yaml
@@ -22,6 +22,6 @@ spec:
   data:
     - remoteRef:
         conversionStrategy: Default
-        key: opf-ops/openshift-monitoring/alert-manager-config
+        key: moc/smaug/openshift-monitoring/alert-manager-config
         property: slack_api_url
       secretKey: slack_api_url

--- a/cluster-scope/overlays/prod/moc/smaug/secretstores/openshift-monitoring.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/secretstores/openshift-monitoring.yaml
@@ -9,9 +9,9 @@ spec:
       auth:
         kubernetes:
           mountPath: smaug-k8s
-          role: opf-ops
+          role: moc-ops
           serviceAccountRef:
             name: vault-secret-fetcher
-      path: smaug-k8s-kv
+      path: k8s_secrets
       server: 'https://vault-ui-vault.apps.smaug.na.operate-first.cloud'
       version: v2


### PR DESCRIPTION
This is to reflect some changes to how secrets are organized. Instead of
using multiple engines for each clusters, it makes more sense to use one
kv secrets engine and have subdirectories for each env/cluster.


Related: https://github.com/operate-first/apps/issues/1993