### PR TITLE
Add aiops tools workshop manifests.

### DIFF
--- a/cluster-scope/base/core/namespaces/aiops-tools-workshop/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/aiops-tools-workshop/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
     - namespace.yaml
 components:
     - ../../../../components/project-admin-rolebindings/aiops-tools-workshop-admins
+    - ../../../../components/project-view-rolebindings/aiops-tools-workshop-view

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/seldon-deployer/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/seldon-deployer/clusterrole.yaml
@@ -1,0 +1,13 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: seldon-deployer
+rules:
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - ClusterServiceVersion
+  verbs:
+  - get
+  - watch
+  - list

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/seldon-deployer/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/seldon-deployer/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- clusterrole.yaml

--- a/cluster-scope/components/project-view-rolebindings/aiops-tools-workshop-view/kustomization.yaml
+++ b/cluster-scope/components/project-view-rolebindings/aiops-tools-workshop-view/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: Component
+apiVersion: kustomize.config.k8s.io/v1alpha1
+resources:
+    - rbac.yaml

--- a/cluster-scope/components/project-view-rolebindings/aiops-tools-workshop-view/rbac.yaml
+++ b/cluster-scope/components/project-view-rolebindings/aiops-tools-workshop-view/rbac.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: namespace-view-aiops-tools-workshop-view
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: view
+subjects:
+    - apiGroup: rbac.authorization.k8s.io
+      kind: Group
+      name: aiops-tools-workshop-attendees

--- a/workshops/aiops-tools/README.md
+++ b/workshops/aiops-tools/README.md
@@ -1,0 +1,30 @@
+# AIOPS Tools Workshops
+
+Tools included in this folder:
+
+* ODH Components
+    * Jupyterhub
+    * Trino
+    * Superset
+    * Seldon
+* ODH Operator
+* Dex
+* Cloudbeaver
+* KFP Tekton
+
+Dependencies:
+* ACME
+* ODF (or an external s3 bucket)
+  * Additional Jupyterhub [clusterrolebinding][crbjh]
+* External Secrets Operator
+* Vault
+* Openshift Pipelines with [enable-custom-tasks][kfp-tekton] feature flags enabled.
+
+
+> Note Vault / ESO dependency can be avoided by deploying secrets directly.
+
+Manifests are bundled using [Kustomize][].
+
+[crbjh]: base/odh-operator/jupyterhub-clusterrolebinding.yaml
+[Kustomize]: https://kustomize.io/
+[kfp-tekton]: https://github.com/kubeflow/kfp-tekton/blob/master/guides/kfp_tekton_install.md#standalone-kubeflow-pipelines-with-tekton-backend-deployment

--- a/workshops/aiops-tools/base/administration/groups/aiops-tools-workshop-attendees.yaml
+++ b/workshops/aiops-tools/base/administration/groups/aiops-tools-workshop-attendees.yaml
@@ -1,0 +1,5 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: aiops-tools-workshop-attendees
+users: []

--- a/workshops/aiops-tools/base/administration/groups/kustomization.yaml
+++ b/workshops/aiops-tools/base/administration/groups/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../../cluster-scope/base/user.openshift.io/groups/aiops-tools-workshop-admins
+  - aiops-tools-workshop-attendees.yaml

--- a/workshops/aiops-tools/base/administration/kustomization.yaml
+++ b/workshops/aiops-tools/base/administration/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- groups
+- rbac
+- namespace

--- a/workshops/aiops-tools/base/administration/namespace/kustomization.yaml
+++ b/workshops/aiops-tools/base/administration/namespace/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../../cluster-scope/base/core/namespaces/aiops-tools-workshop

--- a/workshops/aiops-tools/base/administration/rbac/attendee-role.yaml
+++ b/workshops/aiops-tools/base/administration/rbac/attendee-role.yaml
@@ -1,0 +1,37 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: aiops-tools-workshop-attendees
+rules:
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - ClusterServiceVersion
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - machinelearning.seldon.io
+    resources:
+      - seldondeployments
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete

--- a/workshops/aiops-tools/base/administration/rbac/attendee-rolebinding.yaml
+++ b/workshops/aiops-tools/base/administration/rbac/attendee-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: aiops-tools-workshop-attendees
+roleRef:
+  kind: Role
+  name: aiops-tools-workshop-attendees
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: Group
+    name: aiops-tools-workshop-attendees
+    apiGroup: rbac.authorization.k8s.io

--- a/workshops/aiops-tools/base/administration/rbac/kustomization.yaml
+++ b/workshops/aiops-tools/base/administration/rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - attendee-role.yaml
+  - attendee-rolebinding.yaml

--- a/workshops/aiops-tools/base/cloudbeaver/kustomization.yaml
+++ b/workshops/aiops-tools/base/cloudbeaver/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../cloudbeaver/base

--- a/workshops/aiops-tools/base/dex/kustomization.yaml
+++ b/workshops/aiops-tools/base/dex/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: aiops-tools-workshop
+resources:
+  - ../../../../dex/base

--- a/workshops/aiops-tools/base/kfp-tekton/kustomization.yaml
+++ b/workshops/aiops-tools/base/kfp-tekton/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../cluster-scope/bundles/kfp-tekton
+  - ../../../../kfp-tekton/base
+
+# Add in overlay
+#  - secrets

--- a/workshops/aiops-tools/base/kfp-tekton/secrets/kustomization.yaml
+++ b/workshops/aiops-tools/base/kfp-tekton/secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generatorOptions:
+  disableNameSuffixHash: true

--- a/workshops/aiops-tools/base/kfp-tekton/secrets/mlpipeline-minio-artifact.enc.yaml
+++ b/workshops/aiops-tools/base/kfp-tekton/secrets/mlpipeline-minio-artifact.enc.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: mlpipeline-minio-artifact
+    namespace: kubeflow
+stringData:
+
+    # Minio will create a new bucket accessible via these credentials
+    accesskey: "1234"
+    secretkey: "1234"
+
+    # The following are used my ml pipeline to connect to the minio bucket
+    # Everything can be kept as is, accept the access/secret keys which
+    # should match the credentials used above.
+    OBJECTSTORECONFIG_HOST: minio-service.kubeflow
+    OBJECTSTORECONFIG_PORT: "9000"
+    OBJECTSTORECONFIG_SECURE: "false"
+    OBJECTSTORECONFIG_BUCKETNAME: mlpipeline
+    OBJECTSTORECONFIG_PIPELINEPATH: mlpipeline
+
+    OBJECTSTORECONFIG_ACCESSKEY: "1234"
+    OBJECTSTORECONFIG_SECRETACCESSKEY: "1234"

--- a/workshops/aiops-tools/base/odh-configs/jupyterhub/container-sizes.yaml
+++ b/workshops/aiops-tools/base/odh-configs/jupyterhub/container-sizes.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: odh-jupyterhub-sizes
+  labels:
+    jupyterhub: singleuser-profiles
+data:
+  jupyterhub-singleuser-profiles.yaml: |
+    sizes:
+    - name: Workshop
+      resources:
+        requests:
+          memory: 6Gi
+          cpu: 1m
+        limits:
+          memory: 12Gi
+          cpu: 4

--- a/workshops/aiops-tools/base/odh-configs/jupyterhub/jupyterhub-groups-configmap.yaml
+++ b/workshops/aiops-tools/base/odh-configs/jupyterhub/jupyterhub-groups-configmap.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: jupyterhub
+  name: jupyterhub-default-groups-config
+data:
+  admin_groups: "aiops-tools-workshop-admins"
+  allowed_groups: "aiops-tools-workshop-attendees"

--- a/workshops/aiops-tools/base/odh-configs/jupyterhub/jupyterhub-singleuser-profiles-configmap.yaml
+++ b/workshops/aiops-tools/base/odh-configs/jupyterhub/jupyterhub-singleuser-profiles-configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jupyter-singleuser-profiles
+data:
+  jupyterhub-singleuser-profiles.yaml: |
+      profiles:
+      - name: globals
+        env:
+          - name: S3_ENDPOINT_URL
+            value:
+        resources:
+          requests:
+            memory: 6Gi
+            cpu: 1m
+          limits:
+            memory: 12Gi
+            cpu: 4

--- a/workshops/aiops-tools/base/odh-configs/jupyterhub/kustomization.yaml
+++ b/workshops/aiops-tools/base/odh-configs/jupyterhub/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ocp-ci-analysis.yaml
+  - jupyterhub-singleuser-profiles-configmap.yaml
+  - container-sizes.yaml
+  - jupyterhub-groups-configmap.yaml

--- a/workshops/aiops-tools/base/odh-configs/jupyterhub/ocp-ci-analysis.yaml
+++ b/workshops/aiops-tools/base/odh-configs/jupyterhub/ocp-ci-analysis.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url:
+      "https://github.com/aicoe-aiops/ocp-ci-analysis"
+    opendatahub.io/notebook-image-name:
+      "Openshift CI Analysis Notebook Image"
+    opendatahub.io/notebook-image-desc:
+      "Jupyter notebook image for the OpenShift CI Analysis project"
+  name: ocp-ci-analysis
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - annotations:
+        openshift.io/imported-from: quay.io/aicoe/ocp-ci-analysis
+      from:
+        kind: DockerImage
+        name: quay.io/aicoe/ocp-ci-analysis:latest
+      importPolicy:
+        scheduled: true
+      name: "latest"

--- a/workshops/aiops-tools/base/odh-configs/kustomization.yaml
+++ b/workshops/aiops-tools/base/odh-configs/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- jupyterhub
+- superset
+- trino

--- a/workshops/aiops-tools/base/odh-configs/superset/custom_sso_security_manager.py
+++ b/workshops/aiops-tools/base/odh-configs/superset/custom_sso_security_manager.py
@@ -1,0 +1,25 @@
+import logging
+from superset.security import SupersetSecurityManager
+
+
+class CustomSsoSecurityManager(SupersetSecurityManager):
+
+    def oauth_user_info(self, provider, response=None):
+        logging.debug("Oauth2 provider: {0}.".format(provider))
+        if provider == 'dex':
+            # As example, this line request a GET to base_url + '/' + userDetails with Bearer  Authentication,
+            # and expects that authorization server checks the token, and response with user details
+            me = self.appbuilder.sm.oauth_remotes[provider].get('userinfo')
+            logging.debug("response: {0}".format(me))
+            me = me.json()
+            logging.debug("user_data: {0}".format(me))
+            logging.debug("groups: {0}".format(me.get("groups", [])))
+            return {
+                'name': me['email'],
+                'email': me['email'],
+                'id': me['email'],
+                'username': me['email'],
+                'first_name': '',
+                'last_name': '',
+                "role_keys": me.get("groups", []),
+            }

--- a/workshops/aiops-tools/base/odh-configs/superset/kustomization.yaml
+++ b/workshops/aiops-tools/base/odh-configs/superset/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: superset-config-py
+    files:
+      - superset_config.py
+      - custom_sso_security_manager.py

--- a/workshops/aiops-tools/base/odh-configs/superset/superset_config.py
+++ b/workshops/aiops-tools/base/odh-configs/superset/superset_config.py
@@ -1,0 +1,50 @@
+import os
+from flask_appbuilder.security.manager import AUTH_OAUTH
+
+MAPBOX_API_KEY = os.getenv('MAPBOX_API_KEY', '')
+SQLALCHEMY_DATABASE_URI = "postgresql://{}:{}@supersetdb:5432/{}".format(os.environ['POSTGRESQL_USERNAME'], os.environ['POSTGRESQL_PASSWORD'], os.environ['POSTGRESQL_DATABASE'])
+SQLALCHEMY_TRACK_MODIFICATIONS = True
+SECRET_KEY = os.getenv('SUPERSET_SECRET_KEY', '$(SUPERSET_SECRET_KEY)')
+DATA_DIR = '/var/lib/superset'
+LOG_LEVEL = 'INFO'
+FEATURE_FLAGS = {
+    'ENABLE_TEMPLATE_PROCESSING': True,
+}
+
+AUTH_TYPE = AUTH_OAUTH
+AUTH_USER_REGISTRATION = True
+AUTH_USER_REGISTRATION_ROLE = "Public"
+
+# maps OCP groups (retrieved from role_keys) to Superset roles
+# NOTE: A user can not have a role mapped to them twice
+# Thi will result in a SQL INSERT constraint violation in postgres
+AUTH_ROLES_MAPPING = {
+    "aiops-tools-workshop-admins": ["Admin"],
+    "aiops-tools-workshop-attendees": ["Admin"],
+}
+# if we should replace ALL the user's roles each login, or only on registration
+AUTH_ROLES_SYNC_AT_LOGIN = True
+
+# force users to re-auth after 30min of inactivity (to keep roles in sync)
+PERMANENT_SESSION_LIFETIME = 1800
+OAUTH_PROVIDERS = [
+    {'name': 'dex',
+     'token_key': 'access_token',
+     'icon': 'fa-github',
+     'remote_app': {
+         'client_id': 'superset',
+         'client_secret': SECRET_KEY,
+         'client_kwargs': {
+             'scope': 'openid email groups profile offline_access'
+         },
+         'api_base_url': 'https://dex-aiops-tools-workshop.apps.smaug.na.operate-first.cloud/userinfo',
+         'access_token_url': 'https://dex-aiops-tools-workshop.apps.smaug.na.operate-first.cloud/token',
+         'authorize_url': 'https://dex-aiops-tools-workshop.apps.smaug.na.operate-first.cloud/auth'
+     }
+     }
+]
+
+WTF_CSRF_ENABLED = False
+
+from custom_sso_security_manager import CustomSsoSecurityManager
+CUSTOM_SECURITY_MANAGER = CustomSsoSecurityManager

--- a/workshops/aiops-tools/base/odh-configs/trino/configs/catalogs/aiops_tools_workshop.properties
+++ b/workshops/aiops-tools/base/odh-configs/trino/configs/catalogs/aiops_tools_workshop.properties
@@ -1,0 +1,14 @@
+connector.name=hive-hadoop2
+hive.metastore.uri=thrift://hive-metastore-aiops-tools-workshop:9083
+hive.s3.endpoint=${ENV:AIOPS_TOOLS_WORKSHOP_S3_ENDPOINT_URL_PREFIX}${ENV:AIOPS_TOOLS_WORKSHOP_S3_ENDPOINT}
+hive.s3.signer-type=S3SignerType
+hive.s3.path-style-access=true
+hive.s3.staging-directory=/tmp
+hive.s3.ssl.enabled=false
+hive.s3.sse.enabled=false
+hive.allow-drop-table=true
+hive.parquet.use-column-names=true
+hive.recursive-directories=true
+hive.non-managed-table-writes-enabled=true
+hive.s3.aws-access-key=${ENV:AIOPS_TOOLS_WORKSHOP_AWS_ACCESS_KEY_ID}
+hive.s3.aws-secret-key=${ENV:AIOPS_TOOLS_WORKSHOP_AWS_SECRET_ACCESS_KEY}

--- a/workshops/aiops-tools/base/odh-configs/trino/configs/config-coordinator.properties
+++ b/workshops/aiops-tools/base/odh-configs/trino/configs/config-coordinator.properties
@@ -1,0 +1,16 @@
+coordinator=true
+node-scheduler.include-coordinator=false
+discovery.uri=http://localhost:8080
+web-ui.authentication.type=oauth2
+http-server.authentication.type=PASSWORD,oauth2
+http-server.process-forwarded=true
+http-server.http.port=8080
+http-server.authentication.oauth2.issuer=${ENV:DEX_ROUTE}
+http-server.authentication.oauth2.auth-url=${ENV:DEX_ROUTE}/auth
+http-server.authentication.oauth2.token-url=${ENV:DEX_ROUTE}/token
+http-server.authentication.oauth2.jwks-url=${ENV:DEX_ROUTE}/keys
+http-server.authentication.oauth2.userinfo-url=${ENV:DEX_ROUTE}/userinfo
+http-server.authentication.oauth2.client-id=trino
+http-server.authentication.oauth2.client-secret=${ENV:TRINO_SECRET}
+http-server.authentication.oauth2.scopes=openid,groups,email
+http-server.authentication.oauth2.principal-field=email

--- a/workshops/aiops-tools/base/odh-configs/trino/configs/config-worker.properties
+++ b/workshops/aiops-tools/base/odh-configs/trino/configs/config-worker.properties
@@ -1,0 +1,3 @@
+coordinator=false
+http-server.http.port=8080
+discovery.uri=http://trino-service:8080

--- a/workshops/aiops-tools/base/odh-configs/trino/configs/jmx.properties
+++ b/workshops/aiops-tools/base/odh-configs/trino/configs/jmx.properties
@@ -1,0 +1,1 @@
+connector.name=jmx

--- a/workshops/aiops-tools/base/odh-configs/trino/configs/jvm-coordinator.config
+++ b/workshops/aiops-tools/base/odh-configs/trino/configs/jvm-coordinator.config
@@ -1,0 +1,14 @@
+-server
+-XX:InitialRAMPercentage=50.0
+-XX:MaxRAMPercentage=75.0
+-XX:-UseBiasedLocking
+-XX:+UseG1GC
+-XX:G1HeapRegionSize=32M
+-XX:+ExplicitGCInvokesConcurrent
+-XX:+ExitOnOutOfMemoryError
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:ReservedCodeCacheSize=512M
+-XX:PerMethodRecompilationCutoff=10000
+-XX:PerBytecodeRecompilationCutoff=10000
+-Djdk.attach.allowAttachSelf=true
+-Djdk.nio.maxCachedBufferSize=2000000

--- a/workshops/aiops-tools/base/odh-configs/trino/configs/jvm-worker.config
+++ b/workshops/aiops-tools/base/odh-configs/trino/configs/jvm-worker.config
@@ -1,0 +1,14 @@
+-server
+-XX:InitialRAMPercentage=50.0
+-XX:MaxRAMPercentage=75.0
+-XX:-UseBiasedLocking
+-XX:+UseG1GC
+-XX:G1HeapRegionSize=32M
+-XX:+ExplicitGCInvokesConcurrent
+-XX:+ExitOnOutOfMemoryError
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:ReservedCodeCacheSize=512M
+-XX:PerMethodRecompilationCutoff=10000
+-XX:PerBytecodeRecompilationCutoff=10000
+-Djdk.attach.allowAttachSelf=true
+-Djdk.nio.maxCachedBufferSize=2000000

--- a/workshops/aiops-tools/base/odh-configs/trino/configs/kustomization.yaml
+++ b/workshops/aiops-tools/base/odh-configs/trino/configs/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: trino-catalog
+    files:
+      - jmx.properties
+      - catalogs/aiops_tools_workshop.properties
+  - name: trino-configfiles
+    files:
+      - config-coordinator.properties
+      - config-worker.properties
+      - jvm-coordinator.config
+      - jvm-worker.config
+      - log.properties
+      - node.properties
+      - password-authenticator.properties
+      - password.db

--- a/workshops/aiops-tools/base/odh-configs/trino/configs/log.properties
+++ b/workshops/aiops-tools/base/odh-configs/trino/configs/log.properties
@@ -1,0 +1,1 @@
+io.trino=INFO

--- a/workshops/aiops-tools/base/odh-configs/trino/configs/node.properties
+++ b/workshops/aiops-tools/base/odh-configs/trino/configs/node.properties
@@ -1,0 +1,2 @@
+node.environment=trino
+node.data-dir=/tmp/data/trino

--- a/workshops/aiops-tools/base/odh-configs/trino/configs/password-authenticator.properties
+++ b/workshops/aiops-tools/base/odh-configs/trino/configs/password-authenticator.properties
@@ -1,0 +1,2 @@
+password-authenticator.name=file
+file.password-file=/etc/trino/password.db

--- a/workshops/aiops-tools/base/odh-configs/trino/configs/password.db
+++ b/workshops/aiops-tools/base/odh-configs/trino/configs/password.db
@@ -1,0 +1,1 @@
+admin:$2y$10$hqQ3OuC6FmBHw3tNC.uvfeJ1lRxJlWrN0GJ77ptEVhCdeWZ2o6TpC

--- a/workshops/aiops-tools/base/odh-configs/trino/hive-metastores/aiops_tools_workshop/kustomization.yaml
+++ b/workshops/aiops-tools/base/odh-configs/trino/hive-metastores/aiops_tools_workshop/kustomization.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../../../../kfdefs/base/trino/hive-metastore-template
+commonAnnotations:
+  secret.reloader.stakater.com/reload: "s3buckets"
+patches:
+  - target:
+      kind: Service
+      name: catalog-name
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: hive-metastore-aiops-tools-workshop
+      - op: replace
+        path: /metadata/labels/trino-catalog
+        value: hive-metastore-aiops-tools-workshop
+      - op: replace
+        path: /spec/selector/trino-catalog
+        value: hive-metastore-aiops-tools-workshop
+  - target:
+      kind: StatefulSet
+      name: catalog-name
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: hive-metastore-aiops-tools-workshop
+      - op: replace
+        path: /metadata/labels/trino-catalog
+        value: hive-metastore-aiops-tools-workshop
+      - op: replace
+        path: /spec/selector/matchLabels/trino-catalog
+        value: hive-metastore-aiops-tools-workshop
+      - op: replace
+        path: /spec/serviceName
+        value: hive-metastore-aiops-tools-workshop
+      - op: replace
+        path: /spec/template/metadata/labels/trino-catalog
+        value: hive-metastore-aiops-tools-workshop
+      - op: replace
+        path: /spec/selector/matchLabels/trino-catalog
+        value: hive-metastore-aiops-tools-workshop
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: S3_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              key: AIOPS_TOOLS_WORKSHOP_S3_ENDPOINT
+              name: s3buckets
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: S3_ENDPOINT_URL_PREFIX
+          valueFrom:
+            secretKeyRef:
+              key: AIOPS_TOOLS_WORKSHOP_S3_ENDPOINT_URL_PREFIX
+              name: s3buckets
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: AIOPS_TOOLS_WORKSHOP_AWS_ACCESS_KEY_ID
+              name: s3buckets
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AIOPS_TOOLS_WORKSHOP_AWS_SECRET_ACCESS_KEY
+              name: s3buckets
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: S3_BUCKET_NAME
+          valueFrom:
+            secretKeyRef:
+              key: AIOPS_TOOLS_WORKSHOP_BUCKET
+              name: s3buckets
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: S3_DATA_DIR
+          value: "data"

--- a/workshops/aiops-tools/base/odh-configs/trino/hive-metastores/kustomization.yaml
+++ b/workshops/aiops-tools/base/odh-configs/trino/hive-metastores/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - aiops_tools_workshop

--- a/workshops/aiops-tools/base/odh-configs/trino/kustomization.yaml
+++ b/workshops/aiops-tools/base/odh-configs/trino/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- configs
+- hive-metastores
+- obcs

--- a/workshops/aiops-tools/base/odh-configs/trino/obcs/aiops-tools-workshop.yaml
+++ b/workshops/aiops-tools/base/odh-configs/trino/obcs/aiops-tools-workshop.yaml
@@ -1,0 +1,10 @@
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: aiops-tools-workshop-2
+spec:
+  additionalConfig:
+    maxSize: 60G
+  bucketName: aiops-tools-workshop-2
+  objectBucketName: aiops-tools-workshop-2
+  storageClassName: openshift-storage.noobaa.io

--- a/workshops/aiops-tools/base/odh-configs/trino/obcs/kustomization.yaml
+++ b/workshops/aiops-tools/base/odh-configs/trino/obcs/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: opf-trino
+resources:
+  - aiops-tools-workshop.yaml

--- a/workshops/aiops-tools/base/odh-kfdefs/kfdef.yaml
+++ b/workshops/aiops-tools/base/odh-kfdefs/kfdef.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  name: opendatahub
+spec:
+  applications:
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-common
+      name: odh-common
+
+    # JupyterHub
+    - kustomizeConfig:
+        overlays: []
+        parameters:
+          - name: notebook_destination
+            value: aiops-tools-workshop
+          - name: s3_endpoint_url
+            value: s3.odh.com
+        repoRef:
+          name: manifests
+          path: jupyterhub/jupyterhub
+      name: jupyterhub
+
+    # Superset
+    - kustomizeConfig:
+        parameters:
+          # Note: The admin username is admin
+          - name: superset_memory_requests
+            value: 8Gi
+          - name: superset_memory_limits
+            value: 16Gi
+          - name: superset_cpu_requests
+            value: '4'
+          - name: superset_cpu_limits
+            value: '6'
+          - name: superset_secret
+            value: superset-custom
+          - name: superset_db_secret
+            value: superset-db-custom
+        repoRef:
+          name: manifests
+          path: superset
+      name: superset
+
+    # Trino
+    - kustomizeConfig:
+        parameters:
+          - name: trino_memory_request
+            value: 8Gi
+          - name: trino_memory_limit
+            value: 16Gi
+          - name: trino_cpu_request
+            value: "4"
+          - name: trino_cpu_limit
+            value: "8"
+        repoRef:
+          name: manifests
+          path: trino
+      name: trino
+
+    # Seldon
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odhseldon/cluster
+      name: odhseldon
+
+  repos:
+    - name: manifests
+      uri: "https://github.com/operate-first/odh-manifests/tarball/aiops-tools-workshop-v1.1.2"
+  version: v1.1.2

--- a/workshops/aiops-tools/base/odh-kfdefs/kustomization.yaml
+++ b/workshops/aiops-tools/base/odh-kfdefs/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kfdef.yaml

--- a/workshops/aiops-tools/base/odh-operator/jupyterhub-clusterrolebinding.yaml
+++ b/workshops/aiops-tools/base/odh-operator/jupyterhub-clusterrolebinding.yaml
@@ -5,15 +5,6 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: jupyterhub-hub
-    namespace: opf-jupyterhub
-  - kind: ServiceAccount
-    name: jupyterhub-hub
-    namespace: opf-jupyterhub-stage
-  - kind: ServiceAccount
-    name: jupyterhub-hub
-    namespace: ds-ml-workflows-ws
-  - kind: ServiceAccount
-    name: jupyterhub-hub
     namespace: aiops-tools-workshop
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/workshops/aiops-tools/base/odh-operator/kustomization.yaml
+++ b/workshops/aiops-tools/base/odh-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../odh-operator/base
+  - ../../../../cluster-scope/bundles/opendatahub-operator-manual
+  - jupyterhub-clusterrolebinding.yaml

--- a/workshops/aiops-tools/base/openshift-pipelines/kustomization.yaml
+++ b/workshops/aiops-tools/base/openshift-pipelines/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../cluster-scope/bundles/openshift-pipelines

--- a/workshops/aiops-tools/smaug/configmaps/files/config.yaml
+++ b/workshops/aiops-tools/smaug/configmaps/files/config.yaml
@@ -1,0 +1,41 @@
+issuer: https://dex-aiops-tools-workshop.apps.smaug.na.operate-first.cloud
+
+storage:
+  type: memory
+
+web:
+  http: "0.0.0.0:5556"
+
+grpc:
+  addr: "0.0.0.0:5557"
+
+telemetry:
+  http: "0.0.0.0:5558"
+
+oauth2:
+  skipApprovalScreen: true
+
+staticClients:
+  - id: superset
+    name: Superset
+    redirectURIs:
+      - https://superset-aiops-tools-workshop.apps.smaug.na.operate-first.cloud/oauth-authorized/dex
+      - http://superset-aiops-tools-workshop.apps.smaug.na.operate-first.cloud/oauth-authorized/dex
+    secretEnv: SUPERSET_SECRET
+
+  - id: trino
+    name: Trino
+    redirectURIs:
+      - https://trino-aiops-tools-workshop.apps.smaug.na.operate-first.cloud/oauth2/callback
+    secretEnv: TRINO_SECRET
+connectors:
+  - type: openshift
+    id: openshift
+    name: OpenShift
+    config:
+      issuer: https://kubernetes.default.svc
+      clientID: system:serviceaccount:aiops-tools-workshop:dex
+      clientSecret: $OPENSHIFT_CLIENT_SECRET
+      redirectURI: https://dex-aiops-tools-workshop.apps.smaug.na.operate-first.cloud/callback
+      groups:
+        - system:authenticated

--- a/workshops/aiops-tools/smaug/configmaps/kustomization.yaml
+++ b/workshops/aiops-tools/smaug/configmaps/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - files:
+      - files/config.yaml
+    name: dex
+commonAnnotations:
+  kustomize.config.k8s.io/behavior: replace

--- a/workshops/aiops-tools/smaug/externalsecrets/file-auth-secret.yaml
+++ b/workshops/aiops-tools/smaug/externalsecrets/file-auth-secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: file-auth-secret
+spec:
+    # Specified in base/trino/configs/password.db
+    # https://trino.io/docs/current/security/password-file.html#creating-a-password-file
+    dataFrom:
+        - extract:
+              key: moc/smaug/aiops-tools-workshop/file-auth-secret
+    secretStoreRef:
+        kind: SecretStore
+        name: opf-vault-store
+    target:
+        name: file-auth-secret
+        template:
+            engineVersion: v2

--- a/workshops/aiops-tools/smaug/externalsecrets/kustomization.yaml
+++ b/workshops/aiops-tools/smaug/externalsecrets/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - file-auth-secret.yaml
+  - postgres-dbs.yaml
+  - s3buckets.yaml
+  - superset.yaml
+  - supersetdb.yaml
+  - trino-oauth.yaml

--- a/workshops/aiops-tools/smaug/externalsecrets/postgres-dbs.yaml
+++ b/workshops/aiops-tools/smaug/externalsecrets/postgres-dbs.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: postgres-dbs
+spec:
+    dataFrom:
+        - extract:
+              key: moc/smaug/aiops-tools-workshop/postgres-dbs
+    secretStoreRef:
+        kind: SecretStore
+        name: opf-vault-store
+    target:
+        name: postgres-dbs
+        template:
+            engineVersion: v2

--- a/workshops/aiops-tools/smaug/externalsecrets/s3buckets.yaml
+++ b/workshops/aiops-tools/smaug/externalsecrets/s3buckets.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: s3buckets
+spec:
+    dataFrom:
+        - extract:
+              key: moc/smaug/aiops-tools-workshop/s3buckets
+    secretStoreRef:
+        kind: SecretStore
+        name: opf-vault-store
+    target:
+        name: s3buckets
+        template:
+            engineVersion: v2

--- a/workshops/aiops-tools/smaug/externalsecrets/superset.yaml
+++ b/workshops/aiops-tools/smaug/externalsecrets/superset.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: superset-custom
+spec:
+    dataFrom:
+        - extract:
+              key: moc/smaug/aiops-tools-workshop/superset-custom
+    secretStoreRef:
+        kind: SecretStore
+        name: opf-vault-store
+    target:
+        name: superset-custom
+        template:
+            engineVersion: v2

--- a/workshops/aiops-tools/smaug/externalsecrets/supersetdb.yaml
+++ b/workshops/aiops-tools/smaug/externalsecrets/supersetdb.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: supersetdb
+spec:
+    dataFrom:
+        - extract:
+              key: moc/smaug/aiops-tools-workshop/supersetdb
+    secretStoreRef:
+        kind: SecretStore
+        name: opf-vault-store
+    target:
+        name: supersetdb
+        template:
+            engineVersion: v2

--- a/workshops/aiops-tools/smaug/externalsecrets/trino-oauth.yaml
+++ b/workshops/aiops-tools/smaug/externalsecrets/trino-oauth.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: trino-oauth
+spec:
+    dataFrom:
+        - extract:
+              key: moc/smaug/aiops-tools-workshop/trino-oauth
+    secretStoreRef:
+        kind: SecretStore
+        name: opf-vault-store
+    target:
+        name: trino-oauth
+        template:
+            engineVersion: v2

--- a/workshops/aiops-tools/smaug/kustomization.yaml
+++ b/workshops/aiops-tools/smaug/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: aiops-tools-workshop
+resources:
+  - ../base/administration/rbac
+  - ../base/odh-configs
+  - ../base/odh-kfdefs
+  - ../base/cloudbeaver
+  - ../base/dex
+  - configmaps
+  - externalsecrets
+
+# Already included in smaug via other apps
+#  - ../base/administration/groups
+#  - ../base/administration/namespace
+#  - ../base/kfp-tekton
+#  - ../base/odh-operator
+#  - ../base/openshift-pipelines
+#  - ../base/rbac
+
+patchesStrategicMerge:
+  - patches/dex-clients_patch.yaml
+  - patches/cb_resources_patch.yaml

--- a/workshops/aiops-tools/smaug/patches/cb_resources_patch.yaml
+++ b/workshops/aiops-tools/smaug/patches/cb_resources_patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudbeaver
+spec:
+  template:
+    spec:
+      containers:
+        - name: cloudbeaver
+          resources:
+            limits:
+              cpu: "4"
+              memory: 6Gi
+            requests:
+              cpu: "2"
+              memory: 4Mi

--- a/workshops/aiops-tools/smaug/patches/dex-clients_patch.yaml
+++ b/workshops/aiops-tools/smaug/patches/dex-clients_patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: dex-clients
+spec:
+  dataFrom:
+    - extract:
+        key: moc/smaug/aiops-tools-workshop/dex-clients


### PR DESCRIPTION
The manifests introduce various different services into the
aiops-tools-workshop namespace. This includes, odh, trino, superset,
jupyterhub, cloubeaver, dex, kfp-tekton, various configuration files for
these services in the form of configmaps and externalsecrets.

A readme is included to offer further insight into the dependencies
required. The smaug deployment already has some dependencies included in
the base directory for the workshop, so they are excluded from the smaug
overlay. However, when looking to deploy this workshop to another
cluster, ensure these dependencies are either 1) already included, or 2)
included within this overlay. Otherwise the workshop will not work.

Furthers: https://github.com/operate-first/community/issues/206