### PR TITLE
Adjust osc-cl2 argocd project structure.

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/cluster-management/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/cluster-management/kustomization.yaml
@@ -15,3 +15,11 @@ resources:
   - openmetadata.yaml
   - pachyderm.yaml
   - reloader.yaml
+patches:
+  - patch: |
+      - op: replace
+        path: /spec/project
+        value: os-climate
+    target:
+      group: argoproj.io
+      kind: Application

--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/kustomization.yaml
@@ -5,11 +5,3 @@ nameSuffix: -osc-cl2
 resources:
 - cluster-management
 - fybrik
-patches:
-  - patch: |
-      - op: replace
-        path: /spec/project
-        value: os-climate
-    target:
-      group: argoproj.io
-      kind: Application


### PR DESCRIPTION
Currently we put all argocd apps under the osc argocd project. This was
done to allow some separate between osc argocd apps, and the other
argocd apps deployed within the operate-first cloud. This was useful for
provisioning access to only osc argocd project. But we now have a
situation where we have an existing argocd project (fybrik), that we
would like to leverage for fybrik apps deployed on osc-cl2. So for now
we will make an exception and have fybrik apps within argocd be under
the fybrik argocd project until a more robust structure/format is found.