### PR TITLE
hive "ingest" schema on CL2

### DIFF
--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/group-mapping.properties
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/group-mapping.properties
@@ -5,6 +5,7 @@ demo_dv_quant:os-climate-user2
 demo_dv_user:os-climate-user3
 demo_dv_licensed:os-climate-user1
 demo_dv_eval:os-climate-user1,os-climate-user2
+hive_ingest:MichaelTiemannOSC,erikerlandson,caldeirav
 pcaf_sovereign_footprint:toki8,mersin35,MichaelTiemannOSC,OferHarari,SiLeBa
 pcaf_sovereign_footprint_developers:toki8,mersin35,MichaelTiemannOSC,OferHarari,SiLeBa
 pcaf_sovereign_footprint_admin:toki8,mersin35,MichaelTiemannOSC,OferHarari,SiLeBa

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/rules.json
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/rules.json
@@ -25,6 +25,11 @@
             "allow": "all"
         },
         {
+            "group": "hive_ingest",
+            "catalog": "osc_datacommons_hive_ingest",
+            "allow": "all"
+        },
+        {
             "allow": "read-only"
         }
     ],
@@ -55,6 +60,12 @@
             "catalog": "osc_datacommons_dev",
             "schema": "mdt_sandbox",
             "user": "MichaelTiemannOSC",
+            "owner": true
+        },
+        {
+            "catalog": "osc_datacommons_hive_ingest",
+            "schema": "ingest",
+            "group": "hive_ingest",
             "owner": true
         },
         {
@@ -108,6 +119,17 @@
             "catalog": "osc_datacommons_dev",
             "schema": "mdt_sandbox",
             "user": "MichaelTiemannOSC",
+            "privileges": [
+                "SELECT",
+                "INSERT",
+                "DELETE",
+                "OWNERSHIP"
+            ]
+        },
+        {
+            "catalog": "osc_datacommons_hive_ingest",
+            "schema": "ingest",
+            "group": "hive_ingest",
             "privileges": [
                 "SELECT",
                 "INSERT",
@@ -250,7 +272,18 @@
             ]
         },
         {
+            "catalog": "osc_datacommons_hive_ingest",
+            "schema": "ingest",
+            "privileges": []
+        },
+        {
             "catalog": "osc_datacommons_dev",
+            "privileges": [
+                "SELECT"
+            ]
+        },
+        {
+            "catalog": "osc_datacommons_hive_ingest",
             "privileges": [
                 "SELECT"
             ]

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/trino-acl-dsl.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/trino-acl-dsl.yaml
@@ -9,6 +9,9 @@ catalogs:
   - catalog: osc_datacommons_dev
     public: true
 
+  - catalog: osc_datacommons_hive_ingest
+    public: true
+
 schemas:
   - schema: sandbox
     catalog: osc_datacommons_dev
@@ -33,6 +36,12 @@ schemas:
     admin:
       - user: 'MichaelTiemannOSC'
     public: true
+
+  - schema: ingest
+    catalog: osc_datacommons_hive_ingest
+    admin:
+      - group: hive_ingest
+    public: false
 
 tables:
   - table: demo_dv_backend


### PR DESCRIPTION
Declares the new catalog: `osc_datacommons_hive_ingest`, and a dedicated schema `ingest` intended for use with the osc-ingest-tools method `fast_pandas_ingest_via_hive`

also declares a privileged user group `hive_ingest` that has access to this schema.