### PR TITLE
add b4mad-minecraft to smaug

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/b4mad/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/b4mad/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - racing.yml
+  - minecraft.yml

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/b4mad/minecraft.yml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/b4mad/minecraft.yml
@@ -1,15 +1,15 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: b4mad-racing
+  name: b4mad-minecraft
 spec:
   destination:
     name: smaug
-    namespace: b4mad-racing
+    namespace: b4mad-minecraft
   project: b4mad
   source:
     path: manifests
-    repoURL: https://github.com/b4mad/racing.git
+    repoURL: https://github.com/b4mad/minecraft.git
     targetRevision: main
   syncPolicy:
     syncOptions:

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
 - ../../../../base/core/namespaces/aicoe-meteor
 - ../../../../base/core/namespaces/api-designer
 - ../../../../base/core/namespaces/apicurio-apicurio-registry
+- ../../../../base/core/namespaces/b4mad-minecraft
 - ../../../../base/core/namespaces/boatrockers
 - ../../../../base/core/namespaces/bu-cs-book-dev
 - ../../../../base/core/namespaces/bu-scsaol


### PR DESCRIPTION
this was not migrated to smaug. It's becoming active again and also added to argocd
I also change the metadata name for the racing namespace