### PR TITLE
Adding read access to the boston-university-redhat group to the Loki Query API

### DIFF
--- a/observatorium/overlays/moc/smaug/thanos/rolebindings/opf-observatorium-view.yaml
+++ b/observatorium/overlays/moc/smaug/thanos/rolebindings/opf-observatorium-view.yaml
@@ -29,6 +29,9 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: curator
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: boston-university-redhat
   - kind: ServiceAccount
     name: remote-write-emea-balrog
     namespace: opf-observatorium


### PR DESCRIPTION
I would like to request read access to the boston-university-redhat group to the Loki Query API to see the logs. This is based on the following documentation here: 

https://www.operate-first.cloud/apps/content/observatorium/loki/loki_query_api.html