### PR TITLE
Installing Kepler using kustomize

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/kepler.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/kepler.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kepler
+  namespace: argocd
+spec:
+  project: cluster-management
+  source:
+    path: kepler/overlays/moc/smaug
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  destination:
+    name: smaug
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - nfd.yaml
   - kubevirt-hyperconverged.yaml
   - volsync.yaml
+  - kepler.yaml

--- a/cluster-scope/base/core/namespaces/kepler/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/kepler/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/kepler/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/kepler/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+spec: {}

--- a/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/kepler/50-master-kernel-devel-cgroupv2.yaml
+++ b/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/kepler/50-master-kernel-devel-cgroupv2.yaml
@@ -1,0 +1,12 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 50-master-kernel-devel-cgroupv2
+  labels:
+    machineconfiguration.openshift.io/role: master
+spec:
+  kernelArguments:
+    - systemd.unified_cgroup_hierarchy=1
+    - cgroup_no_v1="all"
+  extensions:
+  - kernel-devel

--- a/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/kepler/50-worker-kernel-devel-cgroupv2.yaml
+++ b/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/kepler/50-worker-kernel-devel-cgroupv2.yaml
@@ -1,0 +1,12 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 50-worker-kernel-devel-cgroupv2
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  kernelArguments:
+    - systemd.unified_cgroup_hierarchy=1
+    - cgroup_no_v1="all"
+  extensions:
+  - kernel-devel

--- a/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/kepler/kustomization.yaml
+++ b/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/kepler/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- 50-master-kernel-devel-cgroupv2
+- 50-worker-kernel-devel-cgroupv2

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -38,6 +38,7 @@ resources:
 - ../../../../base/core/namespaces/ds-github-labeler
 - ../../../../base/core/namespaces/ds-ml-workflows-ws
 - ../../../../base/core/namespaces/fedora
+- ../../../../base/core/namespaces/kepler
 - ../../../../base/core/namespaces/koku-metrics-operator
 - ../../../../base/core/namespaces/kubeflow
 - ../../../../base/core/namespaces/manageiq

--- a/kepler/base/daemonset.yaml
+++ b/kepler/base/daemonset.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kepler-exporter
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: kepler-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: exporter
+        app.kubernetes.io/name: kepler-exporter
+    spec:
+      nodeSelector:
+        sustainable-computing.io/kepler: ""
+      serviceAccountName: kepler-sa
+      containers:
+      - name: kepler-exporter
+        image: quay.io/sustainable_computing_io/kepler:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        command:
+        - /usr/bin/kepler
+        - -address
+        - 0.0.0.0:9102
+        - -enable-gpu
+        - "false"
+        ports:
+        - containerPort: 9102
+          name: kepler-exporter
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: lib-modules
+        - mountPath: /sys
+          name: tracing
+        - name: kernel-src
+          mountPath: /usr/src/kernels
+        - name: kernel-debug
+          mountPath: /sys/kernel/debug
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+      volumes:
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: tracing
+        hostPath:
+          path: /sys
+          type: Directory
+      - name: kernel-debug
+        hostPath:
+          path: /sys/kernel/debug
+          type: Directory
+      - name: kernel-src
+        hostPath:
+          path: /usr/src/kernels
+          type: Directory

--- a/kepler/base/kustomization.yaml
+++ b/kepler/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  sustainable-computing.io/app: kepler
+resources:
+- serviceaccount.yaml
+- service.yaml
+- rolebinding.yaml
+- role.yaml
+- scc.yaml

--- a/kepler/base/role.yaml
+++ b/kepler/base/role.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    sustainable-computing.io/app: kepler
+  name: kepler-leader-election
+  namespace: monitoring
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - nodes/metrics
+      - nodes/proxy
+      - nodes/stats
+    verbs:
+      - get
+      - list
+      - watch

--- a/kepler/base/rolebinding.yaml
+++ b/kepler/base/rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    sustainable-computing.io/app: kepler
+  name: kepler-leader-election
+  namespace: monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kepler-leader-election
+subjects:
+  - kind: ServiceAccount
+    name: kepler-sa
+    namespace: monitoring

--- a/kepler/base/scc.yaml
+++ b/kepler/base/scc.yaml
@@ -1,0 +1,26 @@
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: kepler-scc
+allowPrivilegedContainer: true
+allowHostDirVolumePlugin: true
+allowHostNetwork: true
+allowHostPorts: true
+allowHostIPC: true
+allowHostPID: true
+readOnlyRootFilesystem: true
+defaultAddCapabilities:
+- SYS_ADMIN
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+volumes:
+  - configMap
+  - projected
+  - emptyDir
+  - hostPath
+users:
+  - system:serviceaccount:monitoring:kepler-sa

--- a/kepler/base/service.yaml
+++ b/kepler/base/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kepler-exporter
+    sustainable-computing.io/app: kepler
+  name: kepler-exporter
+  namespace: monitoring
+spec:
+  selector:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kepler-exporter
+  ports:
+    - name: kepler-exporter
+      port: 9102
+      targetPort: 9102

--- a/kepler/base/serviceaccount.yaml
+++ b/kepler/base/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    sustainable-computing.io/app: kepler
+  name: kepler-sa
+  namespace: monitoring

--- a/kepler/overlays/moc/smaug/kustomization.yaml
+++ b/kepler/overlays/moc/smaug/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../base


### PR DESCRIPTION
Initial drop for installing Kepler on operate-first/apps using kustomization. Kepler needs to install machine configs as a pre-requisite to probe cpu. 

**CC @larsks** @HumairAK @durandom Please TAL



Signed-off-by: Parul <parsingh@redhat.com>