### PR TITLE
Correct s3 hive ingest keys for osc-cl2.

### DIFF
--- a/kfdefs/overlays/osc/osc-cl2/trino/secrets/s3buckets.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/secrets/s3buckets.yaml
@@ -4,18 +4,18 @@ metadata:
     name: s3buckets
     namespace: odh-trino
 stringData:
-    OSC_DATACOMMONS_DEV_BUCKET: ENC[AES256_GCM,data:1Vt82kX6pBX3yk0sNNdNUsdUiHtGgV9Ufbdc/qUZ2Q==,iv:VdYTCDj1dtHoLsAom2azW+YRalcqDJOFgIC4sA1TqhY=,tag:l3eRRTCgPoy3gobDAPzByA==,type:str]
-    OSC_DATACOMMONS_DEV_AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:ffqSrrn9jnwim6UayfT1kTVOzd8=,iv:ZEaoTO75yl6i3ceiiGdzpNx7b7bSQa+V62SqI0Yb8yc=,tag:9deZn5GV/OKCoBZA6fonJQ==,type:str]
-    OSC_DATACOMMONS_DEV_AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:mEREpyp2qP976rsGLXDwutIAG49rKO0/H6cJ8U3OH0SylBcBts2FUw==,iv:ajIrM4S+XySvj2cxAwgMVL72Ht33xtObpSZPdeIy78w=,tag:QZq+PGsuWI0ZW6v7+cyMJg==,type:str]
-    OSC_DATACOMMONS_DEV_REGION: ENC[AES256_GCM,data:tzdWDxjZcaw8,iv:xURg7FsNrUJk9dp+hJNcrNA41oUO49Mz1nuYzxveyik=,tag:jZF8/fJqaqt7D8f6idyasQ==,type:str]
-    OSC_DATACOMMONS_DEV_S3_ENDPOINT: ENC[AES256_GCM,data:JzhX1mbGA5fCC94Y+jeFvHd33yGN2foQbEM=,iv:xYr6OyZoOEbC/jS10mZvhNHUGCs0QvaRtSMk+dIpjyM=,tag:KQH1XBAL/9MnNiF6H013Lg==,type:str]
-    OSC_DATACOMMONS_DEV_S3_ENDPOINT_URL_PREFIX: ENC[AES256_GCM,data:sq82dXaJKuY=,iv:B0rlS4gLi6mUvrkOx85v/+T7xEPrfJ5UBpbI5ncZR24=,tag:5AfUHWutoHDmbejemqqYrw==,type:str]
-    OSC_DATACOMMONS_HIVE_INGEST_AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:brqbkGFksMY9PxprLXdc/RIoGQU4+iln8XAILFbHvQ==,iv:FDTk4EMNDvPfgBMTn29c3j6Db1xnovMz1uFFFPR9o1Y=,tag:jkJWAUTVrHRqWWhnmKtWpA==,type:str]
-    OSC_DATACOMMONS_HIVE_INGEST_AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:cF3bBB1eYHji4nTZo9M+VaGYxcs=,iv:QWIAkIGR1ovxLPqLiRqvdPhrJqJGyX/V0PZfUI/k5TY=,tag:dqN4FWMgC2HfvIoi6Dvkyw==,type:str]
-    OSC_DATACOMMONS_HIVE_INGEST_BUCKET: ENC[AES256_GCM,data:VEsyWgZj1q1Z3B2cdmWPTmy8g2t5CTMmchAuPSdLCGrDZNRXIgTqZQ==,iv:H3nAjDFXFlOLq+DtRl8fxNbkuLJ7jpRb4Uwn7FXSXFc=,tag:LR3bpKfXGyqWTc/BTYDaUg==,type:str]
-    OSC_DATACOMMONS_HIVE_INGEST_REGION: ENC[AES256_GCM,data:LtsIzq+iNKH1,iv:tuGB4Ds1rRqq3ztrybrhngMIaqpdPyawj6tBW9hzZ68=,tag:II46+bcElUCWBWkmitx63g==,type:str]
-    OSC_DATACOMMONS_HIVE_INGEST_S3_ENDPOINT: ENC[AES256_GCM,data:YanwzohYYi6A8zZniLEQsdbVO4Jr7FJk45Y=,iv:O9lxp/uJR704KjEReAdOT47l5N3TWvMFxo0AdgwhzAA=,tag:KCeQPNNRfUtxfrPt64/GxA==,type:str]
-    OSC_DATACOMMONS_HIVE_INGEST_S3_ENDPOINT_URL_PREFIX: ENC[AES256_GCM,data:2frkfF18DOQ=,iv:d/feYv7a//xwRpf2f+bL+fbFupGxCCEbNpvAXmK1Lz0=,tag:4oEAg4GTGU/QmfTqRJgogg==,type:str]
+    OSC_DATACOMMONS_DEV_BUCKET: ENC[AES256_GCM,data:x8CvPBc5PccjnOZkbR1sXzLqUqxfZJz9WOyz7pl/sg==,iv:xRwZuJzqJfGU89kLsNocT2MteieeQwmIb0ZWCBasmsM=,tag:C9xJavDdlU/vF8sHLEy1ag==,type:str]
+    OSC_DATACOMMONS_DEV_AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:rd6aNyn4Z5itJHY25ZPWBplqics=,iv:sBRE/YvjinhxGrIIsOmqaJORhHGym2/1OaKH9qwLRMA=,tag:Gs8Xdu33b34ygTMg7oB8cg==,type:str]
+    OSC_DATACOMMONS_DEV_AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:Yga04GLTSVQZYezJG6XW7QWtsviF4w15vI0OnmhpzlZrInVcNwX6/Q==,iv:OOK/kQh7JgHdbfEDxunu9CUxDSZ68JfvvXVY9BITaA4=,tag:NCObs0Pome2UpUPKC1+vKA==,type:str]
+    OSC_DATACOMMONS_DEV_REGION: ENC[AES256_GCM,data:J3ilS3+1IsxY,iv:LUd3e/i4zvzd8gzbpbBLzMElrrS6KtvA2XoZR0O286E=,tag:6RGXI2chqk2dyrszEuWw+g==,type:str]
+    OSC_DATACOMMONS_DEV_S3_ENDPOINT: ENC[AES256_GCM,data:xk1SR6ajvKMRpVKY+BOauBJW3a9cI1R//Iw=,iv:afyrI7qNkeVgjSqiO0h5cr7K4QsKuUyUp/VFim04Oio=,tag:YkiLU8HCCyEZzZ0uMwVv2Q==,type:str]
+    OSC_DATACOMMONS_DEV_S3_ENDPOINT_URL_PREFIX: ENC[AES256_GCM,data:L5QNz2rwNrM=,iv:An5v9soyPvHwQnzdG14WNLd5CCWIH2DnIy0QSskcTOI=,tag:Cy4eVsmG5q3h7fEIf6c8tA==,type:str]
+    OSC_DATACOMMONS_HIVE_INGEST_AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:SGJY+UAdfnHegMLFwhtOTuEFrzYiL/epdz8wCX4mvUkvRMdLN0TNVQ==,iv:4GE+bHo1VOa0BcX2K5VTcyYwrO2BRvRUWo4ZJbFLCbs=,tag:pQ8/RJSai/lZH048czkOHg==,type:str]
+    OSC_DATACOMMONS_HIVE_INGEST_AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:mMbq7Ky0JRDwGRHKioZEr0gRk0g=,iv:xmImmHkR/zXy4iBfiWjGiHQl1xNAcPL/gmbrI+VZdLw=,tag:nTfA6+iOh9SFUlvqZT9WXA==,type:str]
+    OSC_DATACOMMONS_HIVE_INGEST_BUCKET: ENC[AES256_GCM,data:wC/wfehVZq666qdNljFSPy0KofFmc5EeoICE4LARlQ==,iv:HabQ/An0hT8lig27lCwj0eqUaLiil6/o15QEzl/ssC8=,tag:bwoyBc5p17LfRmxh7sT5qA==,type:str]
+    OSC_DATACOMMONS_HIVE_INGEST_REGION: ENC[AES256_GCM,data:/hV16kJZH7zC,iv:ma1ZnYupbVWod2whHsmZm6P96ce1WvfFB31RpHJLEwo=,tag:3MM+IzZFMf0puSoZAV7lYg==,type:str]
+    OSC_DATACOMMONS_HIVE_INGEST_S3_ENDPOINT: ENC[AES256_GCM,data:/mToYIob8kUcZd7FeqtIjJq1RdPaGfZtdFU=,iv:k2JRbELt2SbG2+qSRoIrUvkx/k1j1aklPxsiZbMwOts=,tag:jP9iHzj2TIRV2jBGEF71qQ==,type:str]
+    OSC_DATACOMMONS_HIVE_INGEST_S3_ENDPOINT_URL_PREFIX: ENC[AES256_GCM,data:xZWrBIWHo6g=,iv:ofWmh51eqwGlupOTangw+vW0TN8hgSINdZP3zbvWJ9w=,tag:iqTcPdcZzkyaRGY1YU7PQQ==,type:str]
 type: Opaque
 sops:
     kms: []
@@ -23,27 +23,27 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-08-10T17:13:49Z"
-    mac: ENC[AES256_GCM,data:a397e3oIgFABrjOHKgAkpW/cRMEwCRMIQqASHwCoVhSBIVB7NGpFSYxKIj44Y790sbXdiJP8zErqGalry8zuUVvvida4mIyIUiRyWiu5lPTfC8+IuOCXfoN/Fw8pObfBr2+gFi7zc3SZdpaFacoc2JO3NMMnRWp9oL9/J+ed55g=,iv:Q+/EEA5SLAL/QN+1LWClAMzKRy+lPoXS9dLxkFn43rY=,tag:PVU21A2KArfbgbx+dsa91A==,type:str]
+    lastmodified: "2022-08-10T19:03:07Z"
+    mac: ENC[AES256_GCM,data:dqUlqTIsgx+ONm/gL2dfpbul1md6nl+bHTw+AoTNeLU/7na2s5btIyOHwfznKsyWb9VAxPTMB3XHNVLMfvS7WVYNUUx9/WHcZ849shA5OBeVuHOj/iw5jGi0tJ49INb3gzQX7xKpaWxZfF1mLpYXBKvVsV/aAuPwp7c6eeUeXL4=,iv:cUQcaLT88gv3R9XgfV9sHLhSnZmZC+aqOvMiLCiQ8/I=,tag:qOuOPdfpPnFT3BFLMAaJyg==,type:str]
     pgp:
-        - created_at: "2022-08-10T17:13:48Z"
+        - created_at: "2022-08-10T19:03:06Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMA9aKBcudqifiARAAG3JkVemHJDctxsOBCoea3NwGWrjxm1TGLHferX+Uhml5
-            7XPWshbT74HcT8jLtInJ9Jvwwx9ZWU6fszAKMl5Y1eVtyNjUrg2Y7wYcVGmS8KKK
-            mzxJe+KvWv1j5K8t6g6zjy9Jx1ijtcIO0lvDUZjNUEAys1LQfqO5SUTq2keDNWhX
-            prpae0cBxqw3WzX6RMhrTBSua2Xv9TznCXf6CE3j4BaM1GYBMuwGJIWCL0KWzqLL
-            G1PWW8boswvmFuLXjAqjcr48LaADIBMOv1+Dt9vtKjvA/H0KinRfvcfL2MbTkRw1
-            kVDrn5HgCdKOZceu8j2TLAJ4ovHJ1kXsgrqt2PMmpL8lPqhoMOQOC66HxcDmNqgb
-            8yDxtM0Owz2ECPaOMVAuTJ0I4f/LYQ6sVDZkFAqI0/gRQMsR0s8TkWDfDxnhqaMS
-            rQoeB8GRNfsAzcbzcgKMrQgSei63pqfVqQ9ZSMa53ZohAPm7Wfcu3H7/qzND8bAD
-            6sME4T2Oe+NucgLt5XWaSX6egEp/tCNRnTmW2rfH5RloOK4m/7htZtscS4iVdQtp
-            az1EtuhzOfbcAZZIuDo4ho0/CzfR0IlWkCvV+jdwVrTLLoU6by141RHsAUANaTSa
-            nxQz0msqdTFThr5YFF62pr8B7n8xlHrbD+D3eJDPQUwJqs0M5z192QgvLT5HIcTS
-            5gF8iZldVg0tfQND92WKNxajWQflA2DcKw4T5jF9tuWq1p2ZLB0zFk9w7mkH+dZx
-            oVLE6G+Ppb/Eyw8rVJpLbp3kgxaAfp9calLMHFIvAqeMQ+LFp/eCAA==
-            =SxXr
+            wcFMA9aKBcudqifiARAAtBD26tbc6ihgzsBW5Eph8tHBovwRsY1vQhUGpowKBQMt
+            Env8oCuA0uQWBFQPutfbyPaVk9/anmBnbNcausMdT8O7Cdtm//9wnp+MJCCHLy6B
+            GQRf4lGsXEqObuHLY+w40RLhvxSnYEtHAhQ6P3cThZ38slcpi/kRL+M/gjakeZO/
+            mR43VyWqsQtHKXmttoydZIU/i0p2DhvRPXFEYlUFvxdetDKyGLh4lNRfM3ukAhu6
+            T3oTAHXeuO5Dm3PeBl6FCj8BNlEtiF0nifFYp+hJVb+Ec0wxwRrqjxJLxJ9XjQfC
+            Qpwls5sfNM31mhMuMcs655abwafBaJ3dEi2gA2aDIt1bxx3wKAcx6jOOFtXZbK4P
+            TY5JC2olRSZtN0e6623CXiJg5RQs19ZW+LbZkP4yYMLNZzDVPo6hQsa28woO/4CR
+            iYSyjlUi3NW0wDIt/KXka4C6/4nxVhrA9wo6e4XpWmZJFC4ryChgOp76N82Xihd4
+            C2zV32onb4evm2/FXgvcpPmqavXrML+LULp79paVY992RHDiQfmPKkhGZlMW7r1c
+            3pRnn4Jaufmi6UYtfUqAUYkt4fqF13Q0haQgkSLpLJvfxcVtQDeAESWqBH1NKt4P
+            lSOipv9YvO/gNFZJw9Ot0Ol6eJMog3s84Ycuz8Qz9RQfkfaQmamrOBiHQm9K+9PS
+            5gGodrhNlVPcpO8mfqph3dnTTpelB6kv2A2rBuFqyDeLWssJNV1c8PWO+85JteEZ
+            QT6sFASlMzTXZpoqmqXshqvkLtyYG46rQYE5LehRYjWGI+JcVl5BAA==
+            =Rrw1
             -----END PGP MESSAGE-----
           fp: 0508677DD04952D06A943D5B4DC4116D360E3276
     encrypted_regex: ^(data|stringData)$


### PR DESCRIPTION
The accesskey/bucket name values were switched for hive ingest catalog, this commit corrects that.