### PR TITLE
feat(service-catalog): Add peribolos-as-a-service and probot-extensions to service catalog

### DIFF
--- a/service-catalog/all-components.yaml
+++ b/service-catalog/all-components.yaml
@@ -11,3 +11,5 @@ spec:
     - ./components/observatorium.yaml
     - ./components/odh.yaml
     - ./components/odf.yaml
+    - ./components/peribolos-as-a-service.yaml
+    - ./components/probot-extensions.yaml

--- a/service-catalog/components/peribolos-as-a-service.yaml
+++ b/service-catalog/components/peribolos-as-a-service.yaml
@@ -1,0 +1,27 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: Peribolos-as-a-service
+  description: Declarative GitHub Organization management via Peribolos as a service
+  annotations:
+    operate-first.cloud/logo-url: https://raw.githubusercontent.com/operate-first/peribolos-as-a-service/main/static/robot.png
+    argocd/app-name: peribolos-as-a-service-smaug
+    github.com/project-slug: operate-first/peribolos-as-a-service
+  links:
+    - url: https://github.com/apps/peribolos
+      title: GitHub App
+      icon: web
+    - url: https://github.com/operate-first/peribolos-as-a-service/issues/new
+      title: Support path
+      icon: user
+  tags:
+    - typescript
+    - probot-kubernetes
+    - probot-metrics
+spec:
+  type: service
+  lifecycle: production
+  owner: group:operate-first
+  system: system:operate-first-cloud
+  dependsOn:
+    - component:default/probot-extensions

--- a/service-catalog/components/probot-extensions.yaml
+++ b/service-catalog/components/probot-extensions.yaml
@@ -1,0 +1,29 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: Probot-extensions
+  description: Extensions to Probot App when run as a service
+  annotations:
+    operate-first.cloud/logo-url: https://raw.githubusercontent.com/operate-first/probot-extensions/main/static/robot.png
+    github.com/project-slug: operate-first/probot-extensions
+    backstage.io/adr-location: https://github.com/operate-first/probot-template/tree/main/docs/adrs
+  links:
+    - url: https://www.npmjs.com/package/@operate-first/probot-metrics
+      title: Metrics npm package
+      icon: web
+    - url: https://www.npmjs.com/package/@operate-first/probot-issue-form
+      title: Issue forms npm package
+      icon: web
+    - url: https://www.npmjs.com/package/@operate-first/probot-kubernetes
+      title: Kubernetes npm package
+      icon: web
+    - url: https://github.com/operate-first/peribolos-as-a-service/issues/new
+      title: Support path
+      icon: user
+  tags:
+    - typescript
+spec:
+  type: service
+  lifecycle: production
+  owner: group:operate-first
+  system: system:operate-first-cloud


### PR DESCRIPTION
Part of [#25](https://github.com/operate-first/service-catalog/issues/25)
Add two components to the service catalog:
- `Peribolos-as-a-service`
- `Probot-extensions`
 
A dependency is added:
- `Peribolos-as-a-service` is dependent on `Probot-extensions`

Add tags for `Peribolos-as-a-service` to show which probot extensions it is using.
