### PR TITLE
adding scsaol group to opf-observatorium-view rolebinding

### DIFF
--- a/observatorium/overlays/moc/smaug/thanos/rolebindings/opf-observatorium-view.yaml
+++ b/observatorium/overlays/moc/smaug/thanos/rolebindings/opf-observatorium-view.yaml
@@ -13,6 +13,9 @@ subjects:
     namespace: opf-monitoring
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
+    name: scsaol
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
     name: apicurio
   - kind: Group
     apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Followed steps from [documentation](https://github.com/operate-first/apps/blob/master/docs/content/observatorium/thanos/request_thanos_access.md) to request access for @SuJingyu111 to view thanos metrics.

/CC @HumairAK 