### PR TITLE
fix(service-catalog): Increase resource quota

### DIFF
--- a/cluster-scope/base/core/namespaces/service-catalog/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/service-catalog/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
 components:
     - ../../../../components/limitranges/default
     - ../../../../components/project-admin-rolebindings/service-catalog
-    - ../../../../components/resourcequotas/small
+    - ../../../../components/resourcequotas/large


### PR DESCRIPTION
A bigger resource quota is needed for the `service-catalog` postgres operator.