### PR TITLE
Add various OKD infrastructure

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - cluster-management
 - data-science
 - fybrik
+- okd-team
 - operate-first
 - thoth
 - workshops

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/okd-team/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/okd-team/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - okd-centos.yaml
+  - kvm-device-plugin.yaml

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/okd-team/kvm-device-plugin.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/okd-team/kvm-device-plugin.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kvm-device-plugin
+spec:
+  destination:
+    name: smaug
+    namespace: kvm-device-plugin
+  project: okd-team
+  source:
+    path: kvm-device-plugin/overlays/smaug
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/okd-team/okd-centos.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/okd-team/okd-centos.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: okd-centos
+spec:
+  destination:
+    name: smaug
+    namespace: okd-centos
+  project: okd-team
+  source:
+    path: okd-centos/overlays/smaug
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/argocd/overlays/moc-infra/projects/kustomization.yaml
+++ b/argocd/overlays/moc-infra/projects/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - lab-cicd.yaml
   - mocops.yaml
   - octo-ushift-dev.yaml
+  - okd-team.yaml
   - operate-first.yaml
   - os-climate.yaml
   - rekor.yaml

--- a/argocd/overlays/moc-infra/projects/okd-team.yaml
+++ b/argocd/overlays/moc-infra/projects/okd-team.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: okd-team
+  labels:
+    project-template: global
+spec:
+  destinations:
+    - namespace: 'okd-*'
+      server: 'https://api.smaug.na.operate-first.cloud:6443'
+    - namespace: 'kvm-device-plugin'
+      server: 'https://api.smaug.na.operate-first.cloud:6443'
+  sourceRepos:
+    - '*'
+  roles:
+    - name: project-admin
+      description: Read/Write access to this project only
+      policies:
+        - p, proj:okd-team:project-admin, applications, get, okd-team/*, allow
+        - p, proj:okd-team:project-admin, applications, create, okd-team/*, allow
+        - p, proj:okd-team:project-admin, applications, update, okd-team/*, allow
+        - p, proj:okd-team:project-admin, applications, delete, okd-team/*, allow
+        - p, proj:okd-team:project-admin, applications, sync, okd-team/*, allow
+        - p, proj:okd-team:project-admin, applications, override, okd-team/*, allow
+        - p, proj:okd-team:project-admin, applications, action/*, okd-team/*, allow
+      groups:
+        - okd-team

--- a/cluster-scope/base/apps/daemonsets/kvm-device-plugin/daemonset.yaml
+++ b/cluster-scope/base/apps/daemonsets/kvm-device-plugin/daemonset.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    image.openshift.io/triggers: |
+      [
+        {
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "kvm-device-plugin:latest"
+          },
+          "fieldPath": "spec.template.spec.containers[?(@.name==\"kvm-device-plugin\")].image"
+        }
+      ]
+  labels:
+    app: kvm-device-plugin
+  name: kvm-device-plugin
+  namespace: kvm-device-plugin
+spec:
+  selector:
+    matchLabels:
+      name: kvm-device-plugin
+  template:
+    metadata:
+      labels:
+        name: kvm-device-plugin
+    spec:
+      serviceAccountName: kvm-device-plugin
+      containers:
+      - name: kvm-device-plugin
+        image: kvm-device-plugin:latest
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: device-plugin
+            mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins

--- a/cluster-scope/base/apps/daemonsets/kvm-device-plugin/kustomization.yaml
+++ b/cluster-scope/base/apps/daemonsets/kvm-device-plugin/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kvm-device-plugin
+resources:
+    - daemonset.yaml

--- a/cluster-scope/base/core/namespaces/kvm-device-plugin/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/kvm-device-plugin/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 components:
     - ../../../../components/limitranges/default
     - ../../../../components/resourcequotas/medium
+    - ../../../../components/project-admin-rolebindings/okd-team
 kind: Kustomization
 namespace: kvm-device-plugin
 resources:

--- a/cluster-scope/base/core/namespaces/kvm-device-plugin/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/kvm-device-plugin/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+components:
+    - ../../../../components/limitranges/default
+    - ../../../../components/resourcequotas/medium
+kind: Kustomization
+namespace: kvm-device-plugin
+resources:
+    - namespace.yaml

--- a/cluster-scope/base/core/namespaces/kvm-device-plugin/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/kvm-device-plugin/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kvm-device-plugin

--- a/cluster-scope/base/core/namespaces/okd-centos/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/okd-centos/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+components:
+    - ../../../../components/limitranges/default
+    - ../../../../components/resourcequotas/medium
+kind: Kustomization
+namespace: okd-centos
+resources:
+    - namespace.yaml

--- a/cluster-scope/base/core/namespaces/okd-centos/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/okd-centos/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: okd-centos

--- a/cluster-scope/base/core/namespaces/okd-team/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/okd-team/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+components:
+    - ../../../../components/project-admin-rolebindings/okd-team
+    - ../../../../components/limitranges/default
+    - ../../../../components/resourcequotas/large
+kind: Kustomization
+namespace: okd-team
+resources:
+    - namespace.yaml

--- a/cluster-scope/base/core/namespaces/okd-team/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/okd-team/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "OKD Team (internal)"
+    openshift.io/requester: okd-team
+    op1st/project-owner: okd-team
+  name: okd-team
+spec: {}

--- a/cluster-scope/base/core/namespaces/okd-wg/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/okd-wg/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+components:
+    - ../../../../components/project-admin-rolebindings/okd-wg
+    - ../../../../components/limitranges/default
+    - ../../../../components/resourcequotas/medium
+kind: Kustomization
+namespace: okd-wg
+resources:
+    - namespace.yaml

--- a/cluster-scope/base/core/namespaces/okd-wg/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/okd-wg/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "OKD Working Group (public)"
+    openshift.io/requester: okd-wg
+    op1st/project-owner: okd-wg
+  name: okd-wg
+spec: {}

--- a/cluster-scope/base/rbac.authorization.k8s.io/rolebindings/kvm-device-plugin/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/rolebindings/kvm-device-plugin/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/rolebindings/kvm-device-plugin/rolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/rolebindings/kvm-device-plugin/rolebinding.yaml
@@ -1,0 +1,14 @@
+---
+kind: RoleBinding
+apiVersion: authorization.openshift.io/v1
+metadata:
+  name: kvm-device-plugin
+  namespace: kvm-device-plugin
+subjects:
+- kind: ServiceAccount
+  name: kvm-device-plugin
+  namespace: kvm-device-plugin
+roleRef:
+  kind: Role
+  namespace: kvm-device-plugin
+  name: kvm-device-plugin

--- a/cluster-scope/base/rbac.authorization.k8s.io/roles/kvm-device-plugin/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/roles/kvm-device-plugin/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - role.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/roles/kvm-device-plugin/role.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/roles/kvm-device-plugin/role.yaml
@@ -1,0 +1,15 @@
+---
+kind: Role
+apiVersion: authorization.openshift.io/v1
+metadata:
+  name: kvm-device-plugin
+  namespace: kvm-device-plugin
+rules:
+- resources:
+  - securitycontextconstraints
+  apiGroups:
+  - security.openshift.io
+  verbs:
+  - use
+  resourceNames:
+  - privileged

--- a/cluster-scope/bundles/kvm-device-plugin/kustomization.yaml
+++ b/cluster-scope/bundles/kvm-device-plugin/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base/apps/daemonsets/kvm-device-plugin
+  - ../../base/core/namespaces/kvm-device-plugin
+  - ../../base/rbac.authorization.k8s.io/rolebindings/kvm-device-plugin
+  - ../../base/rbac.authorization.k8s.io/roles/kvm-device-plugin

--- a/cluster-scope/components/project-admin-rolebindings/okd-team/kustomization.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/okd-team/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ./rbac.yaml

--- a/cluster-scope/components/project-admin-rolebindings/okd-team/rbac.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/okd-team/rbac.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-admin-okd-team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: okd-team

--- a/cluster-scope/components/project-admin-rolebindings/okd-wg/kustomization.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/okd-wg/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ./rbac.yaml

--- a/cluster-scope/components/project-admin-rolebindings/okd-wg/rbac.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/okd-wg/rbac.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-admin-okd-wg
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: okd-wg

--- a/cluster-scope/overlays/prod/common/kustomization.yaml
+++ b/cluster-scope/overlays/prod/common/kustomization.yaml
@@ -47,6 +47,8 @@ resources:
 - ../../../base/user.openshift.io/groups/octo-training-model
 - ../../../base/user.openshift.io/groups/octo-ushift-dev
 - ../../../base/user.openshift.io/groups/odh-admin
+- ../../../base/user.openshift.io/groups/okd-team
+- ../../../base/user.openshift.io/groups/okd-wg
 - ../../../base/user.openshift.io/groups/open-aiops
 - ../../../base/user.openshift.io/groups/operate-first
 - ../../../base/user.openshift.io/groups/opf-alerting

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -43,6 +43,8 @@ resources:
 - ../../../../base/core/namespaces/manageiq
 - ../../../../base/core/namespaces/neu-cs6620
 - ../../../../base/core/namespaces/od-demo
+- ../../../../base/core/namespaces/okd-team
+- ../../../../base/core/namespaces/okd-wg
 - ../../../../base/core/namespaces/openshift-cnv
 - ../../../../base/core/namespaces/openshift-logging
 - ../../../../base/core/namespaces/openshift-operators

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -17,7 +17,6 @@ resources:
 - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/reportapis.curator.operatefirst.io
 - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/reports.batch.curator.openshift.io
 - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/reports.curator.operatefirst.io
-- ../../../../base/apps/daemonsets/kvm-device-plugin
 - ../../../../base/core/namespaces/ai-services-thanos-grpc
 - ../../../../base/core/namespaces/aicoe-meteor
 - ../../../../base/core/namespaces/api-designer
@@ -41,7 +40,6 @@ resources:
 - ../../../../base/core/namespaces/fedora
 - ../../../../base/core/namespaces/koku-metrics-operator
 - ../../../../base/core/namespaces/kubeflow
-- ../../../../base/core/namespaces/kvm-device-plugin
 - ../../../../base/core/namespaces/manageiq
 - ../../../../base/core/namespaces/neu-cs6620
 - ../../../../base/core/namespaces/od-demo
@@ -139,8 +137,6 @@ resources:
 - ../../../../base/rbac.authorization.k8s.io/clusterroles/oauth-token-access-review
 - ../../../../base/rbac.authorization.k8s.io/clusterroles/service-catalog-k8s-plugin
 - ../../../../base/rbac.authorization.k8s.io/clusterroles/tekton-dashboard
-- ../../../../base/rbac.authorization.k8s.io/rolebindings/kvm-device-plugin
-- ../../../../base/rbac.authorization.k8s.io/roles/kvm-device-plugin
 - ../../../../base/storage.k8s.io/csidrivers/org.democratic-csi.nfs
 - ../../../../base/storage.k8s.io/storageclasses/moc-nfs-csi
 - ../../../../base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd
@@ -152,6 +148,7 @@ resources:
 - ../../../../bundles/fybrik
 - ../../../../bundles/jaeger-operator
 - ../../../../bundles/kfp-tekton
+- ../../../../bundles/kvm-device-plugin
 - ../../../../bundles/meteor-operator
 - ../../../../bundles/nfd
 - ../../../../bundles/openshift-pipelines

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
 - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/reportapis.curator.operatefirst.io
 - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/reports.batch.curator.openshift.io
 - ../../../../base/apiextensions.k8s.io/customresourcedefinitions/reports.curator.operatefirst.io
+- ../../../../base/apps/daemonsets/kvm-device-plugin
 - ../../../../base/core/namespaces/ai-services-thanos-grpc
 - ../../../../base/core/namespaces/aicoe-meteor
 - ../../../../base/core/namespaces/api-designer
@@ -40,6 +41,7 @@ resources:
 - ../../../../base/core/namespaces/fedora
 - ../../../../base/core/namespaces/koku-metrics-operator
 - ../../../../base/core/namespaces/kubeflow
+- ../../../../base/core/namespaces/kvm-device-plugin
 - ../../../../base/core/namespaces/manageiq
 - ../../../../base/core/namespaces/neu-cs6620
 - ../../../../base/core/namespaces/od-demo
@@ -137,6 +139,8 @@ resources:
 - ../../../../base/rbac.authorization.k8s.io/clusterroles/oauth-token-access-review
 - ../../../../base/rbac.authorization.k8s.io/clusterroles/service-catalog-k8s-plugin
 - ../../../../base/rbac.authorization.k8s.io/clusterroles/tekton-dashboard
+- ../../../../base/rbac.authorization.k8s.io/rolebindings/kvm-device-plugin
+- ../../../../base/rbac.authorization.k8s.io/roles/kvm-device-plugin
 - ../../../../base/storage.k8s.io/csidrivers/org.democratic-csi.nfs
 - ../../../../base/storage.k8s.io/storageclasses/moc-nfs-csi
 - ../../../../base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -43,6 +43,7 @@ resources:
 - ../../../../base/core/namespaces/manageiq
 - ../../../../base/core/namespaces/neu-cs6620
 - ../../../../base/core/namespaces/od-demo
+- ../../../../base/core/namespaces/okd-centos
 - ../../../../base/core/namespaces/okd-team
 - ../../../../base/core/namespaces/okd-wg
 - ../../../../base/core/namespaces/openshift-cnv

--- a/kvm-device-plugin/base/buildconfig.yaml
+++ b/kvm-device-plugin/base/buildconfig.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: kvm-device-plugin
+  name: kvm-device-plugin
+  namespace: kvm-device-plugin
+spec:
+  successfulBuildsHistoryLimit: 1
+  failedBuildsHistoryLimit: 2
+  source:
+    git:
+      ref: master
+      uri: https://github.com/cgwalters/kvm-device-plugin
+    type: Git
+    dockerfile: |
+      FROM image-registry.openshift-image-registry.svc:5000/centos/centos:okd-golang-builder AS builder
+      WORKDIR /go/src/github.com/cgwalters/kvm-device-plugin
+      COPY . .
+      RUN make
+      FROM image-registry.openshift-image-registry.svc:5000/centos/centos:stream9
+      COPY --from=builder /go/src/github.com/cgwalters/kvm-device-plugin/cmd/kvm/kvm /usr/bin/device-plugin-kvm
+      CMD ["/usr/bin/device-plugin-kvm"]
+  strategy:
+    type: Docker
+  output:
+    to:
+      kind: ImageStreamTag
+      name: kvm-device-plugin:latest
+  triggers:
+  - type: ConfigChange
+  - imageChange:
+      from:
+        kind: ImageStreamTag
+        name: "centos:stream9"
+        namespace: okd-centos
+    type: ImageChange
+  - imageChange:
+      from:
+        kind: ImageStreamTag
+        name: "centos:okd-golang-builder"
+        namespace: okd-centos
+    type: ImageChange

--- a/kvm-device-plugin/base/imagestream.yaml
+++ b/kvm-device-plugin/base/imagestream.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: kvm-device-plugin
+  namespace: kvm-device-plugin
+  labels:
+    app: kvm-device-plugin
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - name: latest
+    referencePolicy:
+      type: Source

--- a/kvm-device-plugin/base/kustomization.yaml
+++ b/kvm-device-plugin/base/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - imagestream.yaml
+  - buildconfig.yaml
+  - serviceaccount.yaml

--- a/kvm-device-plugin/base/serviceaccount.yaml
+++ b/kvm-device-plugin/base/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kvm-device-plugin
+  namespace: kvm-device-plugin

--- a/kvm-device-plugin/overlays/smaug/kustomization.yaml
+++ b/kvm-device-plugin/overlays/smaug/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base

--- a/okd-centos/base/buildconfig.yaml
+++ b/okd-centos/base/buildconfig.yaml
@@ -1,0 +1,35 @@
+---
+kind: BuildConfig
+apiVersion: build.openshift.io/v1
+metadata:
+  namespace: okd-centos
+  name: okd-golang-builder
+spec:
+  successfulBuildsHistoryLimit: 1
+  failedBuildsHistoryLimit: 2
+  source:
+    git:
+      ref: main
+      uri: https://github.com/okd-project/images
+    type: Git
+  strategy:
+    dockerStrategy:
+      from:
+        kind: ImageStreamTag
+        name: "centos:stream9"
+        namespace: okd-centos
+      dockerfilePath: okd-golang-builder.Dockerfile
+    type: Docker
+  output:
+    to:
+      kind: ImageStreamTag
+      name: centos:okd-golang-builder
+      namespace: okd-centos
+  triggers:
+  - type: ConfigChange
+  - imageChange:
+      from:
+        kind: ImageStreamTag
+        name: "centos:stream9"
+        namespace: okd-centos
+    type: ImageChange

--- a/okd-centos/base/imagestream.yaml
+++ b/okd-centos/base/imagestream.yaml
@@ -1,0 +1,18 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: centos
+  namespace: okd-centos
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: stream8
+      from:
+        kind: DockerImage
+        name: quay.io/centos/centos:stream8
+    - name: stream9
+      from:
+        kind: DockerImage
+        name: quay.io/centos/centos:stream9

--- a/okd-centos/base/kustomization.yaml
+++ b/okd-centos/base/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - imagestream.yaml
+  - buildconfig.yaml
+  - rolebinding.yaml

--- a/okd-centos/base/rolebinding.yaml
+++ b/okd-centos/base/rolebinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:image-puller
+  namespace: okd-centos
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:image-puller
+subjects:
+- kind: ServiceAccount
+  name: builder
+  namespace: kvm-device-plugin

--- a/okd-centos/overlays/smaug/kustomization.yaml
+++ b/okd-centos/overlays/smaug/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base


### PR DESCRIPTION
This PR adds various resources required for building OKD.

The `okd-centos` namespace is created to host imported centos stream images in an imagestream, and a buildconfig for the `okd-golang-builder` image.
The `okd-golang-builder` image is then used as a base for building the `kvm-device-plugin` image and referencing it in an imagestream.
The `kvm-device-plugin` is then also deployed with a service account. Note that the daemonset is privileged.

All of this is added to the smaug overlay.