### PR TITLE
Add secret stores balrog cluster

### DIFF
--- a/cluster-scope/overlays/prod/emea/balrog/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/balrog/kustomization.yaml
@@ -28,9 +28,8 @@ resources:
     - apiserver
     - machineautoscalers.yaml
     - ingresscontrollers
+    - secret-mgmt
     - secrets
-    - secretstores
-    - serviceaccounts
 generators:
     - secret-generator.yaml
 patchesStrategicMerge:

--- a/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/acme-operator/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/acme-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: acme-operator
+resources:
+  - ../base

--- a/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/base/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- opf-vault-store.yaml
+- vault-secret-fetcher.yaml

--- a/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/base/opf-vault-store.yaml
+++ b/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/base/opf-vault-store.yaml
@@ -1,8 +1,7 @@
 apiVersion: external-secrets.io/v1beta1
 kind: SecretStore
 metadata:
-  name: openshift-monitoring
-  namespace: openshift-monitoring
+  name: opf-vault-store
 spec:
   provider:
     vault:

--- a/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/base/vault-secret-fetcher.yaml
+++ b/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/base/vault-secret-fetcher.yaml
@@ -2,4 +2,3 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: vault-secret-fetcher
-  namespace: openshift-monitoring

--- a/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - acme-operator
+  - openshift-config
+  - openshift-ingress
+  - openshift-logging
+  - openshift-monitoring
+  - openshift-user-workload-monitoring

--- a/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/openshift-config/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/openshift-config/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-config
+resources:
+  - ../base

--- a/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/openshift-ingress/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/openshift-ingress/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-ingress
+resources:
+  - ../base

--- a/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/openshift-logging/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/openshift-logging/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: openshift-logging
 resources:
-  - openshift-monitoring.yaml
+  - ../base

--- a/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/openshift-monitoring/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/openshift-monitoring/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-monitoring
+resources:
+  - ../base

--- a/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/openshift-user-workload-monitoring/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/openshift-user-workload-monitoring/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: openshift-user-workload-monitoring
 resources:
-  - vault-openshift-monitoring.yaml
+  - ../base


### PR DESCRIPTION
This furthers: #1996 

Trying it out for balrog first. This just adds secret stores, does not change any secrets yet. 

Keeping it in cluster-scope reduces a lot of repetition, and since it only requires that this be done once, it will make it easier to incorporate as part of onboarding in the future(when adding a new namespace) without having to create a separate project/app.