### PR TITLE
Update the ray worker and notebook to v0.2.0 version

### DIFF
--- a/kfdefs/base/jupyterhub/notebook-images/ray-ml-notebook.yaml
+++ b/kfdefs/base/jupyterhub/notebook-images/ray-ml-notebook.yaml
@@ -16,4 +16,4 @@ spec:
       name: latest
       from:
         kind: DockerImage
-        name: 'quay.io/thoth-station/s2i-ray-ml-notebook:v0.1.1'
+        name: 'quay.io/thoth-station/s2i-ray-ml-notebook:v0.2.0'

--- a/kfdefs/overlays/moc/smaug/jupyterhub/ray-odh-integration/ray-ml-profile-cm.yaml
+++ b/kfdefs/overlays/moc/smaug/jupyterhub/ray-odh-integration/ray-ml-profile-cm.yaml
@@ -26,7 +26,7 @@ data:
               - name: ray-cluster-template
                 path: rayDashboardRouteTemplate
             configuration:
-              ray_image: 'quay.io/thoth-station/ray-ml-worker:v0.1.2'
+              ray_image: 'quay.io/thoth-station/ray-ml-worker:v0.2.0'
               # number of workers currently disabled due to json/jinja bug in JH launcher
               #max_workers: 5
               memory_request: '3Gi'


### PR DESCRIPTION
Update the ray worker and notebook to v0.2.0 version
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

update contains inclusion of following packages:
- ray[data]
- tensorflow
- pytorch