### PR TITLE
Strimzi operator subscription targeting default openshift-operators ns  

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/strimzi-global-operator/kustomization.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/strimzi-global-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-operators
+resources:
+- subscription.yaml

--- a/cluster-scope/base/operators.coreos.com/subscriptions/strimzi-global-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/strimzi-global-operator/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: strimzi-kafka-operator
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: strimzi-kafka-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: strimzi-cluster-operator.v0.26.0

--- a/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
@@ -33,6 +33,7 @@ resources:
 - ../../../../base/core/namespaces/sostrades
 - ../../../../base/operators.coreos.com/operatorgroups/openshift-nfd
 - ../../../../base/operators.coreos.com/subscriptions/nfd
+- ../../../../base/operators.coreos.com/subscriptions/strimzi-global-operator
 - ../../../../base/config.openshift.io/oauths/cluster
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-rb


### PR DESCRIPTION
Existing subscription targeting specific namespace opf-kafka with associated quotas and settings. In some cases default configuration is more preferable. `strimzi-global-operator` subscription config will deploy operator to default namespace.
This PR is to address issue https://github.com/os-climate/os_c_data_commons/issues/160 