### PR TITLE
Disable argocd prune on osc api certs.

### DIFF
--- a/cluster-scope/overlays/prod/osc/osc-cl1/externalsecrets/api-certs.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/externalsecrets/api-certs.yaml
@@ -3,6 +3,9 @@ kind: ExternalSecret
 metadata:
   name: api-certs
   namespace: openshift-config
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: Prune=false
 spec:
   secretStoreRef:
     name: openshift-config

--- a/cluster-scope/overlays/prod/osc/osc-cl2/externalsecrets/api-certs.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/externalsecrets/api-certs.yaml
@@ -3,6 +3,9 @@ kind: ExternalSecret
 metadata:
   name: api-certs
   namespace: openshift-config
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: Prune=false
 spec:
   secretStoreRef:
     name: openshift-config


### PR DESCRIPTION
API certs get copied over by an external controller onto another secret
named "user-serving-cert-000", including the annotation that's added by
argocd to indicate a resource belongs to an argocd app. This results in
argocd wanting to prune this new secret that's created, because it
assumes this new copy used to be (and is no longer) part of this argocd
app. So we add these annotations to ignore sync of these certs in this
case. We also add an annotation to prevent argocd from reporting OOS
status when this specific secret is OOS, and thus prevent if from
entering an infinte cycle of synchronizations.