### PR TITLE
Add openmetadata-admins group to the openmetadata namespace

### DIFF
--- a/cluster-scope/base/core/namespaces/openmetadata/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/openmetadata/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - namespace.yaml
 components:
 - ../../../../components/project-admin-rolebindings/operate-first
+- ../../../../components/project-admin-rolebindings/openmetadata-admins

--- a/cluster-scope/components/project-admin-rolebindings/openmetadata-admins/kustomization.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/openmetadata-admins/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: Component
+apiVersion: kustomize.config.k8s.io/v1alpha1
+resources:
+    - rbac.yaml

--- a/cluster-scope/components/project-admin-rolebindings/openmetadata-admins/rbac.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/openmetadata-admins/rbac.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: namespace-admin-openmetadata-admins
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: admin
+subjects:
+    - apiGroup: rbac.authorization.k8s.io
+      kind: Group
+      name: openmetadata-admins

--- a/cluster-scope/overlays/prod/osc/osc-cl2/groups/openmetadata-admins.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/groups/openmetadata-admins.yaml
@@ -1,0 +1,6 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: openmetadata-admins
+users:
+  - caldeirav

--- a/openmetadata/base/openmetadata-dependencies/persistentvolumeclaims/airflow-logs.yaml
+++ b/openmetadata/base/openmetadata-dependencies/persistentvolumeclaims/airflow-logs.yaml
@@ -10,4 +10,4 @@ spec:
     - "ReadWriteOnce"
   resources:
     requests:
-      storage: "1Gi"
+      storage: "5Gi"


### PR DESCRIPTION
Allowing group openmetada-admins access to the openmetadata namespace on OS-Climate cluster osc-cl2. Increased pvc size for airflow logs to 5Gi in the same namespace . Latter related to https://github.com/operate-first/operations/issues/489