### PR TITLE
Configured alerts for Seldon and Trino 

### DIFF
--- a/kfdefs/overlays/moc/smaug/seldon/alerts.yaml
+++ b/kfdefs/overlays/moc/smaug/seldon/alerts.yaml
@@ -1,0 +1,34 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: seldon-alerts
+spec:
+  groups:
+    - name: alert_rules
+      rules:
+        - alert: InstanceDown
+          expr: up {namespace="opf-seldon"}== 0
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Instance [{{ $labels.instance }}] down"
+            description: "[{{ $labels.instance }}] of job [{{ $labels.job }}] has been down for more than 15 minute."
+
+        - alert: ContainerMemoryUsage
+          expr: (sum(container_memory_working_set_bytes{name!="", namespace="opf-seldon"}) BY (instance, name) / sum(container_spec_memory_limit_bytes > 0) BY (instance, name) * 100) > 80
+          for: 2m
+          labels:
+            severity: warning
+          annotations:
+            summary: Container Memory usage (instance {{ $labels.instance }})
+            description: "Container Memory usage is above 80%\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+        - alert: ContainerCpuUsage
+          expr: sum(rate(container_cpu_usage_seconds_total{container_name!="POD", namespace="opf-seldon"}[5m])) by (pod_name, container_name) / sum(container_spec_cpu_quota{container_name!="POD", namespace= "opf-seldon"}/container_spec_cpu_period{container_name!="POD", namespace="opf-seldon"}) by (pod_name, container_name) *100 > 80
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Container CPU usage (instance {{ $labels.container_name }})
+            description: "Container CPU usage is above 80%\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"

--- a/kfdefs/overlays/moc/smaug/seldon/kustomization.yaml
+++ b/kfdefs/overlays/moc/smaug/seldon/kustomization.yaml
@@ -2,7 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: opf-seldon
-
 resources:
   - kfdef.yaml
+  - seldon-servicemonitor.yaml
   - seldon-podmonitor.yaml
+  - alerts.yaml

--- a/kfdefs/overlays/moc/smaug/seldon/seldon-servicemonitor.yaml
+++ b/kfdefs/overlays/moc/smaug/seldon/seldon-servicemonitor.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: seldon-servicemonitor
+spec:
+  endpoints:
+  - port: http
+  - path: /prometheus
+  selector: {}
+  namespaceSelector:
+    matchNames:
+      - opf-seldon

--- a/kfdefs/overlays/moc/smaug/trino/alerts.yaml
+++ b/kfdefs/overlays/moc/smaug/trino/alerts.yaml
@@ -1,0 +1,34 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: trino-alerts
+spec:
+  groups:
+    - name: alert_rules
+      rules:
+        - alert: InstanceDown
+          expr: up {namespace="opf-trino", container!=""}== 0
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Instance [{{ $labels.instance }}] down"
+            description: "[{{ $labels.instance }}] of job [{{ $labels.job }}] has been down for more than 15 minute."
+
+        - alert: ContainerMemoryUsage
+          expr: (sum(container_memory_working_set_bytes{name!="", namespace="opf-trino"}) BY (instance, name) / sum(container_spec_memory_limit_bytes > 0) BY (instance, name) * 100) > 80
+          for: 2m
+          labels:
+            severity: warning
+          annotations:
+            summary: Container Memory usage (instance {{ $labels.instance }})
+            description: "Container Memory usage is above 80%\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+        - alert: ContainerCpuUsage
+          expr: sum(rate(container_cpu_usage_seconds_total{container_name!="POD", namespace="opf-trino"}[5m])) by (pod_name, container_name) / sum(container_spec_cpu_quota{container_name!="POD", namespace= "opf-trino"}/container_spec_cpu_period{container_name!="POD", namespace="opf-trino"}) by (pod_name, container_name) *100 > 80
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Container CPU usage (instance {{ $labels.container_name }})
+            description: "Container CPU usage is above 80%\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"

--- a/kfdefs/overlays/moc/smaug/trino/kustomization.yaml
+++ b/kfdefs/overlays/moc/smaug/trino/kustomization.yaml
@@ -10,5 +10,6 @@ resources:
   - secrets
   - servicemonitor.yaml
   - vpa
+  - alerts.yaml
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
Added Container memory, CPU and UP alerts and configured service monitor for seldon. 
[https://github.com/operate-first/apps/issues/1677](url). 
CPU alert [https://github.com/google/cadvisor/issues/2026](url). 