### PR TITLE
feat(schema-store):  Add service account for schema store

### DIFF
--- a/cluster-scope/base/core/serviceaccounts/schemastore-ci/kustomization.yaml
+++ b/cluster-scope/base/core/serviceaccounts/schemastore-ci/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- serviceaccount.yaml

--- a/cluster-scope/base/core/serviceaccounts/schemastore-ci/serviceaccount.yaml
+++ b/cluster-scope/base/core/serviceaccounts/schemastore-ci/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: schemastore-ci
+  namespace: default

--- a/cluster-scope/overlays/prod/common/kustomization.yaml
+++ b/cluster-scope/overlays/prod/common/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../../base/config.openshift.io/projects/cluster
+- ../../../base/core/serviceaccounts/schemastore-ci
 - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-rb
 - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners
 - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/sre


### PR DESCRIPTION
This PR creates schema-store service account and adds it to `common` so that it is accessible in all clusters. This service account is needed for `schema-store` cronjob to be able to access `/openapi/v2` endpoints and update schemas of CRDs.
Part of https://github.com/open-services-group/scrum/issues/19 and https://github.com/open-services-group/scrum/issues/6