### PR TITLE
Adjust aiops tools namespaces and add minio.

### DIFF
--- a/workshops/aiops-tools/base/acme-operator/issuer-letsencrypt-live.yaml
+++ b/workshops/aiops-tools/base/acme-operator/issuer-letsencrypt-live.yaml
@@ -1,0 +1,12 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: letsencrypt-live
+  annotations:
+    acme.openshift.io/priority: "100"
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+  labels:
+    managed-by: "openshift-acme"
+    type: "CertIssuer"
+data:
+  "cert-issuer.types.acme.openshift.io": '{"type":"ACME","acmeCertIssuer":{"directoryUrl":"https://acme-v02.api.letsencrypt.org/directory"}}'

--- a/workshops/aiops-tools/base/acme-operator/kustomization.yaml
+++ b/workshops/aiops-tools/base/acme-operator/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../cluster-scope/bundles/acme-operator
+  - ../../../../acme-operator/base
+  - issuer-letsencrypt-live.yaml
+namespace: acme-operator

--- a/workshops/aiops-tools/base/administration/namespace/kustomization.yaml
+++ b/workshops/aiops-tools/base/administration/namespace/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../../../cluster-scope/base/core/namespaces/aiops-tools-workshop
+  - ../../../../../cluster-scope/base/core/namespaces/kubeflow

--- a/workshops/aiops-tools/base/administration/rbac/kustomization.yaml
+++ b/workshops/aiops-tools/base/administration/rbac/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: aiops-tools-workshop
 resources:
   - attendee-role.yaml
   - attendee-rolebinding.yaml

--- a/workshops/aiops-tools/base/cloudbeaver/kustomization.yaml
+++ b/workshops/aiops-tools/base/cloudbeaver/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: aiops-tools-workshop
 resources:
   - ../../../../cloudbeaver/base

--- a/workshops/aiops-tools/base/kfp-tekton/kustomization.yaml
+++ b/workshops/aiops-tools/base/kfp-tekton/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: kubeflow
 resources:
   - ../../../../cluster-scope/bundles/kfp-tekton
   - ../../../../kfp-tekton/base

--- a/workshops/aiops-tools/base/minio/deployment.yaml
+++ b/workshops/aiops-tools/base/minio/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: minio
+  name: minio
+spec:
+  selector:
+    matchLabels:
+      app: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - args:
+            - server
+            - /data
+          env:
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: accesskey
+                  name: minio
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: secretkey
+                  name: minio
+          image: gcr.io/ml-pipeline/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance
+          name: minio
+          ports:
+            - containerPort: 9000
+          resources:
+            requests:
+              cpu: "4"
+              memory: 16Gi
+          volumeMounts:
+            - mountPath: /data
+              name: data
+              subPath: minio
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio

--- a/workshops/aiops-tools/base/minio/kustomization.yaml
+++ b/workshops/aiops-tools/base/minio/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: aiops-tools-workshop
 resources:
-- jupyterhub
-- superset
-- trino
+  - deployment.yaml
+  - svc.yaml
+  - pvc.yaml
+  - minio.yaml

--- a/workshops/aiops-tools/base/minio/minio.yaml
+++ b/workshops/aiops-tools/base/minio/minio.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: minio
+stringData:
+    accesskey: "1234"
+    secretkey: "1234567890"

--- a/workshops/aiops-tools/base/minio/pvc.yaml
+++ b/workshops/aiops-tools/base/minio/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+    name: minio
+spec:
+    accessModes:
+        - ReadWriteOnce
+    resources:
+        requests:
+            storage: 120Gi

--- a/workshops/aiops-tools/base/minio/svc.yaml
+++ b/workshops/aiops-tools/base/minio/svc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: minio
+spec:
+    ports:
+        - name: http
+          port: 9000
+          protocol: TCP
+          targetPort: 9000
+    selector:
+        app: minio

--- a/workshops/aiops-tools/base/odh-kfdefs/kustomization.yaml
+++ b/workshops/aiops-tools/base/odh-kfdefs/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: aiops-tools-workshop
 resources:
   - kfdef.yaml

--- a/workshops/aiops-tools/base/odh-operator/kustomization.yaml
+++ b/workshops/aiops-tools/base/odh-operator/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: opendatahub-operator
 resources:
   - ../../../../odh-operator/base
   - ../../../../cluster-scope/bundles/opendatahub-operator-manual

--- a/workshops/aiops-tools/base/openshift-pipelines/kustomization.yaml
+++ b/workshops/aiops-tools/base/openshift-pipelines/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: aiops-tools-workshop
 resources:
   - ../../../../cluster-scope/bundles/openshift-pipelines

--- a/workshops/aiops-tools/smaug/configmaps/kustomization.yaml
+++ b/workshops/aiops-tools/smaug/configmaps/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: aiops-tools-workshop
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:

--- a/workshops/aiops-tools/smaug/externalsecrets/kustomization.yaml
+++ b/workshops/aiops-tools/smaug/externalsecrets/kustomization.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: aiops-tools-workshop
 resources:
   - file-auth-secret.yaml
   - postgres-dbs.yaml

--- a/workshops/aiops-tools/smaug/kustomization.yaml
+++ b/workshops/aiops-tools/smaug/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: aiops-tools-workshop
 resources:
   - ../base/administration/rbac
   - ../base/odh-configs
@@ -11,6 +10,7 @@ resources:
   - externalsecrets
 
 # Already included in smaug via other apps
+#  - ../base/acme-operator
 #  - ../base/administration/groups
 #  - ../base/administration/namespace
 #  - ../base/kfp-tekton

--- a/workshops/aiops-tools/smaug/patches/cb_resources_patch.yaml
+++ b/workshops/aiops-tools/smaug/patches/cb_resources_patch.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cloudbeaver
+  namespace: aiops-tools-workshop
 spec:
   template:
     spec:

--- a/workshops/aiops-tools/smaug/patches/dex-clients_patch.yaml
+++ b/workshops/aiops-tools/smaug/patches/dex-clients_patch.yaml
@@ -2,6 +2,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: dex-clients
+  namespace: aiops-tools-workshop
 spec:
   dataFrom:
     - extract:


### PR DESCRIPTION
As per title. 

Minio deployment added as a soft dependency. Namespaces updated as kubeflow needs to be deployed within the kubeflow namespace, so each component has their namespace specified separately, rather than together in the overlay.