### PR TITLE
Add api/ingress certs to rick.

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/emea/rick/cluster-management/cert-manager.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/emea/rick/cluster-management/cert-manager.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+spec:
+  destination:
+    name: rick
+    namespace: openshift-ingress
+  project: cluster-management
+  source:
+    repoURL: https://github.com/operate-first/apps.git
+    path: cert-manager/overlays/emea/rick
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/argocd/overlays/moc-infra/applications/envs/emea/rick/cluster-management/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/emea/rick/cluster-management/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - alertreceiver.yaml
+  - cert-manager.yaml
   - cluster-resources.yaml
   - external-secrets.yaml
   - local-storage.yaml

--- a/cert-manager/overlays/emea/rick/api/certificate.yaml
+++ b/cert-manager/overlays/emea/rick/api/certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: api-certificate-letsencrypt
+  namespace: openshift-config
+spec:
+  dnsNames:
+  - api.rick.emea.operate-first.cloud
+  duration: 2160h0m0s
+  issuerRef:
+    name: api-letsencrypt-production
+  renewBefore: 360h0m0s
+  secretName: api-certificate

--- a/cert-manager/overlays/emea/rick/api/issuer.yaml
+++ b/cert-manager/overlays/emea/rick/api/issuer.yaml
@@ -1,0 +1,23 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: api-letsencrypt-production
+  namespace: openshift-config
+spec:
+  acme:
+    email: ops-team@operate-first.cloud
+    privateKeySecretRef:
+      name: letsencrypt-key
+    server: https://acme-v02.api.letsencrypt.org/directory
+    solvers:
+    - dns01:
+        cloudDNS:
+          hostedZoneName: emea-operate-first
+          project: aicoe-prow
+          serviceAccountSecretRef:
+            key: key.json
+            name: clouddns-dns01-emea-svc-acct
+        cnameStrategy: Follow
+      selector:
+        dnsZones:
+        - emea.operate-first.cloud

--- a/cert-manager/overlays/emea/rick/api/kustomization.yaml
+++ b/cert-manager/overlays/emea/rick/api/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-config
+resources:
+  - issuer.yaml
+  - certificate.yaml
+  - ../secrets

--- a/cert-manager/overlays/emea/rick/ingress/certificate.yaml
+++ b/cert-manager/overlays/emea/rick/ingress/certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ingress-certificate
+  namespace: openshift-ingress
+spec:
+  dnsNames:
+  - '*.apps.rick.emea.operate-first.cloud'
+  duration: 2160h0m0s
+  issuerRef:
+    name: ingress-letsencrypt-production
+  renewBefore: 360h0m0s
+  secretName: ingress-certificate

--- a/cert-manager/overlays/emea/rick/ingress/issuer.yaml
+++ b/cert-manager/overlays/emea/rick/ingress/issuer.yaml
@@ -1,0 +1,23 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: ingress-letsencrypt-production
+  namespace: openshift-ingress
+spec:
+  acme:
+    email: ops-team@operate-first.cloud
+    privateKeySecretRef:
+      name: letsencrypt-key
+    server: https://acme-v02.api.letsencrypt.org/directory
+    solvers:
+    - dns01:
+        cloudDNS:
+          hostedZoneName: emea-operate-first
+          project: aicoe-prow
+          serviceAccountSecretRef:
+            key: key.json
+            name: clouddns-dns01-emea-svc-acct
+        cnameStrategy: Follow
+      selector:
+        dnsZones:
+        - emea.operate-first.cloud

--- a/cert-manager/overlays/emea/rick/ingress/kustomization.yaml
+++ b/cert-manager/overlays/emea/rick/ingress/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-ingress
+resources:
+  - issuer.yaml
+  - certificate.yaml
+  - ../secrets

--- a/cert-manager/overlays/emea/rick/kustomization.yaml
+++ b/cert-manager/overlays/emea/rick/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - api
+  - ingress

--- a/cert-manager/overlays/emea/rick/secrets/.sops.yaml
+++ b/cert-manager/overlays/emea/rick/secrets/.sops.yaml
@@ -1,0 +1,5 @@
+creation_rules:
+  - encrypted_regex: "^(users|data|stringData)$"
+    pgp: >-
+      0508677DD04952D06A943D5B4DC4116D360E3276,
+      2EB7924D7DA3E2DF4717D3EA9E8653F7D343455A

--- a/cert-manager/overlays/emea/rick/secrets/clouddns-dns01-emea-svc-acct.enc.yaml
+++ b/cert-manager/overlays/emea/rick/secrets/clouddns-dns01-emea-svc-acct.enc.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+data:
+    key.json: ENC[AES256_GCM,data:ApkQa3Cr2n8R5LAaf4T9szz9DiIL1rksbfvSReJVhKnzk1aVlfFkSsOv9+8de4KUEv772ud6WXR3Tu8aA+EQiDnvgOrDLwATwnTrvfAaOLO0qCCriOhpxGkav35HJFseXDRK2mBTU1bxySoWj3hJrq3M10gCIVoNZwlBIupGP9l6AuyDFElv7hgtghMDO5h3cTZLGyO4aBqXP93YRmBS+bUTSuatSSTww9Hle3oieprGToMo57XKWbNcqOSSYqjv0glPQdmorIz2PIj6LJle6hq7jbOoMILZ1TCCZ82Rdiqr5aY/xxS4U/sKRGPLp6DQe3o2n8SUhDAunMK11aUdKeBgT3t+ITAqtBqnr4g+QAjzFLDKjkAqep+FvKMbroybHp7k8ckoaxwcdO6LZwX+zNzW+/2V4AmkpXHyNZrrt87GGaWm/Ek1xhAVntDNbsSmTIPJwJtA9QIrcqRV67cxRxZz2SD0+crOWdh8SQcqbAugQbdEF2WrypckRoNj3FWyqnF2DaU6hw1OGdxDD3DR7wM4AFk9MGJ2s1X9Y46Qh+RYETHZQ3W4aMrhfcxwToS0kXWZy7lcZK+6PsYt9Wkfdg2ZBvomN0Nnu9ELJW+J15EH0LK526FO5XCxO253kTRetmqpWlfXjevA0+cITYdP4xD97z6T7cEJWRHSDxHEAvfHqc1scp7cpdVd/c72GPGWYUCyIO9IvWfPSzXImVI6D0C12r8hIGLDgBNDf/wLjohKINfMo9eIVLOHogtRJzovAi15SiiTU1st+xufwLJUICl2e0c0X2gVhtA1p3bd2vxG0wk+AnHWAzmF8ihW5Xl96HVCvaCGGOfiX5byK/3Oot+zRRJOjsKnrYGAL+wyzlJpb8u/lE7V7Rp4PjC4YfzIEciV15763rQIEK0AxsrWNOZvNpnfwYttJZv5LWk8I+ARe/yVLYzXfMZwqynxxjfAY5DE77Wo6ElW+eLfe/k8nbgdbVi8Gq5oXVwmxip6voljD0WjSMLl1iV72hdch8s4yPv1PMNm25FwkSVfhCXhM7IRJsoFlhoyoAhXyz6az6H4T/IZTLsMRbeGL/E8cls4fVGI+VMUlTOv9sV3812MpLu4oegUzG740VgbyEoBve2HMNCqrlEeFvyfOLfQ6/FKdRpCi0mcwMG3CXdfodd3RgLPimD1My7qvVsJOeDXhuAxKGg3wLF48DxS9hq7zfMTNpundCKaLzDu7VtLbmWN77ATMevqG4XEdXL/l0FQb6QuDixcBDSxjMQhbub7rG1bkzRi7B82XGXMIXTy3j4Y69fgKAovEmChmKUzpMDVlgC8O3PjOocm0uuIAB5T+/UStK+kE6A89oLBDCezP3tCpKYDXDMkfd1KEIb4REeyYh7/lw/vip3ASuuTO7A7+FxkI7K54tfdizNdwh5GqolaZt1ATLUdZr7Nly9sgeDS5ZrvbtPyaOQk1L/LtTEB0uhu5wVejk42E7ZUSruBOFEOPerbePoCvIqeM2BibO08lRMnE4o7qgzO3tF3CcyVuW5gJaSLpQ92cgzalWzGfwjw+7mT5pFuu8vjG/JwLIaSWw4KRbScR0HwqHbhC7OD6J8erM3dD4LuFbs8ZM1AWKW9Dkm6fhLtr7eJTeR8VM7pnMhSHCeCkVBTLT3pwScLqn1y8kdt9+jhKQDJtG47vEENZ6Oy+n/XddTpyhMxEhb2In0Zp+0YPIDVyNRJSTWgdmHGxHLuGf9m98Pjg+IDr3iHtTXMitQ9Nj8Qwkc1RA8iUokUfHlg637DTnbT1Xom9a90qj/hxr0w1UVfDwmsn17SyIuTsGaeFsPY51/hPiVXW05gkxJW56UqOkzOMx3OF8PU/J6Oc7Z5uPAavgHiOdL3I6uRhzd7dMmd9kAGHABgRTiDiqFZBJymSfUKZgca/kR/tMYJ9Uk1DU3d487bs/xRNzBtoY3LD7K7fd3cZXjZB5HLs9Golyq0GKDqhVn3C9eDGLKUcAU0a/7pPAeEyp7Pzs89hwwABRRb1BdR1zlAjw7Qv+HZakz0uPLyBiFdOtZxEpFy3ve0br+iqgZjxQqkD9pVGry9D9HJztYt3f7mkdWfIdoTGEDsSAqTUgkAoNOLCIxu2NvzzjAi3/MVD0O0uEm7OU68MSlalbZ3oysBYushmLa11FuvT9J1hYBsAGqxKMQpyJLLu1raRQhDO1tVFQ6H23B1u+0lhYQCLbINClhKJg+pcj5wCIUcMpgvH8i1wX9yv/XepPsPSZ7ZmwH2TSsW1rI1E4HSK5GnHABw5Cljjf3THmd6OENoBCBTtxDQ/JaGRLTe2liMV3pdm6CAgHaKuE5KLP1l+Uva26Dp307cZDYbVS7ZwP+oR0G4Mwq29AfJi8jw1SDZVE1KuM0EwUjZEesdV9WxraRwITXojb4yGV4B89OVK6l8dttJzGZ6AzWdkneouUHtKSbTVl/Nab0H+G59TtsVW0aKgvXpPzJmO1K7OfaRDw3PUfwgh8xM47oPNM05WWddnm7VnBvNupychoF0uFwXBLhnF73obR09/COP5LYeRoSphSPbHNKWee6GvxAK5DoUqkbD4h5FXREWZA+zEx5sxQKNcvArcNvoqgybnhHB8il6hxdafjNMMWLQNkZUsshwzu0/21ZNSheVw9zDf7BiSweizZBHvqmb8ACXxmw9vnXzOlZApwuZmSQpozkkmUamYs/IXjBz85msEVkJOdIovCx227YM3aDV0+Yxg5HchvqE9RjPnOJYGcbYfF/bFQbj6ej0LitjZg0z51k3HQqU0bvGxpIKI2H9bQzTAXS9wykI8ju/4mrrchBFty3jRvgu4eNDfa2XUf9tzWmryZ84YsrhLwyM3tRZNbZBmlY/7V0OwbQiDLTQQm1cbN2ZKpefeAA6v4xQH2XHkKE4gyd4moZvB72Jowb2AMfbjcQ4EgDauwV2AS2ds+tFLYOPz+1a3DM6Z7VFBItZqETzgyDOzez7Da0QVZLPW1KEcLmAnRktsXpWKtlwgFstfOD3sTdiqfhbJGOhO8o0GGxNGZgawThQmOhLfesanuJd8ITYOYm6UFK2XORzsJFyCYAFA+Pg70XwVD9z4HPKcTTVjiwRkB/d5OHa3az6SaVGjITdTER0L/IbHh7DhvCJ6MfzYeNB02lcChSLruy8QBo4qZXrq4a1/dqKpbQg60gkAPoWP6gKLvqWDY0KC8izpXarACjz0o5+kwLAK0TCso5J6IB6fecIjLg8DuNHjG18jA7RR4dCKiGMJEerIWBODZympyMSxrFtNftSQMolGB90oFr5zvdnexs+ldahGKwXEKSqpHeVqnXZGrMbx4HMIdwP00W3uiG3fMCk8V4XspCe8AaR5kh6mcMVlI8RGj3ZjzMIrb4sn3AC6+BzmxovWYlNRG8KCL25nDTc+empP2k3OgAZ3Lfw504VcmAQS8qVX/y8IOVOYcOGMrziXEyODxpZyz2/nw1fjwdVTudd1DxeLdDJkV+doGWPfyj4xxUrzZarPWTHsVQfa4ulVnH0CDpjcN72s6ctgexdLPk0SjxvOYDAXZd3fiMIbb8+q+6QnZMTeRfK78J7Xj8fmffoZ0PjYlQ+RZwWQyhAyWM0fi63YUy8jHsJvkr3dRJ7NsBFAZxzxqo/cOQGOzLSPSSalzitWwP5sxzuDH7ny5t/ffUCYZ6H5AQszhMte3yM9ii6ZgXV5rXKvmLTC3BEVoHVxBVTLi94sTuKeGsy6TS3XOSBUustknpeDGK/MHinaQdS5bKYWihX7hFEOybbsWiF+rfZy046JsvFFy8QReSLpRfdUaOCmT8VpsXYZ/VhZ1boDaVH7jJAON4PcbUwWOoY4bQ2dzDDQKHn6UODTFeXTrUvH0omsPdPFnOhb9NSXVo0xu9hGjkwWqL+CXXRCKqhwni8aMJEryeg8pHztoRDNCZroVsfboSbXQ/w/dJ89+1GOSjiapMLsfy0adqxL+xln8qJRxnZwBaBNBGoznA0qEqugLjakNe4JrCsWHNN5r0MFVVEqYjTNo8w1GhazyMjsUn2twK3Dz6VUANE3blKsJBbOzuge35VWPIwF840YMOUJl4OgxHZ7Kj2zyejtAWqo9Nkp4RHl3OGowuFqG5rjZE4w6c/uGrDqg==,iv:Hr8hFi3WZ6i4rHhKi4Uklyp0odh01hXtHIsZnu2lR8Y=,tag:NCtUIuBb4yXI8R2Fz4vmjQ==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: clouddns-dns01-emea-svc-acct
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-03-08T15:26:08Z"
+    mac: ENC[AES256_GCM,data:zo1L39lrAjDayci+VZFikSPpK0BEttaNtZ9nMou3XZjq8RFMy9eHXsP35WXSRRNvSib56RER23hd7tMU6zg4haMT5Ad+WOztWfxzLjkiJ6tDhFw/1qIpki6xPxXrnybYG7/3uRVPISxBX83UZjh5SHNUOiOmSI7Ngf2gfNFqR94=,iv:8bS8smwVjeWi/+SgCJQiZIF1kjZl+SSOuqxJTJ0tctk=,tag:2lx5XPk8N/GcQTyC223Dig==,type:str]
+    pgp:
+        - created_at: "2022-03-08T15:26:08Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMA9aKBcudqifiARAAWkW+v07FGVw97cGoyqtRQb2J6werXjLM3eTLhSbGUnVv
+            9R0eRFjFRvcwyaMbCzXE4rkcDQjXtO/j5H/PA7ntSyMO5dU91J6YVIo/e1rS3wAJ
+            mALfynUY3Xzh/Fe2aNToG6Ck3hfLol7MLJrd+FJ7CVLguJaZZ2X1s954YPMsna0a
+            hVhtVKaij/GKv3IoucTTHTQAiqKUMgGfnBjI4sWQJQDPXGbkRVxHEHmrFuz7/VMu
+            T2Z22WXkpy5QOz1WZt03uBjZD9+/9TlVqsvVpamuheupmIyrnOnY1NjqWikEkjLf
+            n5nJcJWsLiAzJ45qk9svR0NZSP/vrF2Tl6LYRGsiyhOfJY8FJV965hE+8w5RKdVq
+            ah4UzqpsNNw4wPL0Ysik15/VRm5koMv1ZSfH70iOLGGyxZk4aBvDyleXr/wlrTzG
+            KRY6V3GAddgLuOwdW32OIX/CZjxaFL49lqhBPhb3oUP8gacm39GBL3CXa9Tik+MA
+            gX+tigru768Si9ydyx/yzjHq6oXiFhP4NsOmRMiRxlGHp50ILnyMtNqyMam0hsfd
+            Pl09yJ9QeSNSxmlBHQZRY17edvMxreeHzjq5b86w1Dg0CtWxcrlbt1rrvKUj80qJ
+            UUVj/SKFSPv8dWVbZ2xhoZsK3syZlO9zFn4TunOr93+O4G1gF7IcQqMCCiimLAjS
+            5gHJzlZlR/eRbz9DKid64gfJUyMnGpZ7FL5u8ipsg0IDKBscdZYmsu1fUini3lkw
+            0qbozmqnEL8GrC5pp8Vmmc3kr6sqR8d0H57/2C0dyROJQuKLCGXAAA==
+            =/osb
+            -----END PGP MESSAGE-----
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+        - created_at: "2022-03-08T15:26:08Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcFMAx7mQRst6P0PARAApe84qIBwx/mg6+c0+uVZZX3rRB8eVwA36XmhTmBuZk0M
+            ooPWzfSZFN+hfYJJg6Z38JeHeJEdBq4lzwBUOSmx8ozOltkQWX1ahzFCP0V9z48B
+            1XVahZgbPF7VvKmoghvrS5WtlIF42urPTQhi8/25xio5cJHglAQys3PaO4jEiSfF
+            ftOvFypwa+nljhG+E3sJCS3xIuKiZtx9RIdSqZmL2B/+i1Uka7J8AHU2POcSUJX2
+            VtWt3SrVR24Cmnih7gYf7CeYG8NaykiIZtNJPnvxS/a8Sb6aGXw5y/a6UBeKjWbu
+            Y07BhWv6GeeY7Y00MGllMZaPUG8nwzKHd5hohR+mz7UMSm/lsINjq8wQOaLcAJv3
+            9wV4ElXd+UHDCypSuc2F5wp5EqNj+NRYVrJ4rgbLYhbyP900lxgk+Y3/Jw6KUmeb
+            ww7GkSDofQdh4JkRUQr8XGWT/wXUEc//T6zb2zN8QfEFNwNvSe2qKv6sFP4TpxU/
+            XOAgtx8fwjwXuBCVjD9GubZ6GMShMKA0LwG5/5s3/+gN7c500LOJLzCnORT/DR9P
+            j1IbGcMeM+2+JDzsHj8G6azleN18f2RcgMpyFsfPHrqO9d6M0j8DbVBzKYBXd8dh
+            /An6/MFVti2sKre1OLy4Eo6emLoPo608xasOhplNHSx8Gw+RQAocJOx4T2qiAM/S
+            5gHrXaGlinJOXJRYJRf3tZUGdgYRdsXFSctLG9+tFuxoLX18cpgyw25z2dDhEK6V
+            qq+HYPrURVTDs5AAu5/gkvXkpDZzim0r5tAGvExFVI6lCuJnO7fzAA==
+            =8/Pb
+            -----END PGP MESSAGE-----
+          fp: 2EB7924D7DA3E2DF4717D3EA9E8653F7D343455A
+    encrypted_regex: ^(users|data|stringData)$
+    version: 3.7.1

--- a/cert-manager/overlays/emea/rick/secrets/kustomization.yaml
+++ b/cert-manager/overlays/emea/rick/secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - secret-generator.yaml

--- a/cert-manager/overlays/emea/rick/secrets/secret-generator.yaml
+++ b/cert-manager/overlays/emea/rick/secrets/secret-generator.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: secret-generator
+files:
+  - clouddns-dns01-emea-svc-acct.enc.yaml

--- a/cluster-scope/overlays/prod/emea/rick/apiserver/api_server_cert.yaml
+++ b/cluster-scope/overlays/prod/emea/rick/apiserver/api_server_cert.yaml
@@ -1,0 +1,11 @@
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+spec:
+  servingCerts:
+    namedCertificates:
+      - names:
+          - api.rick.emea.operate-first.cloud
+        servingCertificate:
+          name: api-certificate

--- a/cluster-scope/overlays/prod/emea/rick/apiserver/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/rick/apiserver/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - api_server_cert.yaml

--- a/cluster-scope/overlays/prod/emea/rick/ingresscontrollers/default.yaml
+++ b/cluster-scope/overlays/prod/emea/rick/ingresscontrollers/default.yaml
@@ -1,0 +1,12 @@
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  httpErrorCodePages:
+    name: ""
+  replicas: 2
+  unsupportedConfigOverrides: null
+  defaultCertificate:
+    name: ingress-certificate

--- a/cluster-scope/overlays/prod/emea/rick/ingresscontrollers/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/rick/ingresscontrollers/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - default.yaml

--- a/cluster-scope/overlays/prod/emea/rick/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/rick/kustomization.yaml
@@ -22,6 +22,7 @@ resources:
     - ../../../../base/operators.coreos.com/operatorgroups/openshift-cnv-rn5jf
     - ../../../../base/operators.coreos.com/operatorgroups/openshift-local-storage-zj22x
     - ../../../../base/operators.coreos.com/operatorgroups/openshift-storage-24n7x
+    - ../../../../base/operators.coreos.com/subscriptions/cert-manager
     - ../../../../base/operators.coreos.com/operatorgroups/opf-monitoring
     - ../../../../base/operators.coreos.com/operatorgroups/opf-kafka
     - ../../../../base/operators.coreos.com/subscriptions/cluster-logging
@@ -39,7 +40,9 @@ resources:
     - ../../../../bundles/acme-operator
     - ../../../../bundles/external-secrets-operator
     - ../../../../bundles/nfd
+    - apiserver
     - clusterversion.yaml
+    - ingresscontrollers
     - secrets
     - secretstores
     - serviceaccounts


### PR DESCRIPTION
Despite this cluster being decomissioned soon, we need it secured as it has some secrets that need to be encrypted (since they are stored in git), we want to use vault for this but it cannot fetch from vault due to unsigned api certs. 

See: https://github.com/operate-first/apps/issues/1996