### PR TITLE
feat(service-catalog): Add clusterrolebinding and clusterrole required for k8s plugin in backstage

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/service-catalog-k8s-plugin/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/service-catalog-k8s-plugin/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: service-catalog-k8s-plugin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: service-catalog-k8s-plugin
+subjects:
+- kind: ServiceAccount
+  name: service-catalog-k8s-plugin
+  namespace: service-catalog

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/service-catalog-k8s-plugin/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/service-catalog-k8s-plugin/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/service-catalog-k8s-plugin/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/service-catalog-k8s-plugin/clusterrole.yaml
@@ -1,0 +1,58 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: service-catalog-k8s-plugin
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - services
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - watch
+  - list

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/service-catalog-k8s-plugin/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/service-catalog-k8s-plugin/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- clusterrole.yaml

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -122,6 +122,7 @@ resources:
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/node-labeler
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/oauth-token-access-review-opf-observatorium
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/scc-privileged-opf-ci-pipelines-aicoe-ci
+- ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/service-catalog-k8s-plugin
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/tekton-dashboard
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/vault-server-binding
 - ../../../../base/rbac.authorization.k8s.io/clusterroles/apirequest-count-read-cr
@@ -129,6 +130,7 @@ resources:
 - ../../../../base/rbac.authorization.k8s.io/clusterroles/moc-nfs-democratic-csi-node-cr
 - ../../../../base/rbac.authorization.k8s.io/clusterroles/node-labeler
 - ../../../../base/rbac.authorization.k8s.io/clusterroles/oauth-token-access-review
+- ../../../../base/rbac.authorization.k8s.io/clusterroles/service-catalog-k8s-plugin
 - ../../../../base/rbac.authorization.k8s.io/clusterroles/tekton-dashboard
 - ../../../../base/storage.k8s.io/csidrivers/org.democratic-csi.nfs
 - ../../../../base/storage.k8s.io/storageclasses/moc-nfs-csi


### PR DESCRIPTION
Part of [#12](https://github.com/operate-first/service-catalog/issues/12)

Backstage k8s plugin requires `clusterrole` for proper functionality. See docs [here](https://backstage.io/docs/features/kubernetes/configuration#role-based-access-control).