### PR TITLE
feat(service-catalog): Add github slugs to components

### DIFF
--- a/service-catalog/components/argo.yaml
+++ b/service-catalog/components/argo.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     operate-first.cloud/logo-url: https://cncf-branding.netlify.app/img/projects/argo/icon/color/argo-icon-color.png
     argocd/app-name: opf-app-of-apps-smaug
+    github.com/project-slug: operate-first/apps
   links:
     - url: https://www.operate-first.cloud/apps/content/argocd-gitops/README.html
       title: Support path

--- a/service-catalog/components/dex.yaml
+++ b/service-catalog/components/dex.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     operate-first.cloud/logo-url: https://cncf-branding.netlify.app/img/projects/dex/icon/color/dex-icon-color.png
     argocd/app-name: dex-smaug
+    github.com/project-slug: operate-first/apps
   links:
     - url: https://github.com/dexidp/dex
       title: Support path

--- a/service-catalog/components/grafana.yaml
+++ b/service-catalog/components/grafana.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     operate-first.cloud/logo-url: https://raw.githubusercontent.com/grafana/grafana/main/public/img/grafana_icon.svg
     argocd/app-name: grafana-smaug
+    github.com/project-slug: operate-first/apps
   links:
     - url: https://www.operate-first.cloud/apps/content/grafana/README.html
       title: Support path

--- a/service-catalog/components/observatorium.yaml
+++ b/service-catalog/components/observatorium.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     operate-first.cloud/logo-url: https://observatorium.io/logo.svg
     argocd/app-name: opf-observatorium-smaug
+    github.com/project-slug: operate-first/apps
   links:
     - url: https://www.operate-first.cloud/apps/content/observatorium/README.html
       title: Support path

--- a/service-catalog/components/odf.yaml
+++ b/service-catalog/components/odf.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     operate-first.cloud/logo-url: https://upload.wikimedia.org/wikipedia/commons/d/d8/Red_Hat_logo.svg
     argocd/app-name: odf-morty
+    github.com/project-slug: operate-first/apps
   links:
     - url: https://www.operate-first.cloud/apps/content/observatorium/README.html
       title: Support path

--- a/service-catalog/components/odh.yaml
+++ b/service-catalog/components/odh.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     operate-first.cloud/logo-url: https://raw.githubusercontent.com/opendatahub-io/opendatahub.io/master/assets/img/logos/datahub_mark_color-blkbg.png
     argocd/app-name: opendatahub-operator-smaug
+    github.com/project-slug: opendatahub-io/odh-manifests
   links:
     - url: https://www.operate-first.cloud/apps/content/odh/README.html
       title: Support path


### PR DESCRIPTION
Resolves [#44](https://github.com/operate-first/service-catalog/issues/44)
I am not sure whether to put `opearate-first/apps` in the `odh` component, since ArgoCD plugin references this repo, or leave it like this using `opendatahub-io/odh-manifests`.