### PR TITLE
Add resources needed to deploy rapidast-operator to smaug cluster

### DIFF
--- a/cluster-scope/base/operators.coreos.com/catalogsources/rapidast/catalogsource.yaml
+++ b/cluster-scope/base/operators.coreos.com/catalogsources/rapidast/catalogsource.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: rapidast-catalog
+  namespace: rapidast
+spec:
+  sourceType: grpc
+  image: quay.io/redhatproductsecurity/rapidast-operator-catalog:v0.0.1

--- a/cluster-scope/base/operators.coreos.com/catalogsources/rapidast/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/catalogsources/rapidast/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- catalogsource.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/rapidast/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/rapidast/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: aicoe-meteor
+namespace: rapidast
 resources:
 - operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/rapidast/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/rapidast/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: aicoe-meteor
+resources:
+- operatorgroup.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/rapidast/operatorgroup.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/rapidast/operatorgroup.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: rapidast-operator
+  namespace: rapidast
+spec:

--- a/cluster-scope/base/operators.coreos.com/subscriptions/rapidast/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/rapidast/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: aicoe-meteor
+namespace: rapidast
 resources:
 - subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/rapidast/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/rapidast/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: aicoe-meteor
+resources:
+- subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/rapidast/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/rapidast/subscription.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rapidast-operator
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: rapidast-operator
+  source: rapidast-catalog
+  sourceNamespace: rapidast

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -78,12 +78,14 @@ resources:
 - ../../../../base/imageregistry.operator.openshift.io/configs/cluster
 - ../../../../base/noobaa.io/backingstores
 - ../../../../base/operators.coreos.com/catalogsources/operatorhubio-catalog/
+  ../../../../base/operators.coreos.com/catalogsources/rapidast
 - ../../../../base/operators.coreos.com/operatorgroups/cluster-logging
 - ../../../../base/operators.coreos.com/operatorgroups/koku-metrics-operator
 - ../../../../base/operators.coreos.com/operatorgroups/openshift-cnv-rn5jf
 - ../../../../base/operators.coreos.com/operatorgroups/openshift-vertical-pod-autoscaler
 - ../../../../base/operators.coreos.com/operatorgroups/opf-monitoring
 - ../../../../base/operators.coreos.com/operatorgroups/opf-pulp
+  ../../../../base/operators.coreos.com/operatorgroups/rapidast
 - ../../../../base/operators.coreos.com/subscriptions/camel-k
 - ../../../../base/operators.coreos.com/subscriptions/cert-manager
 - ../../../../base/operators.coreos.com/subscriptions/cluster-logging
@@ -92,6 +94,7 @@ resources:
 - ../../../../base/operators.coreos.com/subscriptions/kubevirt-hyperconverged
 - ../../../../base/operators.coreos.com/subscriptions/ovms-operator
 - ../../../../base/operators.coreos.com/subscriptions/pulp-operator
+  ../../../../base/operators.coreos.com/subscriptions/rapidast
 - ../../../../base/operators.coreos.com/subscriptions/snapscheduler
 - ../../../../base/operators.coreos.com/subscriptions/strimzi
 - ../../../../base/operators.coreos.com/subscriptions/vertical-pod-autoscaler

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -78,14 +78,14 @@ resources:
 - ../../../../base/imageregistry.operator.openshift.io/configs/cluster
 - ../../../../base/noobaa.io/backingstores
 - ../../../../base/operators.coreos.com/catalogsources/operatorhubio-catalog/
-  ../../../../base/operators.coreos.com/catalogsources/rapidast
+- ../../../../base/operators.coreos.com/catalogsources/rapidast
 - ../../../../base/operators.coreos.com/operatorgroups/cluster-logging
 - ../../../../base/operators.coreos.com/operatorgroups/koku-metrics-operator
 - ../../../../base/operators.coreos.com/operatorgroups/openshift-cnv-rn5jf
 - ../../../../base/operators.coreos.com/operatorgroups/openshift-vertical-pod-autoscaler
 - ../../../../base/operators.coreos.com/operatorgroups/opf-monitoring
 - ../../../../base/operators.coreos.com/operatorgroups/opf-pulp
-  ../../../../base/operators.coreos.com/operatorgroups/rapidast
+- ../../../../base/operators.coreos.com/operatorgroups/rapidast
 - ../../../../base/operators.coreos.com/subscriptions/camel-k
 - ../../../../base/operators.coreos.com/subscriptions/cert-manager
 - ../../../../base/operators.coreos.com/subscriptions/cluster-logging
@@ -94,7 +94,7 @@ resources:
 - ../../../../base/operators.coreos.com/subscriptions/kubevirt-hyperconverged
 - ../../../../base/operators.coreos.com/subscriptions/ovms-operator
 - ../../../../base/operators.coreos.com/subscriptions/pulp-operator
-  ../../../../base/operators.coreos.com/subscriptions/rapidast
+- ../../../../base/operators.coreos.com/subscriptions/rapidast
 - ../../../../base/operators.coreos.com/subscriptions/snapscheduler
 - ../../../../base/operators.coreos.com/subscriptions/strimzi
 - ../../../../base/operators.coreos.com/subscriptions/vertical-pod-autoscaler


### PR DESCRIPTION
Adds a catalog source, operator group, and subscription to deploy the RapiDAST operator to the smaug cluster.