### PR TITLE
add reloader annotation to slack first operator

### DIFF
--- a/slack-first/base/deployment.yaml
+++ b/slack-first/base/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: slack-first
   labels:
     app: slack-first
+  annotations:
+    configmap.reloader.stakater.com/reload: "slack-first"
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Quick PR. This adds the annotation for using reloader to watch the `slack-first` configmap, which we discovered should be done when updating the operator to use a daily schedule. It should be noted that this change will need to be synced manually in argocd the first time.

/cc @HumairAK 