### PR TITLE
Fix artifact passing in kfp on osc-cl2 & smaug.

### DIFF
--- a/kfp-tekton/base/deployments/ml-pipeline.yaml
+++ b/kfp-tekton/base/deployments/ml-pipeline.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    configmap.reloader.stakater.com/reload: "kfp-tekton-config"
   labels:
     app: ml-pipeline
     application-crd-id: kubeflow-pipelines

--- a/kfp-tekton/base/kustomization.yaml
+++ b/kfp-tekton/base/kustomization.yaml
@@ -35,8 +35,10 @@ resources:
   - ./serviceaccounts/pipeline-runner.yaml
 
   # Secrets
-  - ./secrets/mlpipeline-minio-artifact.yaml
   - ./secrets/mysql-secret.yaml
+  ## Implement in overlay
+  # - ./secrets/mlpipeline-minio-artifact.yaml
+
 
   # Configmaps
   - ./configmaps/kfp-tekton-config.yaml

--- a/kfp-tekton/base/secrets/mlpipeline-minio-artifact.yaml
+++ b/kfp-tekton/base/secrets/mlpipeline-minio-artifact.yaml
@@ -1,3 +1,4 @@
+# Implement in overlay
 apiVersion: v1
 kind: Secret
 metadata:

--- a/kfp-tekton/overlays/moc/smaug/kustomization.yaml
+++ b/kfp-tekton/overlays/moc/smaug/kustomization.yaml
@@ -6,7 +6,3 @@ namespace: kubeflow
 resources:
   - ../../../base
   - secrets
-patchesStrategicMerge:
-  - params.yaml
-generatorOptions:
-  disableNameSuffixHash: true

--- a/kfp-tekton/overlays/moc/smaug/params.yaml
+++ b/kfp-tekton/overlays/moc/smaug/params.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-data:
-  # Set custom secret to specify minio credentials
-  artifact_secret_name: mlpipeline-minio-artifact-custom
-kind: ConfigMap
-metadata:
-  name: kfp-tekton-params-config

--- a/kfp-tekton/overlays/moc/smaug/secrets/mlpipeline-minio-artifact.enc.yaml
+++ b/kfp-tekton/overlays/moc/smaug/secrets/mlpipeline-minio-artifact.enc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: mlpipeline-minio-artifact-custom
+    name: mlpipeline-minio-artifact
     namespace: kubeflow
     annotations:
         description: |
@@ -10,43 +10,43 @@ metadata:
             credentials to access this object storage. All fields prefixed with OBJECTSTORECONFIG are used by mlpipeline
             pod (apiserver) to configure minio as its object store.
 stringData:
-    accesskey: ENC[AES256_GCM,data:hS4X4J6VevaojSt+b5lkRjAshBM=,iv:VDs39b2qIpQXU5J1aEDEGIjcClb1AIGQih3HB9AcHNk=,tag:IPnwzyWirlrQJUY6SxrlrQ==,type:str]
-    secretkey: ENC[AES256_GCM,data:umxAfNDjw3uDnwDQBQYOtLe49PfFyNrXei3kjvB4sN9XMinv18c5lA==,iv:ogOuI8Esi/1DvQkUDGTeJsqM8VV5HW+5dlnNLMJ9uqA=,tag:InaPl81ehRr39+8wztDCrw==,type:str]
-    OBJECTSTORECONFIG_HOST: ENC[AES256_GCM,data:KFSXPbDyKiqI/E9KQ0BidXptjBrtow==,iv:fE2xWOo8UhZlsVZ2kJQRz5hE4NK19OoHwQfm8rpZBbw=,tag:aChfbvvxAQky1CKznYe3IQ==,type:str]
-    OBJECTSTORECONFIG_PORT: ENC[AES256_GCM,data:oC36WQ==,iv:vSWUywGBCs1k7Fem4lZAMrTHW+3KA7xRPGkr2tIwtns=,tag:h0rTZK68IA4WxwDH/EtlMg==,type:str]
-    OBJECTSTORECONFIG_SECURE: ENC[AES256_GCM,data:JxuX2EY=,iv:k7QQsVJ2QbnCPHurSniSnyYssd6mGBMeg2SgwP0HBjs=,tag:wki4ApNIe878bMN4Ey4OCQ==,type:str]
-    OBJECTSTORECONFIG_BUCKETNAME: ENC[AES256_GCM,data:JR1Bf1uONYLSog==,iv:olpJJpPEtVu7FHUBIEosM4eC9gvLUZiJG11kyZ34uz0=,tag:nJJ1qMT/GjBzMmWnsuxYsA==,type:str]
-    OBJECTSTORECONFIG_ACCESSKEY: ENC[AES256_GCM,data:B7wP40ofH5WiWmQF9zVPYioZing=,iv:tksIU3loqAEdssmJxr68ImLiO/a86v7gOwMqIXaQyFk=,tag:h+l+PWh2VJCxPuxR6xxyMA==,type:str]
-    OBJECTSTORECONFIG_SECRETACCESSKEY: ENC[AES256_GCM,data:suJuqkZwePs1R1gXhThD8w5i43iUe98twYVqexVdqUrazq+CAwwS6g==,iv:EpBu3AU9M+ZgwFedm05roJUUZHz51/A36GeIm9r1u2M=,tag:/HfhMGqWutFgjbwKSFQYhQ==,type:str]
-    OBJECTSTORECONFIG_PIPELINEPATH: ENC[AES256_GCM,data:Ovg2QLOvi2nL+Q==,iv:aVgq2aTju/EamDokpoj/bB/bMuQ5LtOultnISvTIKzg=,tag:y+JO+rLEMZmRWciXewmw9w==,type:str]
+    accesskey: ENC[AES256_GCM,data:nCSvfv0ozpbSjZVJGoYDYAk3yiM=,iv:pJwy+5hmeiM5D1Aa6z6HewaM5d9E+AienmrERishkuE=,tag:uL1uWIoYcF38i3aCClimQg==,type:str]
+    secretkey: ENC[AES256_GCM,data:fo/1JmZ/mMUA9pyQvBsj7zaC0k8M+/7WtO1yVQC2vO9SV0XY/10JVg==,iv:XDzCX740NoxqBNN/2aw7N+wShMnMKdbAo7t2vOqRGqI=,tag:wwge+ufhigUb8hZrVZ6Mtg==,type:str]
+    OBJECTSTORECONFIG_HOST: ENC[AES256_GCM,data:r3EcTur8ojmn0jRbLSAvg5ZOMoOF4w==,iv:pRzzMTLXO87BKJqKYKC853ho42VqQg5sMIpHWJuCFMQ=,tag:M55waMgDFgOU71KC8w+j5Q==,type:str]
+    OBJECTSTORECONFIG_PORT: ENC[AES256_GCM,data:i9OxWw==,iv:uceqlaEpRixGNQylHeBU5mQ3AOuxqyHRbBMc6AcEVZU=,tag:gg555P4G2EfpgEvonEnLfw==,type:str]
+    OBJECTSTORECONFIG_SECURE: ENC[AES256_GCM,data:8ECQjZY=,iv:+Q92LOIDKkIK0loOx7XlKEzG0bB3MNzgVDM1AEbpobk=,tag:HSLvSxY5eShHPqexLfxFGQ==,type:str]
+    OBJECTSTORECONFIG_BUCKETNAME: ENC[AES256_GCM,data:yTohaLJ5v3DmDQ==,iv:WeHbPnBgvieksAXpUBJYlGlK4KGJ1Iwc8gWSENE6LDc=,tag:NPQYIme3NNRoHivlD1br4Q==,type:str]
+    OBJECTSTORECONFIG_ACCESSKEY: ENC[AES256_GCM,data:AgBFtYTeBmuR54yjgEg71QheanE=,iv:6vRXgqu+5/Gdv6N94g1iL8NoEpvFE9psRCt8ahl4B0s=,tag:X+si0SLQlcDtFjMF6g69fg==,type:str]
+    OBJECTSTORECONFIG_SECRETACCESSKEY: ENC[AES256_GCM,data:7cbe8vu16VxzUH3QB+zS3xkXz5nT5L3uCFrNL7YY8mr83aGdeyNbcw==,iv:KS1ukLqe31DkQz+J9t+4WWNK0uI1JSIhxOw5xUdyalw=,tag:86QYmSXVVTGpdMRzyoQErQ==,type:str]
+    OBJECTSTORECONFIG_PIPELINEPATH: ENC[AES256_GCM,data:l6Y8/B/ajT9w6A==,iv:9ROFfgsLjJGTmbpnJlE+eVL69eK+09lRkxj6mDze2Hg=,tag:+Sr9Oi7sbzD3e9ixVZJhKQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2022-03-30T19:09:00Z'
-    mac: ENC[AES256_GCM,data:VOFRZ1Iv6SpgQsaQpQqkeZkHlPPXd2S17K6WhL+0GcpqXGoZU/3OxMTh59HZ6Qlt5n3mMowRg0kAVgGB2d/cRE5yLsvo+vVa5r2VMdPXdyKFAV1zFkhuZKxVWR5KFI/9MDueTNMe0KIv8F822nyPMU9aO1kjpJQT4NWWuz36uJo=,iv:m0DzETytThOXYMfKnJTy4u9uR2tzkqm7UYWayE4pubU=,tag:JZHE0e8UlZaEvGISM9+9PQ==,type:str]
+    age: []
+    lastmodified: "2022-07-14T19:26:30Z"
+    mac: ENC[AES256_GCM,data:inOwRBJJFbYww3IVPioUx4z62tKrodilnsNYmCrHCTt4iohNAfiMUJ9Z5BInvdsWJO4UXzlTR2ERj/WAE1kOerFHHwt9jLVzEF404BX/aXbQWj4MjSZBqvy6PAPcZ1Utwt5gHlFlTg2T9NoBl0O3glY7X1GEtPbHB7wOWEabU9Y=,iv:K0CyneokWnX0Ob/dYDuuP5VSfEofEjlS//WVyaNnDLA=,tag:r7YNEs/yAQqZlKRlF2v6nw==,type:str]
     pgp:
-    -   created_at: '2022-03-30T19:08:59Z'
-        enc: |-
+        - created_at: "2022-07-14T19:26:29Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMA9aKBcudqifiARAAksJfwYi2hUTLbbkRUCK4D9P9E+5Quku1829VDn8dEHYl
-            KFs/3AdqmbQ4vEMqFcx2Db2XcDIIJiCvg2aNCiTPYdCgRbjEpWSh4TFJoStikiVr
-            4WPvo8D/SjMqlbK3RTJzbUzitjCJlV73rwEYfogD2DVwxfdwR/j1szQuefMSoBxi
-            TcuCDuAwQJsqNBWvpeNw27y9M5mBaTEovSiePNI1Ld1AsIqwtGbsBii/ufeXxjO1
-            G0DolzN+cn2bzXpeP7pitmdVUb4Aw6KM2zPo4SP/EXTH+nkNxtJYPNnfLFNSSoC3
-            pfspwwMCYIH4pP3dRaXGpQHA3P/c15LHo0R+OnIf0mzmisHy0vv6IDlqpzmP0vUQ
-            Q/ViKKt1cyeuAn6W3pOj0FUleNb9wn6zYUwd3lR4WsPwsXpE1DXsIyvYppCJsYIB
-            5/rkY92S2lMOl496vsYv3Az0qRepNJ/WKj2jbN3wRJ/V29C6STTdHmbavkjujmbO
-            dOrGLwNlQi7gsdIaRc+d+uJ2afzCeEg5o73buqeGVmsbMBce+lBMrApK3EU+yk/X
-            r6iQcpWjj1RzVicQBwY4CMxggFpaKWQKLTmzjhaaT2EdWYtsEw+7e+ddnolrjGjM
-            MVC2IN8FUP6vqpV7JAAX+YzFjFlLagvJ4mb2qH2tWKr/pV2HiVrUmzvNr6mdz63S
-            4AHkrEz0POdmL1VSJUMGyShd6uFV9+BL4PLhgEDgd+Lrdzrg4CnleOdPP3SkgYxB
-            kXvDsPv3PjDnMmSiQnPDP85dXYaeW1HgHORscQYfUf7mE+2tmrQCZaWW4lfCudDh
-            d/oA
-            =6RNE
+            wcFMA9aKBcudqifiARAABoyC7yJpjBYkE70m0QobQKQyQA4Bb+ieBzQRWA9YGCuP
+            5PcnjDnGffd0G5T6UIZ5jyZJKxl00ZhvqgwXe0kGXIgaS3ll2DWqIsEmuSoL39ZC
+            STbVubcTSEGGUTklP1dIiYBNPtcuptSiydi7uPOkxr5A9WiStWKIXoCWE1p6lL4L
+            vMDXov6+jemf/MMgujxD1ge0jeBJmf3aFnu7hw1u+AtmY3B1D0JfUQKCvl4h6OTp
+            Pxb1JhQOJYB1mwH+Dgfs/t30x84psRAmZw9FExjnVzSmBDYX3XJuGEhhiEQ1qyDb
+            UGEHpfyBfsjxLzdNDIdbNJ9Uu872IU3cxiMAyt82V+Rn9lzhf+h7HlpFCmSGoocd
+            /4mEHcSwwDerdPuu5ivx3U2MaIHWKYb+tx75ly+9G5SsgMeWWzORCzRnViwzBgrd
+            0b2lX9wPWXqPfBy35gyj//EaLjb0Ycs0cTTPHiqe+DQ6+BcJ8ulVRQZL7L8itAt/
+            lEHm6yw8mIQ2d5RhKObabiGw3YLGq9QAwO8LTxg6GAJf6zoWwc/t4xronSD+e1Ay
+            Obfzh1EoZZVHKcWHcjvunCpQ5VjtJTf3hdaX0DFUXADovL9iV1Oc8KAC8IYykwzY
+            Zc5UVRTVLVUklGlOwmxL0h1/gg05Zo8B5M6YyCFq/dnn8bWBdIINIw09XV7G2eTS
+            5gHwVMHo52MWtWWA5/yDoY+D7MCXvVJIGyTWM0nrN2Qj/HKZOsp824M+GBb65w1U
+            VOUYRyb1OP8Q9V++Cy5VBsHk1rczo7uJnVkMCW3cvrK5pOKrLnJCAA==
+            =Rs+P
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
     encrypted_regex: ^(users|data|stringData)$
-    version: 3.6.1
+    version: 3.7.2

--- a/kfp-tekton/overlays/osc/osc-cl2/kustomization.yaml
+++ b/kfp-tekton/overlays/osc/osc-cl2/kustomization.yaml
@@ -6,7 +6,3 @@ namespace: kubeflow
 resources:
   - ../../../base
   - secrets
-patchesStrategicMerge:
-  - params.yaml
-generatorOptions:
-  disableNameSuffixHash: true

--- a/kfp-tekton/overlays/osc/osc-cl2/params.yaml
+++ b/kfp-tekton/overlays/osc/osc-cl2/params.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-data:
-  # Set custom secret to specify minio credentials
-  artifact_secret_name: mlpipeline-minio-artifact-custom
-kind: ConfigMap
-metadata:
-  name: kfp-tekton-params-config

--- a/kfp-tekton/overlays/osc/osc-cl2/secrets/mlpipeline-minio-artifact.enc.yaml
+++ b/kfp-tekton/overlays/osc/osc-cl2/secrets/mlpipeline-minio-artifact.enc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: mlpipeline-minio-artifact-custom
+    name: mlpipeline-minio-artifact
     namespace: kubeflow
     annotations:
         description: |
@@ -10,43 +10,43 @@ metadata:
             credentials to access this object storage. All fields prefixed with OBJECTSTORECONFIG are used by mlpipeline
             pod (apiserver) to configure minio as its object store.
 stringData:
-    accesskey: ENC[AES256_GCM,data:aisK6HdxLCx6fUkfWfNdyUSC8E8=,iv:ROtJEc3eVmnwQeQsbN2HMpGr0gNBPPctmjRZ4nhlvDo=,tag:Zcijflo37NCGTw1XISJfag==,type:str]
-    secretkey: ENC[AES256_GCM,data:GusPf45gfnJOOCncW7MwI5ccVaCvuy+regzf1T1TUK47qsDtOhIXsQ==,iv:uEhpMvkRzXn+BrwOmcCIZfLruOR1ikhVWDM4y210gFY=,tag:yqpyxiRcKO6dkc5ypFVLLQ==,type:str]
-    OBJECTSTORECONFIG_HOST: ENC[AES256_GCM,data:iTdCTQqeDSqp9Iwa2zyMaRvPVlMx+g==,iv:fSLtvh5zZPkVbHqDhwbqsQ7KHZqrEmwUet4eyKgLYzA=,tag:UqqmktpNDQDBgdglEW3Tog==,type:str]
-    OBJECTSTORECONFIG_PORT: ENC[AES256_GCM,data:EkGmjA==,iv:DD1+o3iAjZ0sflYPoJqnUJ+SJTnsTn21IJiJ2XY+2lQ=,tag:hO43RjMv5CU1fcqI9np6RQ==,type:str]
-    OBJECTSTORECONFIG_SECURE: ENC[AES256_GCM,data:HDAk94A=,iv:pbX9GTBzPJWxxti9m0tpMFpg4llZFRr0OlJT97V//UA=,tag:+c8ZOW6C3jw7D9ewKwkvhA==,type:str]
-    OBJECTSTORECONFIG_BUCKETNAME: ENC[AES256_GCM,data:8ziAcfylkBbJ6g==,iv:DwLAdLaVpnBHPYAD0DvmNxrvwDRyENuQmq3cZUK9bcY=,tag:siQHlstDg3GZ9RJM3HSWUQ==,type:str]
-    OBJECTSTORECONFIG_ACCESSKEY: ENC[AES256_GCM,data:YEIZimXGZ1JgxDr0aIiBbHI+1xk=,iv:IR7GqYegNsLS/MDhZtm9k0y8IBAMGbh9OOK+Cz66B8o=,tag:geWgcYKDc0CaNjkXZk7bug==,type:str]
-    OBJECTSTORECONFIG_SECRETACCESSKEY: ENC[AES256_GCM,data:qqKtde8eonCUkvIMWfdGIuea/KPDue4goiu2BS0osuyKpIBAEuNHpA==,iv:0NYBsMkDpYWyT9yzOfcID5XPXHiTA5YfqgeGo+DaawQ=,tag:T3wd3prPXNtepZbTbAUfgw==,type:str]
-    OBJECTSTORECONFIG_PIPELINEPATH: ENC[AES256_GCM,data:Yxme/X1X5Zbx0g==,iv:t+JrcEZdg0DMQgQXbrvVbk9pFcwMgZojk6vGLEYoAaU=,tag:TbkcA7U+q38Yyj3rgRjj7w==,type:str]
+    accesskey: ENC[AES256_GCM,data:AbhmNHVo8Mws22GFrGeFbYvu0bc=,iv:8YjEJzpkZADg9kNnddzD2cYcA7A3vpIhztR7rSJ7MTw=,tag:4ZLdkPtKUc95y9yCyV2aZQ==,type:str]
+    secretkey: ENC[AES256_GCM,data:sCokSfNKEBdH+m8D6qsk5NE2IYzh3PJr3gnuzEW2EKLAlWzqUUwvHw==,iv:t+SXQVIF0Lyjxk0Sd3QcVvv2t5iuIdwWaULgf2DJG64=,tag:cqSQk0gEVG3TStX81xd0YA==,type:str]
+    OBJECTSTORECONFIG_HOST: ENC[AES256_GCM,data:BOrZYTYyJN1WiGJhqYleJcPcGw+5Ow==,iv:O5pi7Nd3cq4YYRnmYv1JFT7BMSuNu/ANx9tkEGwV0bE=,tag:cQSiiqyNhO0rB6gcZKvYhg==,type:str]
+    OBJECTSTORECONFIG_PORT: ENC[AES256_GCM,data:rND7IA==,iv:EXGKHXs92XCJ7tt2kwf5+vj8bMfgg+1xfBqgQhIrZGM=,tag:CFUcbEDALg9E8Ix9HdfIcA==,type:str]
+    OBJECTSTORECONFIG_SECURE: ENC[AES256_GCM,data:m5e8qUw=,iv:++bNvXh7bVLoXBkoRCSk90Df+vf8bVxbRaOiGIb3a/U=,tag:bE+01xQSLGbYlCATcH7T8w==,type:str]
+    OBJECTSTORECONFIG_BUCKETNAME: ENC[AES256_GCM,data:c0Bemmzzgm7qxg==,iv:nawt3aHaDLMLM1GmdIwHOhlIxOQVe60nKX60iBeYHMg=,tag:+t+NY2HQu+k2hoZ6WMqgOQ==,type:str]
+    OBJECTSTORECONFIG_ACCESSKEY: ENC[AES256_GCM,data:h4hnTQHvLVPB9O+VeAMVAwlFW6U=,iv:8VyhWoCloSt1arsnvATZ1bOu+PqRZtuMF8TacxLihR8=,tag:4WNf6GLDF0nqUiVivI4WSg==,type:str]
+    OBJECTSTORECONFIG_SECRETACCESSKEY: ENC[AES256_GCM,data:3qQGj0DEiRkYqpe9epZh+IkYg+pm16F3SvmlOJ6aCsCEiBLYThwnnQ==,iv:1UBDS2TBeRbAnYA1AszcNH/EFb6f7XAohv65yjEihiQ=,tag:oZ4ffq+b4hRO0F5ZHscw5Q==,type:str]
+    OBJECTSTORECONFIG_PIPELINEPATH: ENC[AES256_GCM,data:qemnc+viYKK1AQ==,iv:WRoVyb0O3Q6wE9cN8I3DC/J0/CINpHwfJ1ZByEAYVvI=,tag:12ZCtP8YjIcO2n1mN4ZOCA==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2022-03-29T18:55:04Z'
-    mac: ENC[AES256_GCM,data:KMkHRSd3BgsXMAxC2/iO9m3n6uCzzMGIBRJWI/55CIUhbZVw1HlbVU/LFcBuZH3sm74fuzIHIfZyKmKXtDQ2ouTpJl902SiDmvvCncw9caiqSneN0MC+dZhg1eQ6gNGIgTpALhTMucIE79ACOvqu6dHEBrkkJJGyM5jbLmkPRBg=,iv:/NLZtryrasEUYZsqDARY4ik9HZEtUGMzb3lYsOHAVcY=,tag:ng8Z9tnXhmYg6TKVXf+yTg==,type:str]
+    age: []
+    lastmodified: "2022-07-14T19:30:20Z"
+    mac: ENC[AES256_GCM,data:6LN+HH21ITRgDs6CEWpmALGGrt2qg9WuiSTOUdUmnh2HW8EBkyeUGSF+7CfSUPkYJ1kQUrCNqXUE6UMJOuZVaySq6YCi37xLfVjFLwjETdyVGFdZZnLSRNrlPN2KUoHJ9q7HWHWmxmXE+RLW/ei+Wjee1XR8SMtgVpZk7qutAP4=,iv:vfPgt0yiY+xBO7FXWoNbXf+9XWUQuxqFtPfBzHJpWuM=,tag:TlOX/+3+G4yS0VYrdk5WKQ==,type:str]
     pgp:
-    -   created_at: '2022-03-29T18:55:03Z'
-        enc: |-
+        - created_at: "2022-07-14T19:30:19Z"
+          enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMA9aKBcudqifiARAAbnwaj2STdmvjFkqKZm7nWWNXJDsfsyqAzCcstfdHR/cE
-            zICuBoHvlf2N2TIdiI353LQwmDOLh50NJV++7tJqNRdSp2JSV+SWmpUsr4fdRwlW
-            HBMDPbo1W/aSP3rTTGYWS7oE3/JfIqULkgk2dsUFu/P3I8GDr9Vxmk+KeVR/+4Cw
-            0gNepgjayCiVr2tMtnQu9kAShyrBE636lkmJU2gFWKcvSwF5LrC/cevSz7CHP/7H
-            2iYS6d/1D5vt/Fq0LF2BxEqIcz7EikGjt0lF9fm98GaojlR6v6sv+XTKuxn5De8i
-            EPqFWDALkOAW/J/8cbKCQKuNKsJ3a1To+4jht2A6gHOiyWOUSZXDR4OSFRMlXFwr
-            jlz4IYG5D0DRXPqzdTsbOf7XYxi+pBf4oj9k/Yz+MwTnragPJKl5ZodIvVZTVSJE
-            xigT9BevPGHdkQQX2f7qkntVU9ZXgSJ1UNs1cXj8XD/rM4AzeasdYyy2WE91ehcr
-            gssbFU/zeZfPrCpnv61QDmtE4WGOJsWUDXghsPSCUlkVg/s3Ckh3kcGBunOwEoEX
-            3VHnOU+sSw6ppOHBrUIjU5OthobUio9Hfmps/mLm7doFvARVCIaj2xBQDIk2nqOC
-            wkcHe5kv16BAn8A5YtFO4kjLQNKlnmDGVC3Bggz2sKuhgvkXCE/7JGBwMWY4hXTS
-            4AHk7gIOUDtKAgFnNk53SvGviOHTUOAf4M/hHZTg8OKJvVxg4BDl4doEUEfLtUBF
-            0120mAUU0YU5SwOT0JqgHqe2tmKK4vjgNOSw+zGgC5CxQ0eVwFiPdpbl4tWStsvh
-            ae0A
-            =f/LB
+            wcFMA9aKBcudqifiARAAjOiUh2zA3jp+V+EAjdQ8c7kl343Ra+fHFiADCsGqN35U
+            pn/VlqqMoxLorEpVpiGVcjxUo9nCjIs1XQJsF8WP7jHtVY6mgkBI9ELyUXN02Wuk
+            Zc9Vmm2TfxV6a42zcpFqioXBPUmrjbSY8xnwDfalCXEZup3A1y9eoQ0/id8WxJwv
+            yzap1RXmlN7Tzfxwr36HxPHtSflEgFlDZtuCJ2UZqc49HQ+NDsTlOKyQbV2MT/Oo
+            GDIHnTP9IDzvocVz7BoxSArEJbxlotHGNNb5Wk7EtPtPBhzXqN/nRgn0vLMKDXx4
+            fLU14A7NrEtkd7zcNO5LiSZskNmlvm1qKfDs/fxGAUMSI1F5QorGSbzmixHgUgo6
+            y+TAUdQgY734SNFvI68rBfAQhqp2qzKkVG9EbvfbR7suK+PEhzdf/STvRuQrhXzi
+            oT1lHl159vD+k9KqtG2u3k2Cc1EMevMs7Ip1rr5spgqEgoDG4yNWoj/x++ErNemI
+            HoVXbBPBgguWp4g9b2P405i7dO2GtAdWv009gxELCejbYGTOJaojNevLkI8flEDB
+            Sb+eeB7fkNuK3F1qd+YvJt/uhasXGdwsuXOiazk/Ce9uMIL7BFAPnhozukpyIunU
+            RSC/aJ7MkM00zlBo4syhtLET3+kptNbFprd/3lsrVNiQc3D2vBGmFCGZwQFugizS
+            5gFbUp/V6qg6DS2AgPk1i+vgmq0JealhmgP23N3JTLJtEJR9b3wIA8II5ZZCytGA
+            fPOlOVYv6jaoNyGWXj3AEpLk6PFWpxbl1HymCoYbFwxvjOJvMzG5AA==
+            =jfJp
             -----END PGP MESSAGE-----
-        fp: 0508677DD04952D06A943D5B4DC4116D360E3276
+          fp: 0508677DD04952D06A943D5B4DC4116D360E3276
     encrypted_regex: ^(users|data|stringData)$
-    version: 3.6.1
+    version: 3.7.2


### PR DESCRIPTION
Mlpipeline seems like it hardcodes the secret used for artifact passing
as shown here: https://github.com/kubeflow/kfp-tekton/blob/v1.2.1/backend/src/apiserver/template/tekton_template.go#L319

As such we must update the original "mlpipeline-minio-artificat" secret.

In this change we manually add the secret itself as whole in the overlay
without patching it instead.

Related: https://github.com/operate-first/community/issues/206