### PR TITLE
adding myself to morty cluster admins and removing 4n4nd

### DIFF
--- a/cluster-scope/overlays/prod/emea/morty/groups/cluster-admins.yaml
+++ b/cluster-scope/overlays/prod/emea/morty/groups/cluster-admins.yaml
@@ -5,5 +5,5 @@ metadata:
 users:
   - humairak
   - HumairAK
-  - 4n4nd
   - larsks
+  - Gregory-Pereira


### PR DESCRIPTION
I need cluster admin access to view secrets in the `openshift-monitoring` namespace on morty to debug why loki on other clusters cannot connect to S3 on morty.

/cc @HumairAK 