### PR TITLE
pointing argocd applications to migrated prow

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/ci-prow-test-pods.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/ci-prow-test-pods.yaml
@@ -19,7 +19,7 @@ spec:
   project: operate-first
   source:
     path: prow/overlays/smaug-test-pods
-    repoURL: https://github.com/thoth-station/thoth-application.git
+    repoURL: https://github.com/operate-first/apps.git
     targetRevision: master
   syncPolicy:
     automated:

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/ci-prow.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/operate-first/ci-prow.yaml
@@ -19,7 +19,7 @@ spec:
   project: operate-first
   source:
     path: prow/overlays/smaug
-    repoURL: https://github.com/thoth-station/thoth-application.git
+    repoURL: https://github.com/operate-first/apps.git
     targetRevision: master
   syncPolicy:
     automated:

--- a/prow/OWNERS
+++ b/prow/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - goern
+  - harshad16
+reviewers:
+  - tumido
+  - fridex

--- a/prow/README.md
+++ b/prow/README.md
@@ -1,0 +1,13 @@
+# PROW
+
+This is a standalone ArgoCD Application for PROW. It is meant to be deployed into a separate OpenShift Project, therefore it is not references from the `kustomization.yaml` file at the root directory of this repository.
+
+
+## Validation/Compliance
+
+`kustomize build --enable_alpha_plugins overlays/thoth-station | conftest test --policy ../policy -`
+
+## How to know on which environment are tests running on Prow?
+
+The images used to run tests using Prow are listed in the [thoth-station/thoth-ops-infra](https://github.com/thoth-station/thoth-ops-infra) repository.
+For each repository where Prow is configured, the tests run by Prow and the base container image they use are available in the `.prow.yaml` file.

--- a/prow/add-ist
+++ b/prow/add-ist
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# add-ist
+# Copyright(C) 2021 Christoph Görn
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+"""GitOps tool to add an ImageStreamTag."""
+
+
+import logging
+
+from yaml import load_all, dump_all
+
+try:
+    from yaml import CLoader as Loader, CDumper as Dumper
+except ImportError:
+    from yaml import Loader, Dumper
+
+logging.basicConfig(level=logging.INFO)
+
+
+def reset_latest_tag(imagestream: dict, new_tag: str) -> None:
+    """Reset the latest tag of the imagestream to the tag provided."""
+    for tag in imagestream["spec"]["tags"]:
+        if tag["name"] == "latest":
+            logging.info(
+                f"resetting latest tag from {tag['from']['name']} to {new_tag}"
+            )
+            tag["from"]["name"] = new_tag
+    return
+
+
+def add_tag(imagestream: dict, tag_name: str) -> None:
+    """Add the tag name to the ImageStream."""
+    image_name = imagestream["metadata"]["name"]
+    imagestream["spec"]["tags"].append(
+        {
+            "annotations": None,
+            "name": tag_name,
+            "from": {
+                "kind": "DockerImage",
+                "name": f"gcr.io/k8s-prow/{image_name}:{tag_name}",
+            },
+        }
+    )
+
+
+stream = None
+with open("overlays/smaug/imagestreamtags.yaml") as ist:
+    stream = load_all(ist.read(), Loader=Loader)
+
+updated_imagestream_tags = []
+current_tag = "v20211027-fe152eb205"
+
+for data in stream:
+    logging.info(f"updating ImageStream '{data['metadata']['name']}'")
+    add_tag(data, current_tag)
+    reset_latest_tag(data, current_tag)
+
+    updated_imagestream_tags.append(data)
+
+with open("overlays/smaug/imagestreamtags.yaml.new", "w") as ist:
+    ist.write(dump_all(updated_imagestream_tags, Dumper=Dumper, sort_keys=True))

--- a/prow/base/branchprotector.yaml
+++ b/prow/base/branchprotector.yaml
@@ -1,0 +1,47 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: branchprotector
+spec:
+  schedule: "37 1 * * *"
+  concurrencyPolicy: Forbid
+  suspend: true
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          name: branchprotector
+        spec:
+          containers:
+            - name: branchprotector
+              image: gcr.io/k8s-prow/branchprotector:latest
+              imagePullPolicy: IfNotPresent
+              args:
+                - --config-path=/etc/config/config.yaml
+                - --github-token-path=/etc/github/oauth
+                - --github-endpoint=http://ghproxy
+                - --github-endpoint=https://api.github.com
+                - --confirm
+              volumeMounts:
+                - name: oauth
+                  mountPath: /etc/github
+                  readOnly: true
+                - name: config
+                  mountPath: /etc/config
+                  readOnly: true
+              resources:
+                requests:
+                  memory: "64Mi"
+                  cpu: "125m"
+                limits:
+                  memory: "64Mi"
+                  cpu: "125m"
+          restartPolicy: Never
+          volumes:
+            - name: oauth
+              secret:
+                secretName: oauth-token
+            - name: config
+              configMap:
+                name: config

--- a/prow/base/crier.yaml
+++ b/prow/base/crier.yaml
@@ -1,0 +1,121 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: crier
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: crier
+rules:
+  - apiGroups:
+      - "prow.k8s.io"
+    resources:
+      - "prowjobs"
+    verbs:
+      - "get"
+      - "watch"
+      - "list"
+      - "patch"
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+      - "events"
+    verbs:
+      - "get"
+      - "list"
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+    verbs:
+      - "patch"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: crier
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: crier
+subjects:
+  - kind: ServiceAccount
+    name: crier
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crier
+  labels:
+    app: crier
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: crier
+  template:
+    metadata:
+      labels:
+        app: crier
+    spec:
+      serviceAccountName: crier
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: crier
+          image: crier
+          args:
+            - --blob-storage-workers=10
+            - --config-path=/etc/config/config.yaml
+            - --github-token-path=/etc/github/oauth
+            - --s3-credentials-file=/etc/s3-credentials/service-account.json
+            - --github-endpoint=http://ghproxy
+            - --github-endpoint=https://api.github.com
+            - --github-workers=10
+            - --kubernetes-blob-storage-workers=10
+          ports:
+            - name: metrics
+              containerPort: 9090
+          volumeMounts:
+            - name: oauth-token
+              mountPath: /etc/github
+              readOnly: true
+            - name: config
+              mountPath: /etc/config
+              readOnly: true
+            - name: s3-credentials
+              mountPath: /etc/s3-credentials
+              readOnly: true
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "8m"
+            limits:
+              memory: "256Mi"
+              cpu: "8m"
+      volumes:
+        - name: config
+          configMap:
+            name: config
+        - name: s3-credentials
+          secret:
+            secretName: s3-credentials
+        - name: oauth-token
+          secret:
+            secretName: oauth-token
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: crier
+  name: crier
+spec:
+  ports:
+    - name: metrics
+      port: 9090
+      protocol: TCP
+  selector:
+    app: crier

--- a/prow/base/deck.yaml
+++ b/prow/base/deck.yaml
@@ -1,0 +1,159 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: "deck"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "deck"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+  - apiGroups:
+      - "prow.k8s.io"
+    resources:
+      - prowjobs
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "deck"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "deck"
+subjects:
+  - kind: ServiceAccount
+    name: "deck"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deck
+  labels:
+    app: deck
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: deck
+  template:
+    metadata:
+      labels:
+        app: deck
+    spec:
+      serviceAccountName: deck
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: deck
+          image: deck:latest
+          args:
+            - --config-path=/etc/config/config.yaml
+            - --plugin-config=/etc/plugins/plugins.yaml
+            - --github-token-path=/etc/github/oauth
+            - --github-oauth-config-file=/etc/githuboauth/secret
+            - --tide-url=http://tide/
+            - --hook-url=http://hook:8888/plugin-help
+            - --github-endpoint=http://ghproxy
+            - --github-graphql-endpoint=http://ghproxy/graphql
+            - --github-endpoint=https://api.github.com
+            - --oauth-url=/github-login
+            - --plugin-config=/etc/plugins/plugins.yaml
+            - --s3-credentials-file=/etc/s3-credentials/service-account.json
+            - --cookie-secret=/etc/cookie/secret
+            - --spyglass=true
+          ports:
+            - name: main
+              containerPort: 8080
+            - name: metrics
+              containerPort: 9090
+          volumeMounts:
+            - name: config
+              mountPath: /etc/config
+              readOnly: true
+            - name: oauth
+              mountPath: /etc/github
+              readOnly: true
+            - mountPath: /etc/githuboauth
+              name: oauth-config
+              readOnly: true
+            - name: plugins
+              mountPath: /etc/plugins
+              readOnly: true
+            - name: s3-credentials
+              mountPath: /etc/s3-credentials
+              readOnly: true
+            - mountPath: /etc/cookie
+              name: cookie-secret
+              readOnly: true
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "100m"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz/ready
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            timeoutSeconds: 600
+      volumes:
+        - name: config
+          configMap:
+            name: config
+        - name: oauth
+          secret:
+            secretName: oauth-token
+        - name: plugins
+          configMap:
+            name: plugins
+        - name: s3-credentials
+          secret:
+            secretName: s3-credentials
+        - name: oauth-config
+          secret:
+            secretName: github-oauth-config
+        - name: cookie-secret
+          secret:
+            secretName: cookie
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: deck
+spec:
+  selector:
+    app: deck
+  ports:
+    - name: main
+      port: 80
+      targetPort: 8080
+      protocol: TCP
+    - name: metrics
+      port: 9090
+      protocol: TCP
+  type: NodePort

--- a/prow/base/hook.yaml
+++ b/prow/base/hook.yaml
@@ -1,0 +1,135 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "hook"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "hook"
+rules:
+  - apiGroups:
+      - "prow.k8s.io"
+    resources:
+      - prowjobs
+    verbs:
+      - create
+      - get
+      - list
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - get
+      - update
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "hook"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "hook"
+subjects:
+  - kind: ServiceAccount
+    name: "hook"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hook
+  labels:
+    app: hook
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: hook
+  template:
+    metadata:
+      labels:
+        app: hook
+    spec:
+      serviceAccountName: "hook"
+      terminationGracePeriodSeconds: 180
+      containers:
+        - name: hook
+          image: hook:latest
+          args:
+            - --dry-run=false
+            - --config-path=/etc/config/config.yaml
+            - --github-token-path=/etc/github/oauth
+            - --github-endpoint=http://ghproxy
+            - --github-endpoint=https://api.github.com
+          ports:
+            - name: http
+              containerPort: 8888
+            - name: metrics
+              containerPort: 9090
+          volumeMounts:
+            - name: hmac
+              mountPath: /etc/webhook
+              readOnly: true
+            - name: oauth
+              mountPath: /etc/github
+              readOnly: true
+            - name: config
+              mountPath: /etc/config
+              readOnly: true
+            - name: plugins
+              mountPath: /etc/plugins
+              readOnly: true
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "100m"
+            limits:
+              memory: "1Gi"
+              cpu: "100m"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz/ready
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            timeoutSeconds: 600
+      volumes:
+        - name: hmac
+          secret:
+            secretName: hmac-token
+        - name: oauth
+          secret:
+            secretName: oauth-token
+        - name: config
+          configMap:
+            name: config
+        - name: plugins
+          configMap:
+            name: plugins
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hook
+spec:
+  selector:
+    app: hook
+  ports:
+    - name: main
+      port: 8888
+      protocol: TCP
+    - name: metrics
+      port: 9090
+      protocol: TCP
+  type: NodePort

--- a/prow/base/horologium.yaml
+++ b/prow/base/horologium.yaml
@@ -1,0 +1,90 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: "horologium"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "horologium"
+rules:
+  - apiGroups:
+      - "prow.k8s.io"
+    resources:
+      - prowjobs
+    verbs:
+      - create
+      - list
+      - watch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "horologium"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "horologium"
+subjects:
+  - kind: ServiceAccount
+    name: "horologium"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: horologium
+  labels:
+    app: horologium
+spec:
+  replicas: 1    # Do not scale up.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: horologium
+  template:
+    metadata:
+      labels:
+        app: horologium
+    spec:
+      serviceAccountName: "horologium"
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: horologium
+          image: horologium:latest
+          args:
+            - --dry-run=false
+            - --config-path=/etc/config/config.yaml
+          ports:
+            - name: metrics
+              containerPort: 9090
+          volumeMounts:
+            - name: config
+              mountPath: /etc/config
+              readOnly: true
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "2m"
+            limits:
+              memory: "64Mi"
+              cpu: "2m"
+      volumes:
+        - name: config
+          configMap:
+            name: config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: horologium
+  name: horologium
+spec:
+  ports:
+    - name: metrics
+      port: 9090
+      protocol: TCP
+  selector:
+    app: horologium

--- a/prow/base/imagestreams.yaml
+++ b/prow/base/imagestreams.yaml
@@ -1,0 +1,136 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: hook
+spec:
+  lookupPolicy:
+    local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: plank
+spec:
+  lookupPolicy:
+    local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: sinker
+spec:
+  lookupPolicy:
+    local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: deck
+spec:
+  lookupPolicy:
+    local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: horologium
+spec:
+  lookupPolicy:
+    local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: tide
+spec:
+  lookupPolicy:
+    local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: status-reconciler
+spec:
+  lookupPolicy:
+    local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: crier
+spec:
+  lookupPolicy:
+    local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: needs-rebase
+spec:
+  lookupPolicy:
+    local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: label_sync
+spec:
+  lookupPolicy:
+    local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: pipeline
+spec:
+  lookupPolicy:
+    local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: commenter
+spec:
+  lookupPolicy:
+    local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: clonerefs
+spec:
+  lookupPolicy:
+    local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: entrypoint
+spec:
+  lookupPolicy:
+    local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: initupload
+spec:
+  lookupPolicy:
+    local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: sidecar
+spec:
+  lookupPolicy:
+    local: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: prow-controller-manager
+spec:
+  lookupPolicy:
+    local: true

--- a/prow/base/ingress.yaml
+++ b/prow/base/ingress.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: ing
+spec:
+  backend:    # specify the default backend for `ingress-gce` (https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#default_backend)
+    serviceName: deck
+    servicePort: 80
+  rules:
+  - http:
+      paths:
+      - path: /
+        backend:
+          serviceName: deck
+          servicePort: 80
+      - path: /hook
+        backend:
+          serviceName: hook
+          servicePort: 8888

--- a/prow/base/kustomization.yaml
+++ b/prow/base/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - branchprotector.yaml
+  - crier.yaml
+  - deck.yaml
+  - hook.yaml
+  - horologium.yaml
+  - imagestreams.yaml
+  - needs-rebase.yaml
+  - plank.yaml
+  - prow-controller-manager.yaml
+  - sinker.yaml
+  - statusreconciler.yaml
+  - tide.yaml
+commonLabels:
+  app.kubernetes.io/name: aicoe-prow
+  app.kubernetes.io/component: prow
+  app.kubernetes.io/managed-by: aicoe-thoth-devops

--- a/prow/base/label_sync_job.yaml
+++ b/prow/base/label_sync_job.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: label-sync
+spec:
+  backoffLimit: 2
+  template:
+    metadata:
+      labels:
+        name: label-sync
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: label-sync
+          image: label_sync:latest
+          args:
+            - --config=/etc/config/labels.yaml
+            - --confirm=true
+            - --orgs=thoth-station
+            - --token=/etc/github/oauth
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "125m"
+            limits:
+              memory: "64Mi"
+              cpu: "125m"
+          volumeMounts:
+            - name: oauth
+              mountPath: /etc/github
+              readOnly: true
+            - name: config
+              mountPath: /etc/config
+              readOnly: true
+      volumes:
+        - name: oauth
+          secret:
+            secretName: oauth-token
+        - name: config
+          configMap:
+            name: label-config

--- a/prow/base/needs-rebase.yaml
+++ b/prow/base/needs-rebase.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: needs-rebase
+  labels:
+    app: needs-rebase
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: needs-rebase
+  template:
+    metadata:
+      labels:
+        app: needs-rebase
+    spec:
+      terminationGracePeriodSeconds: 180
+      containers:
+        - name: needs-rebase
+          image: needs-rebase:latest
+          args:
+            - --dry-run=false
+            - --github-endpoint=http://ghproxy
+            - --github-endpoint=https://api.github.com
+          ports:
+            - name: http
+              containerPort: 8888
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "1m"
+            limits:
+              memory: "64Mi"
+              cpu: "1m"
+          volumeMounts:
+            - name: hmac
+              mountPath: /etc/webhook
+              readOnly: true
+            - name: oauth
+              mountPath: /etc/github
+              readOnly: true
+            - name: plugins
+              mountPath: /etc/plugins
+              readOnly: true
+      volumes:
+        - name: hmac
+          secret:
+            secretName: hmac-token
+        - name: oauth
+          secret:
+            secretName: oauth-token
+        - name: plugins
+          configMap:
+            name: plugins
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: needs-rebase
+spec:
+  selector:
+    app: needs-rebase
+  ports:
+    - port: 80
+      targetPort: 8888
+  type: NodePort

--- a/prow/base/pipeline.yaml
+++ b/prow/base/pipeline.yaml
@@ -1,0 +1,83 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: prow-pipeline
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prow-pipeline
+rules:
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+      - pipelineresources
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - prow.k8s.io
+    resources:
+      - prowjobs
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prow-pipeline
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prow-pipeline
+subjects:
+  - kind: ServiceAccount
+    name: prow-pipeline
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: prow-pipeline
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: prow-pipeline
+  template:
+    metadata:
+      labels:
+        app: prow-pipeline
+    spec:
+      serviceAccountName: prow-pipeline
+      containers:
+        - name: pipeline
+          image: pipeline:latest
+          args:
+            - --all-contexts
+            - --config=/etc/prow-config/config.yaml
+          volumeMounts:
+            - mountPath: /etc/kubeconfig
+              name: kubeconfig
+              readOnly: true
+            - mountPath: /etc/prow-config
+              name: prow-config
+              readOnly: true
+      volumes:
+        - name: kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: kubeconfig
+        - name: prow-config
+          configMap:
+            name: config

--- a/prow/base/plank.yaml
+++ b/prow/base/plank.yaml
@@ -1,0 +1,101 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: "plank"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "plank-pods"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - create
+      - delete
+      - list
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "plank"
+rules:
+  - apiGroups:
+      - "prow.k8s.io"
+    resources:
+      - prowjobs
+    verbs:
+      - get
+      - create
+      - list
+      - watch
+      - update
+      - patch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: "plank"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "plank"
+subjects:
+  - kind: ServiceAccount
+    name: "plank"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "plank-pods"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "plank-pods"
+subjects:
+  - kind: ServiceAccount
+    name: "plank"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: plank
+  labels:
+    app: plank
+spec:
+  selector:
+    matchLabels:
+      app: plank
+  replicas: 0
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: plank
+    spec:
+      serviceAccountName: "plank"
+      containers:
+        - name: plank
+          image: plank:latest
+          args:
+            - --dry-run=false
+            - --config-path=/etc/config/config.yaml
+            - --skip-report=true
+          volumeMounts:
+            - name: oauth
+              mountPath: /etc/github
+              readOnly: true
+            - name: config
+              mountPath: /etc/config
+              readOnly: true
+      volumes:
+        - name: oauth
+          secret:
+            secretName: oauth-token
+        - name: config
+          configMap:
+            name: config

--- a/prow/base/prow-controller-manager.yaml
+++ b/prow/base/prow-controller-manager.yaml
@@ -1,0 +1,137 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prow-controller-manager
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prow-controller-manager
+rules:
+  - apiGroups:
+      - "prow.k8s.io"
+    resources:
+      - prowjobs
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    resourceNames:
+      - prow-controller-manager-leader-lock
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - prow-controller-manager-leader-lock
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - events
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+      - list
+      - watch
+      - create
+      - patch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prow-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prow-controller-manager
+subjects:
+  - kind: ServiceAccount
+    name: prow-controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prow-controller-manager
+  labels:
+    app: prow-controller-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prow-controller-manager
+  template:
+    metadata:
+      labels:
+        app: prow-controller-manager
+    spec:
+      serviceAccountName: prow-controller-manager
+      containers:
+        - name: prow-controller-manager
+          args:
+            - --dry-run=false
+            - --config-path=/etc/config/config.yaml
+            - --github-token-path=/etc/github/token
+            - --github-endpoint=http://ghproxy
+            - --github-endpoint=https://api.github.com
+            - --enable-controller=plank
+          image: prow-controller-manager:latest
+          ports:
+            - name: metrics
+              containerPort: 9090
+          volumeMounts:
+            - name: config
+              mountPath: /etc/config
+              readOnly: true
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "8m"
+            limits:
+              memory: "128Mi"
+              cpu: "8m"
+      volumes:
+        - name: config
+          configMap:
+            name: config
+        - name: github-token
+          secret:
+            secretName: github-token
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: prow-controller-manager
+  name: prow-controller-manager
+spec:
+  ports:
+    - name: metrics
+      port: 9090
+      protocol: TCP
+  selector:
+    app: prow-controller-manager

--- a/prow/base/sinker.yaml
+++ b/prow/base/sinker.yaml
@@ -1,0 +1,128 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: "sinker"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "sinker"
+rules:
+  - apiGroups:
+      - "prow.k8s.io"
+    resources:
+      - prowjobs
+    verbs:
+      - delete
+      - list
+      - watch
+      - get
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    resourceNames:
+      - prow-sinker-leaderlock
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - prow-sinker-leaderlock
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - events
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+      - list
+      - watch
+      - get
+      - patch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "sinker"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "sinker"
+subjects:
+  - kind: ServiceAccount
+    name: "sinker"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sinker
+  labels:
+    app: sinker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sinker
+  template:
+    metadata:
+      labels:
+        app: sinker
+    spec:
+      serviceAccountName: sinker
+      containers:
+        - name: sinker
+          args:
+            - --config-path=/etc/config/config.yaml
+            - --dry-run=false
+          image: sinker:latest
+          ports:
+            - name: metrics
+              containerPort: 9090
+          volumeMounts:
+            - name: config
+              mountPath: /etc/config
+              readOnly: true
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "4m"
+            limits:
+              memory: "128Mi"
+              cpu: "4m"
+      volumes:
+        - name: config
+          configMap:
+            name: config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: sinker
+  name: sinker
+spec:
+  ports:
+    - name: metrics
+      port: 9090
+  selector:
+    app: sinker

--- a/prow/base/statusreconciler.yaml
+++ b/prow/base/statusreconciler.yaml
@@ -1,0 +1,94 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "statusreconciler"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "statusreconciler"
+rules:
+  - apiGroups:
+      - "prow.k8s.io"
+    resources:
+      - prowjobs
+    verbs:
+      - create
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "statusreconciler"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "statusreconciler"
+subjects:
+  - kind: ServiceAccount
+    name: "statusreconciler"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: statusreconciler
+  labels:
+    app: statusreconciler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: statusreconciler
+  template:
+    metadata:
+      labels:
+        app: statusreconciler
+    spec:
+      serviceAccountName: statusreconciler
+      terminationGracePeriodSeconds: 180
+      containers:
+        - name: statusreconciler
+          image: status-reconciler:latest
+          args:
+            - --dry-run=false
+            - --continue-on-error=true
+            - --plugin-config=/etc/plugins/plugins.yaml
+            - --config-path=/etc/config/config.yaml
+            - --github-token-path=/etc/github/token
+            - --github-endpoint=http://ghproxy
+            - --github-endpoint=https://api.github.com
+            - --s3-credentials-file=/etc/s3-credentials/service-account.json
+            - --status-path=s3://ci-prow/status-reconciler/status-reconciler-status
+          volumeMounts:
+            - name: github-token
+              mountPath: /etc/github
+              readOnly: true
+            - name: config
+              mountPath: /etc/config
+              readOnly: true
+            - name: plugins
+              mountPath: /etc/plugins
+              readOnly: true
+            - name: s3-credentials
+              mountPath: /etc/s3-credentials
+              readOnly: true
+          resources:
+            requests:
+              cpu: "1m"
+              memory: "128Mi"
+            limits:
+              memory: "128Mi"
+              cpu: "1m"
+      volumes:
+        - name: github-token
+          secret:
+            secretName: github-token
+        - name: config
+          configMap:
+            name: config
+        - name: plugins
+          configMap:
+            name: plugins
+        - name: s3-credentials
+          secret:
+            secretName: s3-credentials

--- a/prow/base/tide.yaml
+++ b/prow/base/tide.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "tide"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "tide"
+rules:
+  - apiGroups:
+      - "prow.k8s.io"
+    resources:
+      - prowjobs
+    verbs:
+      - create
+      - list
+      - get
+      - watch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "tide"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "tide"
+subjects:
+  - kind: ServiceAccount
+    name: "tide"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tide
+  labels:
+    app: tide
+spec:
+  replicas: 1    # Do not scale up.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: tide
+  template:
+    metadata:
+      labels:
+        app: tide
+    spec:
+      serviceAccountName: "tide"
+      containers:
+        - name: tide
+          image: tide:latest
+          args:
+            - --dry-run=false
+            - --config-path=/etc/config/config.yaml
+            - --github-token-path=/etc/github/oauth
+            - --github-endpoint=http://ghproxy
+            - --github-endpoint=https://api.github.com
+            - --github-graphql-endpoint=http://ghproxy/graphql
+            - --s3-credentials-file=/etc/s3-credentials/service-account.json
+            - --status-path=s3://ci-prow/tide/tide-status
+            - --history-uri=s3://ci-prow/tide/tide-history.json
+          ports:
+            - name: main
+              containerPort: 8888
+            - name: metrics
+              containerPort: 9090
+          volumeMounts:
+            - name: oauth-token
+              mountPath: /etc/github
+              readOnly: true
+            - name: config
+              mountPath: /etc/config
+              readOnly: true
+            - name: s3-credentials
+              mountPath: /etc/s3-credentials
+              readOnly: true
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "250m"
+      volumes:
+        - name: oauth-token
+          secret:
+            secretName: oauth-token
+        - name: config
+          configMap:
+            name: config
+        - name: s3-credentials
+          secret:
+            secretName: s3-credentials
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tide
+spec:
+  selector:
+    app: tide
+  ports:
+    - name: main
+      port: 80
+      targetPort: 8888
+      protocol: TCP
+    - name: metrics
+      port: 9090
+      protocol: TCP
+  type: ClusterIP

--- a/prow/overlays/smaug-test-pods/crier_rbac.yaml
+++ b/prow/overlays/smaug-test-pods/crier_rbac.yaml
@@ -1,0 +1,33 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: crier
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+      - "events"
+    verbs:
+      - "get"
+      - "list"
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+    verbs:
+      - "patch"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: crier-namespaced
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: crier
+subjects:
+  - kind: ServiceAccount
+    name: crier
+    namespace: opf-ci-prow

--- a/prow/overlays/smaug-test-pods/deck_rbac.yaml
+++ b/prow/overlays/smaug-test-pods/deck_rbac.yaml
@@ -1,0 +1,25 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: deck
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: deck
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: deck
+subjects:
+  - kind: ServiceAccount
+    name: deck
+    namespace: opf-ci-prow

--- a/prow/overlays/smaug-test-pods/kustomization.yaml
+++ b/prow/overlays/smaug-test-pods/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - crier_rbac.yaml
+  - deck_rbac.yaml
+  - prow-controller-manager_rbac.yaml
+  - sinker_rbac.yaml

--- a/prow/overlays/smaug-test-pods/prow-controller-manager_rbac.yaml
+++ b/prow/overlays/smaug-test-pods/prow-controller-manager_rbac.yaml
@@ -1,0 +1,30 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prow-controller-manager
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - create
+      - delete
+      - list
+      - watch
+      - get
+      - patch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prow-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prow-controller-manager
+subjects:
+  - kind: ServiceAccount
+    name: prow-controller-manager
+    namespace: opf-ci-prow

--- a/prow/overlays/smaug-test-pods/sinker_rbac.yaml
+++ b/prow/overlays/smaug-test-pods/sinker_rbac.yaml
@@ -1,0 +1,29 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "sinker"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+      - list
+      - watch
+      - get
+      - patch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "sinker"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "sinker"
+subjects:
+  - kind: ServiceAccount
+    name: "sinker"
+    namespace: opf-ci-prow

--- a/prow/overlays/smaug/config.yaml
+++ b/prow/overlays/smaug/config.yaml
@@ -1,0 +1,573 @@
+plank:
+  report_templates:
+    "*": "[Full PR test history](https://prow.operate-first.cloud/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://prow.operate-first.cloud/pr?query=is%3Apr%20state%3Aopen%20author%3A{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}). Please help us and [open an issue](https://github.com/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/issues?q=is:issue+is:open) when you hit one in your PR."
+  job_url_prefix_config:
+    "*": https://prow.operate-first.cloud/view/
+  default_decoration_configs:
+    "*":
+      gcs_configuration:
+        bucket: s3://ci-prow/prow-logs
+        path_strategy: explicit
+      s3_credentials_secret: s3-credentials
+      ssh_key_secrets:
+        - ssh-secret
+      utility_images:
+        clonerefs: clonerefs
+        entrypoint: entrypoint
+        initupload: initupload
+        sidecar: sidecar
+sinker:
+  max_pod_age: 6h
+  max_prowjob_age: 12h
+  resync_period: 1m
+  terminated_pod_ttl: 120m
+
+prowjob_namespace: opf-ci-prow
+pod_namespace: opf-ci-prow
+log_level: debug
+
+in_repo_config:
+  enabled:
+    aicoe-aiops: true
+    AICoE: true
+    b4mad: true
+    open-services-group: true
+    operate-first: true
+    os-climate: true
+    thoth-station: true
+
+  allowed_clusters:
+    "AICoE": ["api.smaug.na.operate-first.cloud:6443"]
+    "aicoe-aiops": ["api.smaug.na.operate-first.cloud:6443"]
+    "b4mad": ["api.smaug.na.operate-first.cloud:6443"]
+    "operate-first": ["api.smaug.na.operate-first.cloud:6443"]
+    "open-services-group": ["api.smaug.na.operate-first.cloud:6443"]
+    "os-climate": ["api.smaug.na.operate-first.cloud:6443"]
+    "thoth-station": ["api.smaug.na.operate-first.cloud:6443"]
+
+branch-protection:
+  allow_disabled_policies: true
+  orgs:
+    AICoE:
+      protect: true
+      allow_force_pushes: false
+      required_status_checks:
+        contexts:
+          - aicoe-ci/prow/pre-commit
+      repos:
+        Varangian:
+          protect: true
+          allow_force_pushes: false
+          required_status_checks:
+            contexts:
+              - aicoe-ci/prow/pre-commit
+          exclude:
+            - "^revert-"
+            - "^kebechet-"
+            - "^dependabot/"
+        meteor:
+          protect: true
+          allow_force_pushes: false
+          required_status_checks:
+            contexts:
+              - aicoe-ci/prow/pre-commit
+          exclude:
+            - "^revert-"
+            - "^kebechet-"
+            - "^dependabot/"
+        okr:
+          protect: false
+      restrictions:
+        users: []
+        teams:
+          - sourceops
+        required_pull_request_reviews:
+          dismiss_stale_reviews: false
+          required_approving_review_count: 1
+    b4mad:
+      repos:
+        minecraft:
+          protect: true
+          allow_force_pushes: false
+          required_status_checks:
+            contexts:
+              - aicoe-ci/prow/pre-commit
+          exclude:
+            - "^revert-"
+            - "^kebechet-"
+            - "^dependabot/"
+    thoth-station:
+      protect: true
+      allow_force_pushes: false
+      required_status_checks:
+        contexts:
+          - aicoe-ci/prow/pre-commit
+      exclude:
+        - "^revert-"
+        - "^kebechet-"
+        - "^dependabot/"
+        - "^pres-"
+        - "^gh-pages"
+      restrictions:
+        users: []
+        teams:
+          - sourceops
+        required_pull_request_reviews:
+          dismiss_stale_reviews: false
+          required_approving_review_count: 1
+      repos:
+        tensorflow:
+          protect: false
+        contra-env-infra:
+          protect: false
+        statusfy:
+          protect: false
+        statusfy-ops:
+          protect: false
+        website-tooling:
+          protect: false
+        cuda:
+          protect: false
+        stub-api:
+          protect: false
+        nvidia-usage-dashboard:
+          protect: false
+        template-project:
+          protect: false
+        pipelines-catalog:
+          protect: false
+        bz1816214-example:
+          protect: false
+    open-services-group:
+      protect: true
+      allow_force_pushes: false
+      required_status_checks:
+        contexts:
+          - pre-commit
+      exclude:
+        - "^revert-"
+        - "^kebechet-"
+        - "^dependabot/"
+        - "^pres-"
+        - "^gh-pages"
+      restrictions:
+        users: []
+        teams:
+          - sourceops
+        required_pull_request_reviews:
+          dismiss_stale_reviews: false
+          required_approving_review_count: 1
+    os-climate:
+      protect: true
+      allow_force_pushes: false
+      required_status_checks:
+        contexts:
+          - aicoe-ci/prow/pre-commit
+      repos:
+        aicoe-osc-demo:
+          protect: true
+          allow_force_pushes: false
+          required_status_checks:
+            contexts:
+              - aicoe-ci/prow/pre-commit
+          exclude:
+            - "^revert-"
+            - "^kebechet-"
+            - "^dependabot/"
+      restrictions:
+        users: []
+        teams:
+          - sourceops
+        required_pull_request_reviews:
+          dismiss_stale_reviews: false
+          required_approving_review_count: 1
+deck:
+  spyglass:
+    size_limit: 100000000    # 100MB
+    # gcs_browser_prefix: https://gcsweb.k8s.io/gcs/
+    # testgrid_config: gs://k8s-testgrid/config
+    # testgrid_root: https://testgrid.k8s.io/
+    lenses:
+      - lens:
+          name: metadata
+        required_files:
+          - ^(?:started|finished)\.json$
+        optional_files:
+          - ^(?:podinfo|prowjob)\.json$
+      - lens:
+          name: buildlog
+          config:
+            highlight_regexes:
+              - timed out
+              - "ERROR:"
+              - (FAIL|Failure \[)\b
+              - panic\b
+              - ^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]
+              - "^INFO: Analyzed \\d+ targets"
+        required_files:
+          - ^.*build-log\.txt$
+      - lens:
+          name: podinfo
+        required_files:
+          - ^podinfo\.json$
+  additional_allowed_buckets:
+    - ci-prow
+  tide_update_period: 1s
+
+tide:
+  sync_period: 2m
+
+  pr_status_base_urls:
+    "*": https://prow.operate-first.cloud/pr
+
+  merge_method:
+    aicoe-aiops: merge
+    AICoE: squash
+    b4mad: squash
+    open-services-group: merge
+    operate-first: squash
+    os-climate: merge
+    thoth-station: merge
+
+  queries:
+    - orgs:
+        - aicoe-aiops
+        - b4mad
+        - open-services-group
+        - thoth-station
+      excludedRepos:
+        - thoth-station/dgraph-thoth-config
+        - thoth-station/workload-operator
+        - thoth-station/tensorflow
+        - thoth-station/contra-env-infra
+        - thoth-station/ansible-role-core-imagestreams
+        - thoth-station/ansible-role-core-templates
+        - thoth-station/ansible-role-core-cronjob
+        - thoth-station/ansible-role-metrics-exporter
+        - thoth-station/ansible-role-cronjob
+        - thoth-station/ansible-role-argo-workflows
+        - thoth-station/ansible-role-postgresql
+        - thoth-station/ansible-role-kebechet
+        - thoth-station/ansible-role-postgresql-metrics-exporter
+        - thoth-station/statusfy
+        - thoth-station/statusfy-ops
+        - thoth-station/website-tooling
+        - thoth-station/cuda
+        - thoth-station/stub-api
+        - thoth-station/nvidia-usage-dashboard
+        - thoth-station/pipelines-catalog
+        - thoth-station/bz1816214-example
+        - b4mad/sirius
+        - b4mad/airdata
+        - b4mad/auddress
+      labels:
+        - approved
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - needs-rebase
+    - orgs:
+        - operate-first
+        - os-climate
+      labels:
+        - approved
+        - lgtm
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - needs-rebase
+    - repos:
+        - AICoE/aicoe-cd
+        - AICoE/aicoe-ci
+        - AICoE/aicoe-sre
+        - AICoE/content-pipeline
+        - AICoE/data-driven-development
+        - AICoE/donkeycar
+        - AICoE/elyra-aidevsecops-tutorial
+        - AICoE/idh-manifests
+        - AICoE/internal-data-hub
+        - AICoE/jpegio
+        - AICoE/manage-dependencies-tutorial
+        - AICoE/overlays-for-ai-pipeline-tutorial
+        - AICoE/prometheus-anomaly-detector
+        - AICoE/prometheus-api-client-python
+        - AICoE/pyIFD
+        - AICoE/recommend-base-image-tutorial
+        - AICoE/summit-2021-octo-keynote
+        - AICoE/s2i-custom-notebook
+        - AICoE/sefkhet-abwy
+        - AICoE/Varangian
+        - AICoE/seraph
+      labels:
+        - approved
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - needs-rebase
+    - repos:
+        - AICoE/common
+        - AICoE/meteor
+        - AICoE/meteor-operator
+      labels:
+        - approved
+        - lgtm
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+        - needs-rebase
+
+  blocker_label: tide/merge-blocker
+  squash_label: tide/merge-method-squash
+  rebase_label: tide/merge-method-rebase
+  merge_label: tide/merge-method-merge
+
+  context_options:
+    from-branch-protection: true
+    skip-unknown-contexts: true
+    orgs:
+      AICoE:
+        repos:
+          prometheus-api-client-python:
+            required-contexts:
+              - aicoe-ci/pre-commit-check
+              - aicoe-ci/pytest-check
+          sefkhet-abwy:
+            required-contexts:
+              - aicoe-ci/pre-commit-check
+              - aicoe-ci/build-check
+      thoth-station:
+        repos:
+          adviser:
+            required-contexts:
+              - aicoe-ci/build-check
+          amun-api:
+            required-contexts:
+              - aicoe-ci/build-check
+          buildlog-parser:
+            required-contexts:
+              - aicoe-ci/build-check
+          init-job:
+            required-contexts:
+              - aicoe-ci/build-check
+          integration-tests:
+            required-contexts:
+              - aicoe-ci/prow/pytest
+              - aicoe-ci/build-check
+          kebechet:
+            required-contexts:
+              - aicoe-ci/build-check
+          management-api:
+            required-contexts:
+              - aicoe-ci/build-check
+          user-api:
+            required-contexts:
+              - aicoe-ci/build-check
+          package-extract:
+            required-contexts:
+              - aicoe-ci/build-check
+          si-aggregator:
+            required-contexts:
+              - aicoe-ci/build-check
+          si-bandit:
+            required-contexts:
+              - aicoe-ci/build-check
+          si-cloc:
+            required-contexts:
+              - aicoe-ci/build-check
+          investigator:
+            required-contexts:
+              - aicoe-ci/build-check
+          workflow-helpers:
+            required-contexts:
+              - aicoe-ci/build-check
+      operate-first:
+        repos:
+          peribolos-as-a-service:
+            skip-unknown-contexts: false
+          probot-extensions:
+            skip-unknown-contexts: false
+          probot-template:
+            skip-unknown-contexts: false
+
+periodics:
+  - name: integration-tests-prod
+    interval: 6h
+    decorate: true
+    spec:
+      containers:
+        - image: quay.io/thoth-station/integration-tests:v0.11.1
+          imagePullPolicy: Always
+          command:
+            - python3
+            - app.py
+          env:
+            - name: MAIL_REPORT
+              valueFrom:
+                configMapKeyRef:
+                  key: mail-report
+                  name: integration-tests
+            - name: GENERATE_REPORT
+              valueFrom:
+                configMapKeyRef:
+                  key: generate-report
+                  name: integration-tests
+            - name: THOTH_DEPLOYMENT_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: deployment-name
+                  name: integration-tests
+            - name: THOTH_LOGGING_NO_JSON
+              valueFrom:
+                configMapKeyRef:
+                  key: logging-no-json
+                  name: integration-tests
+            - name: THOTH_USER_API_HOST
+              valueFrom:
+                configMapKeyRef:
+                  key: user-api
+                  name: integration-tests
+            - name: THOTH_MANAGEMENT_API_HOST
+              valueFrom:
+                configMapKeyRef:
+                  key: management-api
+                  name: integration-tests
+            - name: THOTH_AMUN_API_HOST
+              valueFrom:
+                configMapKeyRef:
+                  key: amun-api
+                  name: integration-tests
+            - name: THOTH_MANAGEMENT_API_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: management-api-token
+                  name: integration-tests
+            - name: THOTH_INTEGRATION_TESTS_TAGS
+              valueFrom:
+                configMapKeyRef:
+                  key: tags
+                  name: integration-tests
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "1"
+            limits:
+              memory: "512"
+              cpu: "2"
+    annotations:
+      description: Periodic e2e tests against MOC deployment
+
+  - name: periodic-close-rotten
+    interval: 3h
+    decorate: true
+    annotations:
+      description: Closes rotten issues after 30d of inactivity
+    spec:
+      containers:
+        - image: commenter
+          command:
+            - /app/robots/commenter/app.binary
+          args:
+            - |-
+              --query=org:thoth-station org:AICoE org:operate-first org:open-services-group
+              -label:lifecycle/frozen
+              label:lifecycle/rotten
+            - --updated=720h
+            - --token=/etc/token/oauth
+            - |-
+              --comment=Rotten issues close after 30d of inactivity.
+              Reopen the issue with `/reopen`.
+              Mark the issue as fresh with `/remove-lifecycle rotten`.
+
+              /close
+            - --template
+            - --ceiling=10
+            - --confirm
+          volumeMounts:
+            - name: token
+              mountPath: /etc/token
+      volumes:
+        - name: token
+          secret:
+            secretName: oauth-token
+
+  - name: periodic-rotten
+    interval: 3h
+    decorate: true
+    annotations:
+      description: Adds lifecycle/rotten to stale issues after 30d of inactivity
+    spec:
+      containers:
+        - image: commenter
+          command:
+            - /app/robots/commenter/app.binary
+          args:
+            - |-
+              --query=org:thoth-station org:AICoE org:operate-first org:open-services-group
+              -label:lifecycle/frozen
+              label:lifecycle/stale
+              -label:lifecycle/rotten
+            - --updated=720h
+            - --token=/etc/token/oauth
+            - |-
+              --comment=Stale issues rot after 30d of inactivity.
+              Mark the issue as fresh with `/remove-lifecycle rotten`.
+              Rotten issues close after an additional 30d of inactivity.
+
+              If this issue is safe to close now please do so with `/close`.
+
+              /lifecycle rotten
+            - --template
+            - --ceiling=10
+            - --confirm
+          volumeMounts:
+            - name: token
+              mountPath: /etc/token
+      volumes:
+        - name: token
+          secret:
+            secretName: oauth-token
+
+  - name: periodic-stale
+    interval: 3h
+    decorate: true
+    annotations:
+      description: Adds lifecycle/stale to issues after 90d of inactivity
+    spec:
+      containers:
+        - image: commenter
+          command:
+            - /app/robots/commenter/app.binary
+          args:
+            - |-
+              --query=org:thoth-station org:AICoE org:operate-first org:open-services-group
+              -label:lifecycle/frozen
+              -label:lifecycle/stale
+              -label:lifecycle/rotten
+            - --updated=2160h
+            - --token=/etc/token/oauth
+            - |-
+              --comment=Issues go stale after 90d of inactivity.
+              Mark the issue as fresh with `/remove-lifecycle stale`.
+              Stale issues rot after an additional 30d of inactivity and eventually close.
+
+              If this issue is safe to close now please do so with `/close`.
+
+              /lifecycle stale
+            - --template
+            - --ceiling=10
+            - --confirm
+          volumeMounts:
+            - name: token
+              mountPath: /etc/token
+      volumes:
+        - name: token
+          secret:
+            secretName: oauth-token

--- a/prow/overlays/smaug/ghproxy.yaml
+++ b/prow/overlays/smaug/ghproxy.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: ghproxy
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations: null
+      name: latest
+      from:
+        kind: DockerImage
+        name: gcr.io/k8s-prow/ghproxy:latest
+      importPolicy: {}
+      referencePolicy:
+        type: Local
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  labels:
+    app: ghproxy
+  name: ghproxy
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ghproxy
+  labels:
+    app: ghproxy
+spec:
+  selector:
+    matchLabels:
+      app: ghproxy
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ghproxy
+    spec:
+      containers:
+        - name: ghproxy
+          image: ghproxy:latest
+          args:
+            - --cache-dir=/cache
+            - --cache-sizeGB=9
+            - --serve-metrics=true
+          ports:
+            - name: main
+              containerPort: 8888
+            - name: metrics
+              containerPort: 9090
+          volumeMounts:
+            - name: cache
+              mountPath: /cache
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "2m"
+            limits:
+              memory: "64Mi"
+              cpu: "2m"
+      volumes:
+        - name: cache
+          persistentVolumeClaim:
+            claimName: ghproxy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: ghproxy
+  name: ghproxy
+spec:
+  ports:
+    - name: main
+      port: 80
+      protocol: TCP
+      targetPort: 8888
+    - name: metrics
+      port: 9090
+  selector:
+    app: ghproxy
+  type: ClusterIP

--- a/prow/overlays/smaug/imagestreamtags.yaml
+++ b/prow/overlays/smaug/imagestreamtags.yaml
@@ -1,0 +1,1028 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: clonerefs
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations: null
+    from:
+      kind: ImageStreamTag
+      name: v20211027-fe152eb205
+    name: latest
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/clonerefs:v20210319-be35a198b9
+    importPolicy: {}
+    name: v20210319-be35a198b9
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/clonerefs:v20210531-03cf33ddeb
+    importPolicy: {}
+    name: v20210531-03cf33ddeb
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/clonerefs:v20210705-728bc30968
+    name: v20210705-728bc30968
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/clonerefs:v20211008-8c358bcb9d
+    name: v20211008-8c358bcb9d
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/clonerefs:v20211019-a9a7558110
+    name: v20211019-a9a7558110
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/clonerefs:v20211019-b0788a9d38
+    name: v20211019-b0788a9d38
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/clonerefs:v20211025-c04ea2035e
+    name: v20211025-c04ea2035e
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/clonerefs:v20211027-fe152eb205
+    name: v20211027-fe152eb205
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: commenter
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations: null
+    from:
+      kind: ImageStreamTag
+      name: v20211027-fe152eb205
+    name: latest
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/commenter:v20210415-ecffc9c27e
+    importPolicy: {}
+    name: v20210415-ecffc9c27e
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/commenter:v20210705-728bc30968
+    name: v20210705-728bc30968
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/commenter:v20211008-8c358bcb9d
+    name: v20211008-8c358bcb9d
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/commenter:v20211019-a9a7558110
+    name: v20211019-a9a7558110
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/commenter:v20211019-b0788a9d38
+    name: v20211019-b0788a9d38
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/commenter:v20211025-c04ea2035e
+    name: v20211025-c04ea2035e
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/commenter:v20211027-fe152eb205
+    name: v20211027-fe152eb205
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: crier
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations: null
+    from:
+      kind: ImageStreamTag
+      name: v20211027-fe152eb205
+    name: latest
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/crier:v20210204-de2fa22b93
+    importPolicy: {}
+    name: v20210204-de2fa22b93
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/crier:v20210211-72696ce111
+    importPolicy: {}
+    name: v20210211-72696ce111
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/crier:v20210304-a61492beff
+    name: v20210304-a61492beff
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/crier:v20210412-f0c722e283
+    name: v20210412-f0c722e283
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/crier:v20210705-728bc30968
+    name: v20210705-728bc30968
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/crier:v20211008-8c358bcb9d
+    name: v20211008-8c358bcb9d
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/crier:v20211019-a9a7558110
+    name: v20211019-a9a7558110
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/crier:v20211019-b0788a9d38
+    name: v20211019-b0788a9d38
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/crier:v20211025-c04ea2035e
+    name: v20211025-c04ea2035e
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/crier:v20211027-fe152eb205
+    name: v20211027-fe152eb205
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: deck
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations: null
+    from:
+      kind: ImageStreamTag
+      name: v20211027-fe152eb205
+    name: latest
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/deck:v20210204-de2fa22b93
+    importPolicy: {}
+    name: v20210204-de2fa22b93
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/deck:v20210211-72696ce111
+    importPolicy: {}
+    name: v20210211-72696ce111
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/deck:v20210304-a61492beff
+    name: v20210304-a61492beff
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/deck:v20210412-f0c722e283
+    name: v20210412-f0c722e283
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/deck:v20210705-728bc30968
+    name: v20210705-728bc30968
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/deck:v20211008-8c358bcb9d
+    name: v20211008-8c358bcb9d
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/deck:v20211019-a9a7558110
+    name: v20211019-a9a7558110
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/deck:v20211019-b0788a9d38
+    name: v20211019-b0788a9d38
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/deck:v20211025-c04ea2035e
+    name: v20211025-c04ea2035e
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/deck:v20211027-fe152eb205
+    name: v20211027-fe152eb205
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: entrypoint
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations: null
+    from:
+      kind: ImageStreamTag
+      name: v20211027-fe152eb205
+    name: latest
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/entrypoint:v20210319-be35a198b9
+    importPolicy: {}
+    name: v20210319-be35a198b9
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/entrypoint:v20210705-728bc30968
+    name: v20210705-728bc30968
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/entrypoint:v20211008-8c358bcb9d
+    name: v20211008-8c358bcb9d
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/entrypoint:v20211019-a9a7558110
+    name: v20211019-a9a7558110
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/entrypoint:v20211019-b0788a9d38
+    name: v20211019-b0788a9d38
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/entrypoint:v20211025-c04ea2035e
+    name: v20211025-c04ea2035e
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/entrypoint:v20211027-fe152eb205
+    name: v20211027-fe152eb205
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: hook
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations: null
+    from:
+      kind: ImageStreamTag
+      name: v20211027-fe152eb205
+    name: latest
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/hook:v20210204-de2fa22b93
+    importPolicy: {}
+    name: v20210204-de2fa22b93
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/hook:v20210211-72696ce111
+    importPolicy: {}
+    name: v20210211-72696ce111
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/hook:v20210304-a61492beff
+    name: v20210304-a61492beff
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/hook:v20210412-f0c722e283
+    name: v20210412-f0c722e283
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/hook:v20210705-728bc30968
+    name: v20210705-728bc30968
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/hook:v20211008-8c358bcb9d
+    name: v20211008-8c358bcb9d
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/hook:v20211019-a9a7558110
+    name: v20211019-a9a7558110
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/hook:v20211019-b0788a9d38
+    name: v20211019-b0788a9d38
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/hook:v20211025-c04ea2035e
+    name: v20211025-c04ea2035e
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/hook:v20211027-fe152eb205
+    name: v20211027-fe152eb205
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: horologium
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations: null
+    from:
+      kind: ImageStreamTag
+      name: v20211027-fe152eb205
+    name: latest
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/horologium:v20210204-de2fa22b93
+    importPolicy: {}
+    name: v20210204-de2fa22b93
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/horologium:v20210211-72696ce111
+    importPolicy: {}
+    name: v20210211-72696ce111
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/horologium:v20210304-a61492beff
+    name: v20210304-a61492beff
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/horologium:v20210412-f0c722e283
+    name: v20210412-f0c722e283
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/horologium:v20210705-728bc30968
+    name: v20210705-728bc30968
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/horologium:v20211008-8c358bcb9d
+    name: v20211008-8c358bcb9d
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/horologium:v20211019-a9a7558110
+    name: v20211019-a9a7558110
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/horologium:v20211019-b0788a9d38
+    name: v20211019-b0788a9d38
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/horologium:v20211025-c04ea2035e
+    name: v20211025-c04ea2035e
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/horologium:v20211027-fe152eb205
+    name: v20211027-fe152eb205
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: initupload
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations: null
+    from:
+      kind: ImageStreamTag
+      name: v20211027-fe152eb205
+    name: latest
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/initupload:v20210319-be35a198b9
+    importPolicy: {}
+    name: v20210319-be35a198b9
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/initupload:v20210705-728bc30968
+    name: v20210705-728bc30968
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/initupload:v20211008-8c358bcb9d
+    name: v20211008-8c358bcb9d
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/initupload:v20211019-a9a7558110
+    name: v20211019-a9a7558110
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/initupload:v20211019-b0788a9d38
+    name: v20211019-b0788a9d38
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/initupload:v20211025-c04ea2035e
+    name: v20211025-c04ea2035e
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/initupload:v20211027-fe152eb205
+    name: v20211027-fe152eb205
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: label_sync
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations: null
+    from:
+      kind: ImageStreamTag
+      name: v20211027-fe152eb205
+    importPolicy: {}
+    name: latest
+    referencePolicy:
+      type: Source
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/label_sync:v20210127-5fd357428d
+    importPolicy: {}
+    name: v20210127-5fd357428d
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/label_sync:v20210211-72696ce111
+    importPolicy: {}
+    name: v20210211-72696ce111
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/label_sync:v20210304-a61492beff
+    importPolicy: {}
+    name: v20210304-a61492beff
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/label_sync:v20210310-26726f9bd5
+    importPolicy: {}
+    name: v20210310-26726f9bd5
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/label_sync:v20210412-f0c722e283
+    importPolicy: {}
+    name: v20210412-f0c722e283
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/label_sync:v20210705-728bc30968
+    name: v20210705-728bc30968
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/label_sync:v20211008-8c358bcb9d
+    name: v20211008-8c358bcb9d
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/label_sync:v20211019-a9a7558110
+    name: v20211019-a9a7558110
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/label_sync:v20211019-b0788a9d38
+    name: v20211019-b0788a9d38
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/label_sync:v20211025-c04ea2035e
+    name: v20211025-c04ea2035e
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/label_sync:v20211027-fe152eb205
+    name: v20211027-fe152eb205
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: needs-rebase
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations: null
+    from:
+      kind: ImageStreamTag
+      name: v20211027-fe152eb205
+    name: latest
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/needs-rebase:v20210204-de2fa22b93
+    importPolicy: {}
+    name: v20210204-de2fa22b93
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/needs-rebase:v20210211-72696ce111
+    importPolicy: {}
+    name: v20210211-72696ce111
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/needs-rebase:v20210304-a61492beff
+    name: v20210304-a61492beff
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/needs-rebase:v20210412-f0c722e283
+    name: v20210412-f0c722e283
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/needs-rebase:v20210705-728bc30968
+    name: v20210705-728bc30968
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/needs-rebase:v20211008-8c358bcb9d
+    name: v20211008-8c358bcb9d
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/needs-rebase:v20211019-a9a7558110
+    name: v20211019-a9a7558110
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/needs-rebase:v20211019-b0788a9d38
+    name: v20211019-b0788a9d38
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/needs-rebase:v20211025-c04ea2035e
+    name: v20211025-c04ea2035e
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/needs-rebase:v20211027-fe152eb205
+    name: v20211027-fe152eb205
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: pipeline
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations: null
+    from:
+      kind: ImageStreamTag
+      name: v20211027-fe152eb205
+    name: latest
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/pipeline:v20210201-6494714d87
+    importPolicy: {}
+    name: v20210201-6494714d87
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/pipeline:v20210211-72696ce111
+    importPolicy: {}
+    name: v20210211-72696ce111
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/pipeline:v20210304-a61492beff
+    name: v20210304-a61492beff
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/pipeline:v20210412-f0c722e283
+    name: v20210412-f0c722e283
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/pipeline:v20210705-728bc30968
+    name: v20210705-728bc30968
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/pipeline:v20211008-8c358bcb9d
+    name: v20211008-8c358bcb9d
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/pipeline:v20211019-a9a7558110
+    name: v20211019-a9a7558110
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/pipeline:v20211019-b0788a9d38
+    name: v20211019-b0788a9d38
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/pipeline:v20211025-c04ea2035e
+    name: v20211025-c04ea2035e
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/pipeline:v20211027-fe152eb205
+    name: v20211027-fe152eb205
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: prow-controller-manager
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations: null
+    from:
+      kind: ImageStreamTag
+      name: v20211027-fe152eb205
+    name: latest
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/prow-controller-manager:v20210705-728bc30968
+    name: v20210705-728bc30968
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/prow-controller-manager:v20211008-8c358bcb9d
+    name: v20211008-8c358bcb9d
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/prow-controller-manager:v20211019-a9a7558110
+    name: v20211019-a9a7558110
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/prow-controller-manager:v20211019-b0788a9d38
+    name: v20211019-b0788a9d38
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/prow-controller-manager:v20211025-c04ea2035e
+    name: v20211025-c04ea2035e
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/prow-controller-manager:v20211027-fe152eb205
+    name: v20211027-fe152eb205
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: sidecar
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations: null
+    from:
+      kind: ImageStreamTag
+      name: v20211027-fe152eb205
+    name: latest
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/sidecar:v20210319-be35a198b9
+    importPolicy: {}
+    name: v20210319-be35a198b9
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/sidecar:v20210705-728bc30968
+    name: v20210705-728bc30968
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/sidecar:v20211008-8c358bcb9d
+    name: v20211008-8c358bcb9d
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/sidecar:v20211019-a9a7558110
+    name: v20211019-a9a7558110
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/sidecar:v20211019-b0788a9d38
+    name: v20211019-b0788a9d38
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/sidecar:v20211025-c04ea2035e
+    name: v20211025-c04ea2035e
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/sidecar:v20211027-fe152eb205
+    name: v20211027-fe152eb205
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: sinker
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations: null
+    from:
+      kind: ImageStreamTag
+      name: v20211027-fe152eb205
+    name: latest
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/sinker:v20210204-de2fa22b93
+    importPolicy: {}
+    name: v20210204-de2fa22b93
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/sinker:v20210211-72696ce111
+    importPolicy: {}
+    name: v20210211-72696ce111
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/sinker:v20210304-a61492beff
+    name: v20210304-a61492beff
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/sinker:v20210412-f0c722e283
+    name: v20210412-f0c722e283
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/sinker:v20210705-728bc30968
+    name: v20210705-728bc30968
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/sinker:v20211008-8c358bcb9d
+    name: v20211008-8c358bcb9d
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/sinker:v20211019-a9a7558110
+    name: v20211019-a9a7558110
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/sinker:v20211019-b0788a9d38
+    name: v20211019-b0788a9d38
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/sinker:v20211025-c04ea2035e
+    name: v20211025-c04ea2035e
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/sinker:v20211027-fe152eb205
+    name: v20211027-fe152eb205
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: status-reconciler
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations: null
+    from:
+      kind: ImageStreamTag
+      name: v20211027-fe152eb205
+    name: latest
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/status-reconciler:v20210204-de2fa22b93
+    importPolicy: {}
+    name: v20210204-de2fa22b93
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/status-reconciler:v20210211-72696ce111
+    importPolicy: {}
+    name: v20210211-72696ce111
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/status-reconciler:v20210304-a61492beff
+    name: v20210304-a61492beff
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/status-reconciler:v20210412-f0c722e283
+    name: v20210412-f0c722e283
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/status-reconciler:v20210705-728bc30968
+    name: v20210705-728bc30968
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/status-reconciler:v20211008-8c358bcb9d
+    name: v20211008-8c358bcb9d
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/status-reconciler:v20211019-a9a7558110
+    name: v20211019-a9a7558110
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/status-reconciler:v20211019-b0788a9d38
+    name: v20211019-b0788a9d38
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/status-reconciler:v20211025-c04ea2035e
+    name: v20211025-c04ea2035e
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/status-reconciler:v20211027-fe152eb205
+    name: v20211027-fe152eb205
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: tide
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations: null
+    from:
+      kind: ImageStreamTag
+      name: v20211027-fe152eb205
+    name: latest
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/tide:v20210204-de2fa22b93
+    importPolicy: {}
+    name: v20210204-de2fa22b93
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/tide:v20210211-72696ce111
+    importPolicy: {}
+    name: v20210211-72696ce111
+    referencePolicy:
+      type: Local
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/tide:v20210304-a61492beff
+    name: v20210304-a61492beff
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/tide:v20210412-f0c722e283
+    name: v20210412-f0c722e283
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/tide:v20210705-728bc30968
+    name: v20210705-728bc30968
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/tide:v20211008-8c358bcb9d
+    name: v20211008-8c358bcb9d
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/tide:v20211019-a9a7558110
+    name: v20211019-a9a7558110
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/tide:v20211019-b0788a9d38
+    name: v20211019-b0788a9d38
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/tide:v20211025-c04ea2035e
+    name: v20211025-c04ea2035e
+  - annotations: null
+    from:
+      kind: DockerImage
+      name: gcr.io/k8s-prow/tide:v20211027-fe152eb205
+    name: v20211027-fe152eb205

--- a/prow/overlays/smaug/integration-test-configmap.yaml
+++ b/prow/overlays/smaug/integration-test-configmap.yaml
@@ -1,0 +1,14 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: integration-tests
+data:
+  mail-report: "0"
+  generate-report: "0"
+  logging-no-json: "1"
+  deployment-name: "smaug-prod"
+  user-api: "api.moc.thoth-station.ninja"
+  management-api: "management.moc.thoth-station.ninja"
+  amun-api: "amun.moc.thoth-station.ninja"
+  tags: ""

--- a/prow/overlays/smaug/kustomization.yaml
+++ b/prow/overlays/smaug/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - ghproxy.yaml
+  - integration-test-configmap.yaml
+  - route-ghproxy-metrics.yaml
+  - routes.yaml
+  - s3-storage.yaml
+  - service-monitor.yaml
+patchesStrategicMerge:
+  - imagestreamtags.yaml
+  - unsuspend_branchprotector.yaml
+configMapGenerator:
+  - name: config
+    files:
+      - config.yaml
+  - name: plugins
+    files:
+      - plugins.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+generators:
+  - secret-generator.yaml

--- a/prow/overlays/smaug/plugins.yaml
+++ b/prow/overlays/smaug/plugins.yaml
@@ -1,0 +1,361 @@
+blunderbuss:
+  max_request_count: 2
+  use_status_availability: true
+
+label:
+  additional_labels:
+    - community/discussion
+    - community/group-programming
+    - community/maintenance
+    - community/question
+    - deployment_name/ocp4-stage
+    - deployment_name/ocp4-test
+    - deployment_name/moc-prod
+    - epic
+    - hacktoberfest
+    - hacktoberfest-accepted
+    - kind/cleanup
+    - kind/demo
+    - kind/deprecation
+    - kind/documentation
+    - kind/question
+    - sig/advisor
+    - sig/build
+    - sig/cyborgs
+    - sig/devops
+    - sig/documentation
+    - sig/indicators
+    - sig/investigator
+    - sig/knowledge-graph
+    - sig/slo
+    - sig/solvers
+    - thoth/group-programming
+    - thoth/human-intervention-required
+    - thoth/potential-observation
+    - tide/merge-method-merge
+    - tide/merge-method-rebase
+    - tide/merge-method-squash
+    - triage/accepted
+    - triage/duplicate
+    - triage/needs-information
+    - triage/not-reproducible
+    - triage/unresolved
+    - lifecycle/submission-accepted
+    - lifecycle/submission-rejected
+
+require_matching_label:
+  - missing_label: needs-triage
+    org: thoth-station
+    repo: core
+    issues: true
+    prs: false
+    regexp: ^triage/accepted$
+    missing_comment: |
+      This issue is currently awaiting triage.
+      If a refinement session determines this is a relevant issue, it will accept the issue by applying the
+      `triage/accepted` label and provide further guidance.
+
+      The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
+  - missing_label: needs-sig
+    org: thoth-station
+    repo: core
+    issues: true
+    regexp: ^(sig|wg|committee)/
+    missing_comment: |
+      There are no sig labels on this issue. Please add an appropriate label by using one of the following commands:
+      - `/sig <group-name>`
+      - `/wg <group-name>`
+
+      Please see the [group list](https://github.com/thoth-station/core/blob/master/community/sig-list.md) for a listing of the SIGs, and working groups available.
+  - missing_label: needs-triage
+    org: thoth-station
+    repo: support
+    issues: true
+    prs: false
+    regexp: ^triage/accepted$
+    missing_comment: |
+      This issue is currently awaiting triage.
+      One of the @thoth-station/devs will take care of the issue, and will accept the issue by applying the
+      `triage/accepted` label and provide further guidance.
+
+      The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
+  - missing_label: needs-sig
+    org: thoth-station
+    repo: support
+    issues: true
+    regexp: ^(sig|wg|committee)/
+    missing_comment: |
+      There are no sig labels on this issue. Please add an appropriate label by using one of the following commands:
+      - `/sig <group-name>`
+      - `/wg <group-name>`
+
+      Please see the [group list](https://github.com/thoth-station/core/blob/master/community/sig-list.md) for a listing of the SIGs, and working groups available.
+  - missing_label: needs-triage
+    org: thoth-station
+    repo: thoth-application
+    issues: true
+    prs: false
+    regexp: ^triage/accepted$
+    missing_comment: |
+      This issue is currently awaiting triage.
+      One of the @thoth-station/devsops will take care of the issue, and will accept the issue by applying the
+      `triage/accepted` label and provide further guidance.
+
+      The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
+
+external_plugins:
+  b4mad:
+    - name: needs-rebase
+      events:
+        - issue_comment
+        - pull_request
+  thoth-station:
+    - name: needs-rebase
+      events:
+        - issue_comment
+        - pull_request
+  os-climate:
+    - name: needs-rebase
+      events:
+        - issue_comment
+        - pull_request
+  open-services-group:
+    - name: needs-rebase
+      events:
+        - issue_comment
+        - pull_request
+  operate-first:
+    - name: needs-rebase
+      events:
+        - issue_comment
+        - pull_request
+  AICoE:
+    - name: needs-rebase
+      events:
+        - issue_comment
+        - pull_request
+  aicoe-aiops:
+    - name: needs-rebase
+      events:
+        - issue_comment
+        - pull_request
+
+welcome:
+  - repos:
+      - b4mad
+      - AICoE
+      - aicoe-aiops
+      - open-services-group
+      - operate-first
+      - thoth-station
+    message_template: "Welcome @{{.AuthorLogin}}! <br><br>It looks like this is your first PR to <a href='https://github.com/{{.Org}}/{{.Repo}}'>{{.Org}}/{{.Repo}}</a> 🎉. Please refer to our [pull request process documentation](https://git.k8s.io/community/contributors/guide/pull-requests.md) to help your PR have a smooth ride to approval. <br><br>You will be prompted by a bot to use commands during the review process. Do not be afraid to follow the prompts! It is okay to experiment. [Here is the bot commands documentation](https://go.k8s.io/bot-commands). <br><br>You can also check if {{.Org}}/{{.Repo}} has [its own contribution guidelines](https://github.com/{{.Org}}/{{.Repo}}/tree/master/CONTRIBUTING.md). <br><br>You may want to refer to our [testing guide](https://git.k8s.io/community/contributors/devel/sig-testing/testing.md) if you run into trouble with your tests not passing. <br><br>If you are having difficulty getting your pull request seen, please follow the [recommended escalation practices](https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#why-is-my-pull-request-not-getting-reviewed). Also, for tips and tricks in the contribution process you may want to read the [Kubernetes contributor cheat sheet](https://git.k8s.io/community/contributors/guide/contributor-cheatsheet/README.md). We want to make sure your contribution gets all the attention it needs! <br><br>Thank you, and welcome to the Thoth-Station. :smiley:"
+
+lgtm:
+  - repos:
+      - AICoE
+      - aicoe-aiops
+      - b4mad
+      - open-services-group
+      - operate-first
+      - os-climate
+      - thoth-station
+
+approve:
+  - repos:
+      - AICoE
+      - aicoe-aiops
+      - b4mad
+      - open-services-group
+      - operate-first
+      - os-climate
+      - thoth-station
+    require_self_approval: true
+    ignore_review_state: false
+    lgtm_acts_as_approve: false
+
+repo_milestone:
+  "":
+    maintainers_id: 4924960
+    maintainers_team: milestone-maintainers
+
+milestone_applier:
+  thoth-station/thoth-application:
+    master: 2022.06.20
+    v2022.06.20: 2022.06.20
+    v2022.04.18: 2022.04.18
+
+project_config:
+  project_org_configs:
+    thoth-station:
+      org_default_column_map:
+        SIG-DevSecOps: New
+        SIG-Observability: New
+        SIG-Stack-Guidance: New
+        SIG-User-Experience: New
+
+      # get this via `curl -H "Authorization: token ????" "https://api.github.com/orgs/thoth-station/teams"`
+      org_maintainers_team_id: 4924960
+
+project_manager:
+  orgsRepos:
+    thoth-station:
+      projects:
+        SIG-DevSecOps:
+          columns:
+            - name: New
+              labels:
+                - sig/devsecops
+              org: thoth-station
+              state: open
+        SIG-Observability:
+          columns:
+            - name: New
+              labels:
+                - sig/observability
+              org: thoth-station
+              state: open
+        SIG-Stack-Guidance:
+          columns:
+            - name: New
+              labels:
+                - sig/stack-guidance
+              org: thoth-station
+              state: open
+        SIG-User-Experience:
+          columns:
+            - name: New
+              labels:
+                - sig/user-experience
+              org: thoth-station
+              state: open
+
+plugins:
+  b4mad:
+    plugins:
+      - approve
+      - assign
+      - blockade
+      - blunderbuss
+      - help
+      - hold
+      - label
+      - lgtm
+      - lifecycle
+      - shrug
+      - size
+      - trigger
+      - verify-owners
+      - wip
+  open-services-group:
+    plugins:
+      - approve
+      - assign
+      - blockade
+      - blunderbuss
+      - help
+      - hold
+      - label
+      - lgtm
+      - lifecycle
+      - override
+      - milestone
+      - milestoneapplier
+      - milestonestatus
+      - project
+      - require-matching-label
+      - shrug
+      - size
+      - transfer-issue
+      - trigger
+      - verify-owners
+      - wip
+  operate-first:
+    plugins:
+      - approve
+      - assign
+      - blockade
+      - help
+      - hold
+      - label
+      - lgtm
+      - lifecycle
+      - override
+      - shrug
+      - size
+      - transfer-issue
+      - trigger
+      - verify-owners
+      - wip
+  os-climate:
+    plugins:
+      - approve
+      - assign
+      - blockade
+      - blunderbuss
+      - help
+      - hold
+      - label
+      - lgtm
+      - lifecycle
+      - override
+      - size
+      - transfer-issue
+      - trigger
+      - verify-owners
+      - wip
+  thoth-station:
+    plugins:
+      - approve
+      - assign
+      - blockade
+      - blunderbuss
+      - help
+      - hold
+      - label
+      - lgtm
+      - lifecycle
+      - milestone
+      - milestoneapplier
+      - milestonestatus
+      - project
+      - projectmanager
+      - require-matching-label
+      - shrug
+      - size
+      - transfer-issue
+      - trigger
+      - verify-owners
+      - wip
+  AICoE:
+    plugins:
+      - approve
+      - assign
+      - blockade
+      - blunderbuss
+      - help
+      - hold
+      - label
+      - lgtm
+      - lifecycle
+      - override
+      - size
+      - transfer-issue
+      - trigger
+      - verify-owners
+      - wip
+  aicoe-aiops:
+    plugins:
+      - approve
+      - assign
+      - blockade
+      - blunderbuss
+      - help
+      - hold
+      - label
+      - lgtm
+      - lifecycle
+      - override
+      - size
+      - trigger
+      - verify-owners
+      - wip

--- a/prow/overlays/smaug/route-ghproxy-metrics.yaml
+++ b/prow/overlays/smaug/route-ghproxy-metrics.yaml
@@ -1,0 +1,12 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: ghproxy-metrics
+spec:
+  path: /metrics
+  to:
+    kind: Service
+    name: ghproxy
+    weight: 100
+  port:
+    targetPort: metrics

--- a/prow/overlays/smaug/routes.yaml
+++ b/prow/overlays/smaug/routes.yaml
@@ -1,0 +1,64 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: deck
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    haproxy.router.openshift.io/timeout: 45s
+spec:
+  host: prow.operate-first.cloud
+  to:
+    kind: Service
+    name: deck
+    weight: 100
+  port:
+    targetPort: main
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: hook
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    haproxy.router.openshift.io/timeout: 45s
+spec:
+  host: prow.operate-first.cloud
+  path: /hook
+  to:
+    kind: Service
+    name: hook
+    weight: 100
+  port:
+    targetPort: main
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: hook-metrics
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    haproxy.router.openshift.io/timeout: 45s
+spec:
+  path: /metrics
+  to:
+    kind: Service
+    name: hook
+    weight: 100
+  port:
+    targetPort: metrics
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: deck-metrics
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    haproxy.router.openshift.io/timeout: 45s
+spec:
+  path: /metrics
+  to:
+    kind: Service
+    name: deck
+    weight: 100
+  port:
+    targetPort: metrics

--- a/prow/overlays/smaug/s3-storage.yaml
+++ b/prow/overlays/smaug/s3-storage.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: ci-prow
+spec:
+  additionalConfig:
+    maxSize: "10G"
+  bucketName: ci-prow
+  storageClassName: openshift-storage.noobaa.io

--- a/prow/overlays/smaug/secret-generator.yaml
+++ b/prow/overlays/smaug/secret-generator.yaml
@@ -1,0 +1,6 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: thoth-secret-generator
+files:
+  - ./secrets.enc.yaml

--- a/prow/overlays/smaug/secrets.enc.yaml
+++ b/prow/overlays/smaug/secrets.enc.yaml
@@ -1,0 +1,201 @@
+apiVersion: v1
+items:
+-   apiVersion: v1
+    data:
+        oauth: ENC[AES256_GCM,data:PmmC/EjLuuGZX5VhaOExIz5zpoD//JmzAetJLMBs3Etjvm+G+mz2FY2T3sQ2WDviSVkVrP6XBT4=,iv:Qgqi3+9e8tYE3/q6MCUYsl0Hpo6wlaFaI/fE1t76Bsw=,tag:77RFd6uUCYUDSpElcOz2Vg==,type:str]
+    kind: Secret
+    metadata:
+        name: oauth-token
+    type: Opaque
+-   apiVersion: v1
+    kind: Secret
+    metadata:
+        name: github-token
+    data:
+        token: ENC[AES256_GCM,data:qOVKvkp/iFwFp70XgdDzgvaNO/Q3IHNzW1XLVQ0Nx1gKw4CjrFC8T7yvKxcKhMLCTHN3AkUGU0M=,iv:btMd9vkzA1VLpCVZIHHwvvk9xxBsqr0pki8+nfDpHSw=,tag:ctwEC5xSXfY3WZo5P0aHYg==,type:str]
+-   apiVersion: v1
+    data:
+        secret: ENC[AES256_GCM,data:usRjF2n/ePISkxgCxAQzskm16gfEblDjD9x1vZLZb2TfNAoRrdyD8ooUpl8dqt/Cwqqfs6fs9Gdky+VDohH0RIAtLBN4taK3nSzCNWHqCREU2GbDVDi0KJHfxGGquWnB3sXeXKVOuMkOTGHQUM75v5s5ZYbHaVywlbGZKkC6Sh1q28iu1SxXctzuOSMYJgg0PUJ0FsXUZARQHrtDnqdfptpAnubop+WgSlSTw/3QwuPCt0ekmIn173WSw/Ab+o+PZGZrMEKt3YHLCsAUcJAmi7y/SPoDRtngNnQNAo5spFA4YypH5+Y6TUraI8L5tJ0X67RWdXK9a3P/neDLneQTzof77erK/8fPNjI6olQ5yk2mLc+n7ZfVs8Oe/0/ZY3Xhfo/7CZ/msoU98p5ahHzwpg==,iv:3upm505GMbkK+c0PxIMJj3LzG52+t8cvF1YwdLIQ0oI=,tag:yLhLQjcRL///ESClyAViSQ==,type:str]
+    kind: Secret
+    metadata:
+        name: github-oauth-config
+    type: Opaque
+-   apiVersion: v1
+    data:
+        hmac: ENC[AES256_GCM,data:1rwCpAsv6NVJpKRiXXRDYg+1lMEMoYBUFt9lCC3tEZZEeLtX8+FjqdEjYP59QcKG79gcZpomy3A=,iv:x2umS2MSaeG8W3vqJPgUNH+Hb5av8g2LLqqojyJ1TKE=,tag:fuziPLds8+jFcQwNZHhghg==,type:str]
+    kind: Secret
+    metadata:
+        name: hmac-token
+    type: Opaque
+-   apiVersion: v1
+    data:
+        secret: ENC[AES256_GCM,data:/onIJFZPUmCvl8+GOwScVa+W2zoJWVdOMqlg/eKferuf3mggczuCU5Htxboao327MJwzuuOxK65q++J6,iv:zQUBhcwufe/6yUJ4vfABPziCozacvy82lGJ9a8qXEYU=,tag:H2kxd4r0CR6caHrlOtBQ1Q==,type:str]
+    kind: Secret
+    metadata:
+        name: cookie
+    type: Opaque
+-   apiVersion: v1
+    kind: Secret
+    metadata:
+        name: s3-credentials
+    stringData:
+        service-account.json: ENC[AES256_GCM,data:cWQgGXKEmOItSAqpVq4awfoRnTp53UIErYGqjuWkA0lxjpquM6OnpiwtDl2/gTIqm2ufYWTFoKIJwvngCRukG3kSOKSKSWkslVOaZH6GiOzW9HHD/nNBFqfv4zGB70vBA7ABZgcDk56h1bDfsxZnshb4MsO4WX3Y4INsG9FVP4BoRZfPjj7bA/i/3BRc0wtJZOd1M3bBm6y2IKv9zXTZpjgtNW4x//5YmGn0Jadgsgdj+i7AK0baKD+9vZyJu/DV9ESFItOq4fh4g1Ak0kY0HB9CkSXGgvwROndokxF0ZarwmafX4vwT5IFJnlhs8hXrnWMJN9kvQheWcEBEVe4/N20iSxA=,iv:8Fr8qDATQ4yuWh/12rJkW8Ia8Er1/zPrHWc6ReMIETI=,tag:iCvIhWrEuQOgs+wgSKgc6Q==,type:str]
+-   apiVersion: v1
+    data:
+        ssh-privatekey: ENC[AES256_GCM,data:RwoP1lOAUPU5UbTxAVTkeQgNf3qf9IXuyIFGi1YqvhA793IuqnIwDJ8TltrG9g4ywzBjZZyajD+F6Y4sEIZAYgWP/29gyMP3TvA3wSWpDeYLQ/MEf7tC5q9CAkLAsIfvsKLxjzvPc5OdQ4ssK45WV4fGh8JuPSgt1YbhffoKAjRDQFoQeLVz0KDec8tFGZso5bsDVVxx41tEx53B+nNwImbOlsedK0BKQ5ol3HMTisCWNRtFbyG6ERQoh+2mnN6mUggJahjUdiRUlOfnH7OAe7HNnpe6K+kE43uEw0cLyqbXBTqVIeYt6mQkYs9xOiaDusmbzwdKN5PDrGuEyZu/U3mZpAZu8WzQNa5sJlADvS2Fg50yfA/nGyMqYv47ZP+gJPCQ9PhEhMPeVX/+LwegqZSqP5z17iDN0VZjX2Ke4JT//gLIOr1hq8K++rpBCJTOCtAZdgz1pZcpb4R3BmARSuLJXFnIQnz8NpYZZKVrqtUmwT8l3pwF4+ax/Cgk6krgZsr8bTp58qaFPmUjrdbH+QaW1hDOZxwYPqt54zWFXnB6nbG8kRngsDTPggcvhp4PP0SDNKEifWJQU4zJgn0vK3iw7wU+bNv89fYNvYa2gN+BP7VmrkB2B3RwJ+iN5MLC9H5Mflyr5HnrSzUOsn5EhcnrvjoN8u9G1boWcyffGCXn4whj9hVqg2Xp7vFafdUymds0NkItQQVCuPu7GWRK5yNY5Ux8GQEbQAblC4IfigmO6W5wNn7gcEdfFPp9aU/nxMuNe0GZb0IryxDM0BNW5iYam1a8qdiXDSO5iiQysW2rEittqMTzk4g9gmpC6MsfPLUMb1sOztEaHQ5Z0wgs9QoErZ/aynclWORjeElz08QwjPSep2FgtbkK8XTGv+s0ZNUvCmTOhBE5WDc2IPV81wWqX/mOMem/Pijb0FhqOAkmS/wyXCVYdK3zT1k0lasfvU8exD/V21l5DC2wz/7zEpQ5nOqyk/IVSucqxdgF11sFQC5p33pSCo3VdUlK7A8e8igqR295b29dzjWLY4CCDi4V1lK/ywg4N/XmWnx72KkNBKidyUXwqCljXGUPU1ObcYYeTQrQrC498RDDzcFfn4K/vk07RVs3Rf+fvGfzAPB9S7iLLqJNzj4WjJKZ7XGAJBqmCD/CFh1q4y8lrpPrXBc3uIpOizceBSCgfdW4VXu3AtZvYy6PELDgzpz0iIzOpVvt36WVitg17LD5qvMMn+6lRJc+Z1Go19GX7xI765cdp9Ar5mG2nECMkEMkVPf/6dZ57jF25wgEIerRszQqvuBvxGpuxCzsC+phKKvTMT67UF8MKEBgecsVQJ8AyJ6WT9weg0st+iKTR3lbOfuGzDE7bOkyCOT/LjfxiptUyN7Ld/lAL9FxUnS2O85guzENZmnWnstgYRrsSsdVhBEXywgGo53vl3rvFRHIMMoaa4T9Eiz6WJYpbyVRodO1BhSiit2YCETkXjdOykckdYIL3niJyRgyLHaC405OUHAYnscjjOQuEMRZE/hZ4VeKm6prvl6V+KZzZ15f9ZEMH+C4T9hbUlM8USAouL9YvJ5Enuky8VRBrJa9ULFc9xNbQ3pgW95Nfu+WHZ4Q73Ye02i82rc4jp3jdr1W1U/ahYtTry9Z+jBV112bAqxlwBX7TqF+1nIhwI+xDtg+ZauGn8z8NxeXo/+Nw5l7+JSrcPGW5V3OwMPx47fr8r6bMBw/b8z/+9qW9+r0RHOOgduX8C7uB24e4tDpQMSKgz770pNRJBleyV1oxT5o0ph9ccc+sjJWFMQTKaqfoAvjS/6icJ/18U/BUlUt3Ch2fcQnAUzY0Vlqw+q1vTTj+p7py1QMy7leXzEx4Tt/UiMQLAIetRurv2iz+teKeD6wwK9pdtZWJO98W7n+be/z0o/8fKDccsp7PJ9UNr6xxT0DLAuWvfIkUKrMX4JkY/xXfB7UXwMD2QWXUrF+9dENxXeUJy2Jb/RBwcnfO/z2KE3uSudothebHGBv4PR8NMsX/jo2DFDAoC8rGfUltpZdGRLAuPlRyjwVLx/VSavwitMX35xoxfcOpAi8w+g5aEKSwg0j8RF2iaLcrR2qMu5ARdwQXlRwjjPXCDSGs8nPGwH2w/St4+VCgTcVCdLm+MY9NdyVzfAupEgebrZa8x1/yVVIH1Q3gGszInlOfwbVOor2LFjmkiFbNN2Sbuom57UR8gE4aaciKLt5AYaxcf91A1sdL4ladS0VAXSa67YFAjKn+ovRr/vKPzaqWquFwz7GP+I/kQ3ASGd8cKQokG0jAPVpRbGvUC+6aK5rnnGnwKGu10aYyUowJ0Ds3A9jI2aLKYzFCJluvZ37WqhSgmlQFL3jMZfXMqxg5aa3ZdaTrvhhHtijyvUSTPkQFr/rTpmc1aSOSS84N4k/PkW+2YvgvO6npvzlAu/VJxpoT7InHvqO9YQofPB2YwZBJEVEnj0N3sCxclZeS+cOTtJMqLno6bcoo1BkghEx+Gp2Ab2KKRzBa0FXFPB69sX9FgqMrHIm08X7dQsRc2duRgSTI7iw1fuuJgTYkQLVe54iS8AYctB9XuARjZgKjVj60xCz4KUbX/Ha2LnANgIY0XJ3IgUzBcCKqJ+ik5F2ohIul724MGzf54awqewvU7pZTaH9YrjdMp68+dNqnIpD98MaTTS4dkYXLtcD/NmNjfUQaIrvdMgQhb/u0Xo0s9JVXu1RIghUlFI/A2FjQbJocU2JZjZ66Z4AOc6TjopbYaADGkCq6ahvnIkaWKcjobYTcdO2bCfozg5ot4vUa+rjOzhJs0Dasmn0Njz3ire7CZs7pmzLwcDlAb0KLedHV+ln4mf9UZQlpMYr+lo3crBiosFOpiTlBQXmM+6aE4zyQIKQUboD9JF/Phs9J7+yaBQs+kdlLNVf1Nk/eXPOZxFzbEPdTWF7y6raHm5ivKz7dJK4YX3XjLm/zcji/AALwGC1R6QOBW+74yUGS//0oSIHrv+addV6PKrvAFVMtfAvA3bqdINK3zb3scHiU2kD4Hz9oDpwefkZZlHSfvFZEDVpUkVoW8La3XQJ6jiuwrZcm/zg1Z/vX4L+NYM358DzuR3ZIrbMDC544pGfxxI6YTY6KMcy/b6y8vB0a3+z+OfWht7ht1Nxg4+3jjMUAwd03YsbT0I66AzYi8Em6ZhEE+Cbe1t364iirt7lC+MJy9MCSJGuZtTh2miP835N+UVHYT82DH/yYDhHwP5Mj48i8zvrV/wXeMyhKrNdvNrrQ9PQPJPZnKOePwPMJkTctsq8pFcwIB/1miXh4DNePow2xaHAPgnnh49HbK5uefoxUuqDyYAAB++33LzCZ50hD19F2AV39whYa4LajCX1bu/r0Fh2/ARokVH2iIxJAPqTUNkEjjDMNFV80ZBPXcTsjfAzJGvHs9pOQz4/7qbQUchsQiG/6RKkTuHUzCRSVLu8YU9I0eMB69sJZYjJFPC5fZBHjZSBj6+5etkecO9VqrTPOZHoCL9p+AdNgKJ73lPSoV3yMjiwaAJifcR6rClood/mnrQ19IdKIilrBn/vBz54X5nT9tQaTBL/8tR+lWzl1jCc71/9+kmynYwYayv6rIIz1pvEEeUVEPhrpsdHUYThlTTz3xM8Bj2m5aHVHcemZl1BwZVjldFTHP9uryGmzW8NgxZ0T/iYoKff/AXPRo8Ts582DH+vGgg9DbaZzVQyGcjGGVJKk4pcR7Rtpy+62XfYx+yiAOM1fW1Gw8wU8Dhcpw/kd8G5gV8domWBExg2B/2s/CqYPNm7861vlvKvxJV1lyR8dlL+f1IikLDlREyeyQLCJtSOl840M0wefTqwNG3PM00dWJb9tUXVUdBgiDL6Wcss7xDLEefCLPzvV+OTbGXHhYSzSp0igYYsFQwlxf9NOotOoXOaOdwSvOayOyZXWZ8dmbprC2PpkRhxQqncKZ/xFKTYOiiRid9u5t/Hm8aHFWphsjuH6oENCAvzgyN3KHZ44mhH1f1ufsl3xuAFWU+IMJePJGbGdopVEc+JFApNY9ymHLkfKVCa/YQHStOi6KiiPFQqQ3JTQJ+M21t2x+sr5kfCPUItfwOv1Xn71MNlydmLmM9BHiRH+EgEmusT2n8/Ab51J6uy0d/PSDZFJZpmgktz2v6WBUvRaCn6XcpD62nc+7l3I//D4uqJJb4jVPLScmgqleb/sJ7CmrAX+wbWhPA7NHgsJ/O43W7tL7TnTLz5637KnKFrc/zEUjxcGysStL2N5kenCyvXHOFFPkIQ+vrRspNxuvezj8Pff/nLCwmBGNeWc4WgncMY2s5NfysL9nsnyjw8L1dFmg6akNvH18UEu51v9UvKCGqZiJwrHfATz7G+b+1g8lTbWERlvBVvNynnX9jUO1wTAvODztam6SRNAXWWhoBRtH+8zo3h3pT1TOnY+AanHHDqxaHfxo332a7P++pKh0n6texJ+ZPy/FS9o9VU60rmDl5FPLDp1AjB1NZSm2/pT1INCIDL5qJvUjZHPKfHZK/8/ZRARrkpA1x1lIgTAnk0yM5Dti9jOuIoAynF0s0sKFa1qYBe5jpfthKSVfLr3wWC3IQ99BtAEeXVApIBRymQPKxuubPhXy8pK+HT2ZH3lGYzMM6btI53vi7uTDHb,iv:xb2xCPn0tHkjbzXtVlJtYc0+bh+E5BxfB1db/08GMSA=,tag:WR0+kEwUhVB5MoggJHPXUQ==,type:str]
+    kind: Secret
+    metadata:
+        name: ssh-secret
+    type: kubernetes.io/ssh-auth
+-   apiVersion: v1
+    data:
+        app-secret-key: ENC[AES256_GCM,data:0EiHueFLJH92YbulM8jCkSMb+TM=,iv:4oa5AtHwr1qAQV8bzQUuLCnasGEPtPSN3x6hnS2nz1c=,tag:GJkc3wKu5CJ4PmvyoWc2oA==,type:str]
+        management-api-token: ENC[AES256_GCM,data:PsqzK/rCf+RNFe2g,iv:bR8O6hpn9fagrsXW7OV6Dke935tIAk2xkGAp1hTp7QI=,tag:6ByzWK4vSCl2ulbCzK6iCA==,type:str]
+        user-api-token: ENC[AES256_GCM,data:O5DYpyHuNf0Vh0dS,iv:NZbWwYj/VXoxb3Ulw/UiPG+dzq8WNhj5KBUYgtnR5Ao=,tag:Z9YI8YgRcv8REl+p/QAeRg==,type:str]
+    kind: Secret
+    metadata:
+        name: integration-tests
+    type: Opaque
+kind: List
+metadata:
+    resourceVersion: ""
+    selfLink: ""
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    lastmodified: '2022-02-25T18:18:10Z'
+    mac: ENC[AES256_GCM,data:qplxFQN8MuW7RpwvVLzNKyq2JwGrQg0YmlNceC7uj2TIzuSwrMWuEfGhc3ER9SID2RinhFoGGqomr823mLDlh/GBUY5UdFDqabhJ4hAHby6UGf4taagTsE23ST8sxPGnVAH0kI91f3iMlaD+au1KcnPPnySDkqX5fzwMo3vQsMo=,iv:wDYZhl2tQ3OrvtMfXOsumbHkw9gy45getwH4bwKOd8s=,tag:zETm0vJpRN4ZXXkF32HtKA==,type:str]
+    pgp:
+    -   created_at: '2022-02-25T18:18:09Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA1gbAjViyxWYAQ/8DcVQ3sv86rZmSY8szHPz+ywUp/IUKwYzLl+qaGQGKp22
+            zgr6UD10TP1110p92TmHPusxJ6ZvOQsr3NQMhr64S245+CNjW4lpC735ALwGIxtm
+            LZ7gK/qvgkvOXVOs6UF+FkDmRXnPm9gDB/GEiOMYLe7tyuOjBGQP8GpWDxKEhJQF
+            /M5kbGlvPDP9k2qHDTeGGf8UgzkcPt8j4EnDhLzqW9GCiSSeQLaRzLZVW8TE8XhS
+            ZXm1ZlRxZC6CEZtBKeb7pKWtms8sJs4PPSQkjGpzD7TiLolnoBmPDxoigUzvqinY
+            Kz2NJzJCbMg1Tt04Vvroxo/SZtZvSyp2aU8XMVNSH4FWvlOvvnb66LwO+27ixCjP
+            XD34ViYvugvn0ItIJr8dssqTDEJ72hqawXYlwaw2imRv3eMH6Wzskt9Q1kkYSU0X
+            xOz8g2jb3x4AV8w+GTNJ2NirqEcou9XHqFqBUeObIwV+7WrErskCNb8mlVm/qNb1
+            D44RJbVH1tAzHbpjqslQoASlHCm/7k6J1BNa2U35MimI5LXsjsXItk4sVtw33gZa
+            kDx6hwUWIMhk38Or3X3z7km5l1D6+Vtp+YBV34cVr9trOXW6aocK0xnxHqoNJ5iT
+            IIVaSC6sSQSf4gGhGmvCvOCPDNymNeXZ1b8QMN4KKJJ+y+jl5Yl9Mytr/QNWqGLS
+            XAEOYGE+JxQ8Ne/JFG7Ww2EG8MLO3IRVooQBR4V9+z8c9ME+R0WjWxshw9PTOQG0
+            wE9t9racbgp50pPs+kjKh57BDXk8QAbR5dXC9hNckvXeKC4AvxxXxj+/hJXY
+            =y20U
+            -----END PGP MESSAGE-----
+        fp: 34AFE2A7C8E00ED66916D95DA9FBD7DE773B2A34
+    -   created_at: '2022-02-25T18:18:09Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA+/WpawS9RPbAQf9F0UfjWZIR2/kKtA1NC8TikOOvYZOkAeHDRSRgZqREfC7
+            WkCXQ5cQe2jJ8eLPQjjERaGsAGLnMFryE6W6UKy/67BgSvipiqGviUZPPv0Y6qFt
+            df7WkzEeT8DNl6WVUk9uT5jq1rlAefG0UkrD3ayj9ZuwABudlJCbMad5qVqIQ1Vs
+            0zo4e3SVIx/EAOci5bm0hT3xP2fCC3LSYdt6ZzXBHKWu5ni2NOoRHKixbeuwwQEU
+            zj/t5OLaid1qkY4U9mcbYn1dK3jzPF71l2JmVAUdP/tBvTyDylAivFjPJpII0T0l
+            gAW4cfITV6VUZ6YU79iU9CzjRNw1HChlH0GulfugW9JcASaENMG4B367TnExrN0r
+            A09Mv5t85qtw+b1lK5U9HP5xEdnt6FzzOKTz86jVJWCZ4PJymc4h2M4MDGC330Ga
+            4DFZ/3Kf1NuKPgwxb9Vh9qXM3G7thUGuv5uT0Co=
+            =Tgy6
+            -----END PGP MESSAGE-----
+        fp: 87FC5D0ACF3AA48FCC029086262A80E41BCEEBF7
+    -   created_at: '2022-02-25T18:18:09Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMA/irrHa183bxAQf/e6a2tAp7Pra/IIoPp9+4E4ZP8RM4d4lRPZ/YqYIUQkwy
+            SckDOSzLPMWaVNclMD66IRP85yfji8hfraM7uvwII/OM+FTxbbTXZ6f/BlpBVV4l
+            UPw+LkOKcnutNU6zJNiwvfZTlAwrvhtG5TGvPnXpUNE55877HKYUuOU1RRCwkkeH
+            MFwF/ni0hooEXA5m2FZHILMTgaPSlAuyYl0EdVobHs/otNPjUbHXPeTj+/80TZgb
+            u/WzIZQp6i2PeyVyv9/YYEM9uRoIYcjOZhmVLX35UT9qVnrJCaiUgXsEXeSe5G8o
+            mnKYvj6oZOK1z8+eW3PDOYKUTrezTc9nyDfRpxbZvNJcAbXOair0A6k6Ft2IAFrB
+            WV1IXmtcBzy0jJkfi07TxO3O/6J2tCdebltm1ovR6ySUlMkxbK9Thq4E8feNVB2h
+            PKr9zteQQgh0pX+F20lIxSXDqJZiYxcof+tYgeg=
+            =0uUV
+            -----END PGP MESSAGE-----
+        fp: EFDB9AFBD18936D9AB6B2EECBD2C73FF891FBC7E
+    -   created_at: '2022-02-25T18:18:09Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA9aKBcudqifiARAAovan/knHq9JFSDsMlJAn/msZJoFDRqFP30CfW2cgYsjt
+            3UflDDAb1ZilQ7JID16fhaxrnyB/HqzJPcIioTFX3M/9SiC8CYfeDmxlIdTN9wdL
+            GRRTbbibp/2tQxjPYH/CQYdwKFI5vWBr1mZ0MWMd2qX/9BQ1kJbxXbswIjFNfNa5
+            uQZrStFf6eh+Lq63meSTfnmtMn0OzAwvnqUFkuM04gZS53S/0YMQ5n+YnGU3SeVK
+            PkFGp1dDpDN+5AbgPEoX5nPYKsCeCBisXcUsWLqS8OxfsYt16W92qtuN6zhhKU3W
+            xIw1RPt2V4suKmt++SUfWydv+d7BUnjEvm0DdVyJBwP60nDaRen4PBcTeAN9uvCL
+            XPECD1W8mWdhpNYB0rOxKSk6HYsfZH/QP4gCf+Efs1uc+Iq1qk2njqIURs5nPQZA
+            PLn4DHnGpdZqTFZKo11gA+bTfxA+PgtmRqps2sJWTagv+oP+wSSk5olVTNRfy4jZ
+            /q0dezUaQZemHw6VuV7V0XA0EGI+fAPvkBRQiNroBnVO7qblKN0IC+oX5ADxe9bU
+            0jd+51Q1QgzbncJd9Os/Zi2bF+aW+jgQYLkVEJ7vcRt0gCLkuZL0D8DVk007/+4O
+            lI+f+8QXcR+yYqi+9CTfStwNOgI6kbMWvLlb/5kjY/PElZ+UWPALTP4lwqCrWJXS
+            XAFVeAKLqQc1P9lxHSw0JlL0A/Yni8sc+4rMLG5ciVR5P8MV9BwcEu32viHppnGN
+            jIpt8vJz/PxD7nFggX+hZOBgZ/vyoWfOf2mbiA6tCoK4gBuPSzCzBFIZGjIR
+            =bwW0
+            -----END PGP MESSAGE-----
+        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+    -   created_at: '2022-02-25T18:18:09Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIOA9LRbhPydJmLEAf/U3YLwtn+BOMQz8mbZaCS26SOlYVUFvwobp3+2K6eVFBH
+            LNSfIWXMeAWHVzVfodfQlYExLZtiJYy3BCUU4YOSwjf9HguHfs8K6+qUQbVt0rhn
+            h9Ery0OeIexOuZnYF8XExZOMJXQ2v0kpU/Zy9100jjPJaOLTupGzhb/PYcBKnEPZ
+            dcIo31EZSbCnZeeEDcTWDzI3M5lHVELFvolWI412c9/IOZST5zD2Lk4PbB8WLMCx
+            UG9IwFwI9PJ1wFCofpCl/bwt1y40vTZQ/h2Eo35KwsiE1pqleKQdEAr8Z7ZADeHu
+            s01f9wXsga0qUmTwkjMhgpg2n6ITYnQMQjLokPvrpAf/XDkOYsPYBSsYvtl5R2su
+            GRBcq2oOVyw1HDSIpm9BfNdTgOvm6Sco1aa5KeJa2J8pV1hpupR3CJFV9EDeZuDc
+            oApmJcKC6elYnOUt4ipNzmSW49ox8k38wbLolvOk8+XVlx49WKFGXsR+CptYnmgt
+            N+epbmAMwPf+fcLccTWw5Bl2AsYPJp9jKlnct5RdS/Wfze5Zjzcmd4ryhB4I06P0
+            dEJVa3WQ68ohORlIR1b+Rs+VWZzv2qX6f5iedD9PwKy6SsgQXgNx3e1stHCMZ+ZQ
+            yjZ85Bgkf53s5ZYjqHa9SEVZto9d9uw2qt9QDJPXZ07+27qsFsoJFCYduOEiLzI0
+            QdJcAZqjJ8pLnjxcGgiSRWf+9yaxdZVDaggpymcPIDvot2sMHVLRAOugVU21AVo0
+            87vAO5LlbMCRw/N5wYI5Q3g+G4uLuPFN7anY8t9Iawjn3D+5Sg7IVx55bj7l7hA=
+            =6F1c
+            -----END PGP MESSAGE-----
+        fp: 8D191B7544E9CCC3547B25A877E5A5B31D13A647
+    -   created_at: '2022-02-25T18:18:09Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA9NBwWNwg7uAAQ/7BNt/npEeZIRmAhG/VwcCIbBYt/TIOb1eZisdrqRTZC0j
+            NFzlvZVciXBKXQGe7aD/Twn6ZhepWYjwrdvYiTvOFgK1SWGTVvfYOe036CG9kAjq
+            d0M0+kIPYh/Xy4gLbJZGNMf3ELlLUK2c1AYrsBiGjuZI2/kgrWnYzea/S1IlDpj3
+            apH/fq/Z7WeHTw3SNbm2G7Bfp6AXlps+Y41GKICGNs7yyJCupe/wo0h99jhS2/4W
+            np4MxpzBknHUZ1jM0QvVXbecQxY9W/GMX3ZC9MyDji5QpNTCOEEa/xaSBe8LYvvj
+            kzf/IrFeJSkCW4sQbojaFLNSSlIMCK7WJfzMR3Eujt5gsFjRRysX6Q4baGLmJNQe
+            VIB8l2YOJo2ithl8ADk1ptsacPNarwCUQIxfyao0AUdVyEx9GLnzFVM3HtURk4C5
+            upwZcZtk/nCWWPSmbY4u/VbTWtrgVmUHzO9cGccC5qlN6IFWDpK7zWmrym9RRwmq
+            vDuXzRY9h6K5xiCG3OhcS5qLL7rflWyit+gPOOzJzXKPGNDWZRmJTCp86DJtRS5T
+            qt+SXsA3ALGlCmR6Eozah/wxizRjRsIZ8ztogYAXmOB5W1WuEYMv9kF9I8Xh8cLR
+            5rAFxs2Sil9lwQaCB7wOqT2hfTwgYRDOJVW8eNehYOgAvlu8DDt+R6fsDiTanULS
+            XAFVnQ4bDYD9SHMNx0a6Lp7Ff/aOP4u0RiLrfsiy3MtaAcnxVpvcZcduEUk/5gw0
+            5dzHGhlHCjhLwqZ6XZSdgvuGbIZE7HUOB3+0Qa77as4hYer4t5ZF+sYK/t4j
+            =fvnS
+            -----END PGP MESSAGE-----
+        fp: A01778ACB7CC4D41B00FDD78CCBE624D8FF6D016
+    -   created_at: '2022-02-25T18:18:09Z'
+        enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA7vMDF1jUn3mARAAouFfqhmr+O6NKwiRtwAgCg5f2qq7zLpRtcfuKpxEkDGP
+            tm27VjoToObUsVYgzuQYypOIUqjySEQDmkAW/RGKmqYVaBQqp+sE8wgWZxP6nuUG
+            Quqy9kw+qV8Y5gVv7pj4F8KdAQv4MTWNUnJay5i85xbJ+v+pfNmOdCr9oBnBagvp
+            bMq51dG9BIvLp9CrC0ewMkanJXm0SAjVV3dXGtrIQrnm4NZAgpm6CW5j044YfWHU
+            opQ4gBUbYyc0cU7Lg+1TTl/8PuMdWomT6zoKp/iMsItvVCrF6mchtHfUxGwysPBq
+            29pbS6ReQzJzVk68KpM543XdYUIrBlaFozw4mou2CRcdXOheieo4zzR9Lvt65ou2
+            3g6KVcAcW/ytjxLAxokLvSRn/SNxsNZs5FVQPNx0u+nFeA7k1GeY63llZr8wP4lE
+            N+HQzKtCmMdy9bSLx0l1zrWlSl2x2ubwCj2Anj5daP+8IKPbpb99erTxFVlC7ECE
+            FZfSTSqCCfKigHnKAc3sKqTlcEBxDcjlLjhj8jT5gIyV3NDOlyHbCt7fSdKDUBol
+            VBZZf4uBpzYeKC7u5kSHuXX2uOPsEelWiG/YRZjaNhoclfuJU2RsXfR+9CmIRPpi
+            Ja4tfBeeOdYirCDkQQI3WUZvhKS6rehe8MBGp5AcJ5gOELRIEUaXThsWNsnxPt3S
+            XAGEMH0nC5cJOXNZ9ZSszGjEiwGonXMTHFla345ntPbKoJJGs6VpIOmKZGFoLeRV
+            02rB5CbreUF3ExxhpVJOJK7oEu9uAlGTs2naXKx1C9piq8gBbB0O8+wX7gMf
+            =DGO8
+            -----END PGP MESSAGE-----
+        fp: 68BD1529A372C8BA561C9DDC377298152D08B95B
+    encrypted_regex: ^(data|stringData|tls)$
+    version: 3.5.0

--- a/prow/overlays/smaug/service-monitor.yaml
+++ b/prow/overlays/smaug/service-monitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: opf-prow-monitor
+  labels:
+    monitor-component: operate-first
+spec:
+  endpoints:
+    - interval: 30s
+      port: metrics
+      scheme: https
+  namespaceSelector:
+    matchNames:
+      - opf-ci-prow
+  selector: {}

--- a/prow/overlays/smaug/unsuspend_branchprotector.yaml
+++ b/prow/overlays/smaug/unsuspend_branchprotector.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: branchprotector
+spec:
+  suspend: false


### PR DESCRIPTION
This PR includes migration of prow manifests from `thoth-station/thoth-application` to  `operate-first/apps` in addition to pointing the argocd applications resposible for prow towards their new path in this repo.

Related to: https://github.com/thoth-station/thoth-application/pull/2606/files.

/cc @harshad16 
/cc @HumairAK 