### PR TITLE
Add project admin and view options for strimzi.

### DIFF
--- a/cluster-scope/base/core/namespaces/kafka/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/kafka/kustomization.yaml
@@ -1,0 +1,7 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+namespace: kafka
+resources:
+    - namespace.yaml
+components:
+    - ../../../../components/project-admin-rolebindings/kafka-admins

--- a/cluster-scope/base/core/namespaces/kafka/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/kafka/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: kafka
+    annotations:
+        openshift.io/requester: os-climate

--- a/cluster-scope/base/core/namespaces/openshift-operators/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-operators/kustomization.yaml
@@ -1,5 +1,7 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-components:
-    - ../../../../components/project-edit-rolebindings/ocp-pipelines-sre
+apiVersion: kustomize.config.k8s.io/v1beta1
 namespace: openshift-operators
+components:
+    - ../../../../components/project-admin-rolebindings/openshift-operators-admin
+    - ../../../../components/project-edit-rolebindings/ocp-pipelines-sre
+    - ../../../../components/project-view-rolebindings/openshift-operators-view

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/strimzi-aggregate-to-admin/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/strimzi-aggregate-to-admin/clusterrole.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: strimzi-aggregate-to-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups:
+      - kafka.strimzi.io
+    resources:
+      - kafkabridges
+      - kafkaconnectors
+      - kafkaconnects
+      - kafkamirrormaker2s
+      - kafkamirrormakers
+      - kafkarebalances
+      - kafkas
+      - kafkatopics
+      - kafkausers
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/strimzi-aggregate-to-admin/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/strimzi-aggregate-to-admin/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrole.yaml

--- a/cluster-scope/base/user.openshift.io/groups/kafka-admins/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/kafka-admins/group.yaml
@@ -1,0 +1,5 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+    name: kafka-admins
+users: []

--- a/cluster-scope/base/user.openshift.io/groups/kafka-admins/kustomization.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/kafka-admins/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+    - group.yaml

--- a/cluster-scope/base/user.openshift.io/groups/openshift-operators-admin/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/openshift-operators-admin/group.yaml
@@ -1,0 +1,6 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+    name: openshift-operators-admin
+users:
+    - ""

--- a/cluster-scope/base/user.openshift.io/groups/openshift-operators-admin/kustomization.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/openshift-operators-admin/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+    - group.yaml

--- a/cluster-scope/base/user.openshift.io/groups/openshift-operators-view/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/openshift-operators-view/group.yaml
@@ -1,0 +1,6 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+    name: openshift-operators-view
+users:
+    - ""

--- a/cluster-scope/base/user.openshift.io/groups/openshift-operators-view/kustomization.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/openshift-operators-view/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+    - group.yaml

--- a/cluster-scope/components/project-admin-rolebindings/kafka-admins/kustomization.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/kafka-admins/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: Component
+apiVersion: kustomize.config.k8s.io/v1alpha1
+resources:
+    - rbac.yaml

--- a/cluster-scope/components/project-admin-rolebindings/kafka-admins/rbac.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/kafka-admins/rbac.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: namespace-admin-kafka-admins
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: admin
+subjects:
+    - apiGroup: rbac.authorization.k8s.io
+      kind: Group
+      name: kafka-admins

--- a/cluster-scope/components/project-admin-rolebindings/openshift-operators-admin/kustomization.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/openshift-operators-admin/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: Component
+apiVersion: kustomize.config.k8s.io/v1alpha1
+resources:
+    - rbac.yaml

--- a/cluster-scope/components/project-admin-rolebindings/openshift-operators-admin/rbac.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/openshift-operators-admin/rbac.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: namespace-admin-openshift-operators-admin
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: admin
+subjects:
+    - apiGroup: rbac.authorization.k8s.io
+      kind: Group
+      name: openshift-operators-admin

--- a/cluster-scope/components/project-view-rolebindings/openshift-operators-view/kustomization.yaml
+++ b/cluster-scope/components/project-view-rolebindings/openshift-operators-view/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: Component
+apiVersion: kustomize.config.k8s.io/v1alpha1
+resources:
+    - rbac.yaml

--- a/cluster-scope/components/project-view-rolebindings/openshift-operators-view/rbac.yaml
+++ b/cluster-scope/components/project-view-rolebindings/openshift-operators-view/rbac.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: namespace-view-openshift-operators-view
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: view
+subjects:
+    - apiGroup: rbac.authorization.k8s.io
+      kind: Group
+      name: openshift-operators-view

--- a/cluster-scope/overlays/prod/osc/osc-cl2/groups/kafka-admins.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/groups/kafka-admins.yaml
@@ -1,0 +1,7 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: kafka-admins
+users:
+  - caldeirav
+  - bryonbaker

--- a/cluster-scope/overlays/prod/osc/osc-cl2/groups/openshift-operators-admin.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/groups/openshift-operators-admin.yaml
@@ -1,0 +1,6 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: openshift-operators-admin
+users:
+  - ""

--- a/cluster-scope/overlays/prod/osc/osc-cl2/groups/openshift-operators-view.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/groups/openshift-operators-view.yaml
@@ -1,0 +1,6 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: openshift-operators-view
+users:
+  - bryonbaker

--- a/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
@@ -11,6 +11,8 @@ patchesStrategicMerge:
 - groups/kubeflow-admin.yaml
 - groups/odh-admin.yaml
 - groups/odh-users.yaml
+- groups/openshift-operators-admin.yaml
+- groups/openshift-operators-view.yaml
 - groups/pachyderm-admins.yaml
 - groups/seldon-admin.yaml
 - operators.coreos.com/patches/nfd-sub-patch.yaml
@@ -28,6 +30,7 @@ resources:
 - ../../../../base/core/namespaces/odh-trino
 - ../../../../base/core/namespaces/openmetadata
 - ../../../../base/core/namespaces/openshift-nfd
+- ../../../../base/core/namespaces/openshift-operators
 - ../../../../base/core/namespaces/opf-monitoring
 - ../../../../base/core/namespaces/nvidia-gpu-operator
 - ../../../../base/core/namespaces/sostrades
@@ -42,12 +45,15 @@ resources:
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners
 - ../../../../base/rbac.authorization.k8s.io/clusterroles/acme-operator
 - ../../../../base/rbac.authorization.k8s.io/clusterroles/pytorchjobs-create-aggregate-to-admin
+- ../../../../base/rbac.authorization.k8s.io/clusterroles/strimzi-aggregate-to-admin
 - ../../../../base/user.openshift.io/groups/cluster-admins
 - ../../../../base/user.openshift.io/groups/cluster-readers
 - ../../../../base/user.openshift.io/groups/inception-admins
 - ../../../../base/user.openshift.io/groups/kubeflow-admin
 - ../../../../base/user.openshift.io/groups/odh-admin
 - ../../../../base/user.openshift.io/groups/odh-users
+- ../../../../base/user.openshift.io/groups/openshift-operators-admin
+- ../../../../base/user.openshift.io/groups/openshift-operators-view
 - ../../../../base/user.openshift.io/groups/pachyderm-admins
 - ../../../../base/user.openshift.io/groups/seldon-admin
 - ../../../../base/user.openshift.io/groups/sostrades

--- a/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
@@ -8,6 +8,7 @@ patchesStrategicMerge:
 - groups/cluster-admins.yaml
 - groups/cluster-readers.yaml
 - groups/inception-admins.yaml
+- groups/kafka-admins.yaml
 - groups/kubeflow-admin.yaml
 - groups/odh-admin.yaml
 - groups/odh-users.yaml
@@ -23,6 +24,7 @@ resources:
 - ../../../../base/core/namespaces/dex
 - ../../../../base/core/namespaces/dex-secondary
 - ../../../../base/core/namespaces/inception
+- ../../../../base/core/namespaces/kafka
 - ../../../../base/core/namespaces/kubeflow
 - ../../../../base/core/namespaces/odh-jupyterhub
 - ../../../../base/core/namespaces/odh-seldon
@@ -49,6 +51,7 @@ resources:
 - ../../../../base/user.openshift.io/groups/cluster-admins
 - ../../../../base/user.openshift.io/groups/cluster-readers
 - ../../../../base/user.openshift.io/groups/inception-admins
+- ../../../../base/user.openshift.io/groups/kafka-admins
 - ../../../../base/user.openshift.io/groups/kubeflow-admin
 - ../../../../base/user.openshift.io/groups/odh-admin
 - ../../../../base/user.openshift.io/groups/odh-users

--- a/kafka/overlays/osc/osc-cl2/kustomization.yaml
+++ b/kafka/overlays/osc/osc-cl2/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []


### PR DESCRIPTION
The PR allows for a role in osc-cl2 that will grant all project admins
the ability to create kafka resources in any namespace they have project
admin in. It also allows for a view/admin group, wherein if a user is
added, they have view/admin permissions to openshift-operators
namespace respectively.

These roles are added to base so they may be used elsewhere going
forward.

The commit also sets up kafka structure for osc-cl2 for future
manifests.

Furthers: https://github.com/os-climate/os_c_data_commons/issues/191 
closes: https://github.com/operate-first/support/issues/613