### PR TITLE
feat: Add local user to ArgoCD for backstage

### DIFF
--- a/argocd/overlays/moc-infra/configs/argo_cm/envs
+++ b/argocd/overlays/moc-infra/configs/argo_cm/envs
@@ -3,3 +3,4 @@ kustomize.buildOptions=--enable-alpha-plugins
 url=https://argocd.operate-first.cloud
 users.anonymous.enabled=false
 statusbadge.enabled=true
+accounts.backstage=apiKey

--- a/argocd/overlays/moc-infra/configs/argo_rbac_cm/policy.csv
+++ b/argocd/overlays/moc-infra/configs/argo_rbac_cm/policy.csv
@@ -31,3 +31,4 @@ g, fybrik, role:standard-user
 g, tremor-demo, role:standard-user
 g, osc-admins, role:standard-user
 g, chris-project, role:standard-user
+g, backstage, role:readonly


### PR DESCRIPTION
Part of: https://github.com/operate-first/service-catalog/issues/20

We need a local account with read only access - we will generate and pass it's apikey to Backstage.