### PR TITLE
feat(onboarding): Add team sostrades in os-cli2

### DIFF
--- a/cluster-scope/base/core/namespaces/sostrades/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/sostrades/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+- resourcequota.yaml
+- limitrange.yaml
+components:
+- ../../../../components/project-admin-rolebindings/sostrades
+namespace: sostrades

--- a/cluster-scope/base/core/namespaces/sostrades/limitrange.yaml
+++ b/cluster-scope/base/core/namespaces/sostrades/limitrange.yaml
@@ -1,0 +1,13 @@
+kind: LimitRange
+apiVersion: v1
+metadata:
+  name: sostrades-limitrange-custom
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: '1'
+        memory: 1Gi
+      defaultRequest:
+        cpu: 300m
+        memory: 400Mi

--- a/cluster-scope/base/core/namespaces/sostrades/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/sostrades/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: sostrades
+    annotations:
+        openshift.io/display-name: SoSTrades Namespace
+        openshift.io/requester: sostrades

--- a/cluster-scope/base/core/namespaces/sostrades/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/sostrades/resourcequota.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: sostrades-resourcequota-custom
+spec:
+  hard:
+    limits.cpu: '30'
+    limits.memory: 100Gi
+    requests.cpu: '6'
+    requests.memory: 10Gi
+    requests.storage: 20Gi
+    count/objectbucketclaims.objectbucket.io: "1"

--- a/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
@@ -30,6 +30,7 @@ resources:
 - ../../../../base/core/namespaces/openshift-nfd
 - ../../../../base/core/namespaces/opf-monitoring
 - ../../../../base/core/namespaces/nvidia-gpu-operator
+- ../../../../base/core/namespaces/sostrades
 - ../../../../base/operators.coreos.com/operatorgroups/openshift-nfd
 - ../../../../base/operators.coreos.com/subscriptions/nfd
 - ../../../../base/config.openshift.io/oauths/cluster


### PR DESCRIPTION
Pull request following the guide 'How to onboard a new project to a cluster on Operate First Cloud' to integrate SosTrades Project in Operate-first on os-cli2 cluster.

Sostrades Project is already in os-cli2 cluster but following discussion with Michel Tiemann, he advised us to migrate to the 2nd cluster made available for OS-Climate.

(sos-trades is a 6-repo contribution fromt Airbus for their "System of Systems" (SOS) platform. See https://github.com/os-climate/sostrades-core)

Here is a description of the project : SoSTrades is the tool used for the implementation of WITNESS or Transition Tool within OS-Climate. We plan to connect with Pysical risk and Data commons in the near future. SoSTrades is a web-based, multi-user, interactive publication-quality graph simulation platform. It allows users to drop new modules without additional coding, and provides embedded advanced numerical capabilities for simulation and multi-disciplinary optimization. It also has built-in collaborative capabilities to allow different experts to work together.