### PR TITLE
fixing grafana_oauth spec labels

### DIFF
--- a/grafana/overlays/moc/smaug/grafana-oauth.yaml
+++ b/grafana/overlays/moc/smaug/grafana-oauth.yaml
@@ -14,14 +14,14 @@ spec:
           name: grafana-config-overrides
   configMaps:
     - grafana-landing-page
+  serviceAccount:
+    labels:
+      app.kubernetes.io/instance: cluster-resources-smaug
   config:
     server:
       root_url: https://grafana.operate-first.cloud
     dashboards:
       default_home_dashboard_path: "/etc/grafana-configmaps/grafana-landing-page/landingpage.json"
-    serviceAccount:
-      labels:
-        app.kubernetes.io/instance: cluster-resources-smaug
     auth.generic_oauth:
       enabled: true
       scopes: openid email groups profile


### PR DESCRIPTION
Addresses: https://github.com/operate-first/apps/issues/2054

`serviceaccount` should be a part of spec: https://github.com/grafana-operator/grafana-operator/blob/master/documentation/deploy_grafana.md#configuring-the-serviceaccount
instead of part of `config`.