### PR TITLE
Fix minio operator source

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/minio-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/minio-operator/subscription.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   channel: stable
   name: minio-operator
-  source: operatorhub.io-operators
+  source: certified-operators
   sourceNamespace: openshift-marketplace
   installPlanApproval: Automatic


### PR DESCRIPTION
The catalog source in the original PR was mis-spelled; the catalog name for
OperatorHub is `operatorhubio-catalog`, not `operathub.io-operators`.
However, it turns out that the `certified-operators` catalog has a more
recent version.

