### PR TITLE
feat(service-catalog): Create ArgoCD app

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - prod-aicoe-ci.yaml
   - pulp.yaml
   - reloader.yaml
+  - service-catalog.yaml
   - slack-first.yaml
   - tekton-chains.yaml
   - triage-party.yaml

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/service-catalog.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/service-catalog.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: service-catalog
+spec:
+  project: operate-first
+  source:
+    repoURL: https://github.com/operate-first/service-catalog.git
+    targetRevision: main
+    path: manifests/overlays/prod
+  destination:
+    name: smaug
+    namespace: service-catalog
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false

--- a/argocd/overlays/moc-infra/projects/operate-first.yaml
+++ b/argocd/overlays/moc-infra/projects/operate-first.yaml
@@ -75,3 +75,5 @@ spec:
       kind: ThanosRuler
     - group: logging.openshift.io
       kind: ClusterLogForwarder
+    - group: postgres-operator.crunchydata.com
+      kind: PostgresCluster

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/service-catalog/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/service-catalog/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: service-catalog
+resources:
+- operator-group.yaml

--- a/cluster-scope/base/operators.coreos.com/operatorgroups/service-catalog/operator-group.yaml
+++ b/cluster-scope/base/operators.coreos.com/operatorgroups/service-catalog/operator-group.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: crunchy-postgres-group
+spec:
+  targetNamespaces:
+  - service-catalog

--- a/cluster-scope/base/operators.coreos.com/subscriptions/service-catalog/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/service-catalog/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: service-catalog
+resources:
+- subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/service-catalog/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/service-catalog/subscription.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: crunchy-postgres-sub
+spec:
+  channel: v5
+  name: crunchy-postgres-operator
+  source: certified-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-scope/bundles/service-catalog/kustomization.yaml
+++ b/cluster-scope/bundles/service-catalog/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base/operators.coreos.com/operatorgroups/service-catalog
+  - ../../base/operators.coreos.com/subscriptions/service-catalog

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -143,6 +143,7 @@ resources:
 - ../../../../bundles/opf-vault
 - ../../../../bundles/reloader
 - ../../../../bundles/seraph
+- ../../../../bundles/service-catalog
 - ../../../../bundles/tekton-chains
 - ../../../../bundles/volsync
 - ../common


### PR DESCRIPTION
Part of #2036 

## Changes
- Create ArgoCD app for service-catalog
- Create prostgres-db bundle required by the service-catalog

Right now blocked by [#2](https://github.com/operate-first/service-catalog/pull/2).

