### PR TITLE
Fix mistake during onboarding sostrades on os-cli2

### DIFF
--- a/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
@@ -49,6 +49,7 @@ resources:
 - ../../../../base/user.openshift.io/groups/odh-users
 - ../../../../base/user.openshift.io/groups/pachyderm-admins
 - ../../../../base/user.openshift.io/groups/seldon-admin
+- ../../../../base/user.openshift.io/groups/sostrades
 - ../../../../bundles/external-secrets-operator
 - ../../../../bundles/kfp-tekton
 - ../../../../bundles/opendatahub-operator-manual


### PR DESCRIPTION
I didn't have the rights on the namespace sostrades on the os-cli2 cluster and after checking I saw that I had forgotten this line in the kustomization file.