### PR TITLE
Fix typo in rbac for bu-cs-book-dev namespace

### DIFF
--- a/cluster-scope/components/project-admin-rolebindings/bu-cs-book-dev/rbac.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/bu-cs-book-dev/rbac.yaml
@@ -1,4 +1,4 @@
-piVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
     name: namespace-admin-bu-cs-book-dev


### PR DESCRIPTION
Fixing typo in cluster-scope/components/project-admin-rolebindings/bu-cs-book-dev/rbac.yaml