### PR TITLE
Add pep to osc-cl1 odh-admin group

### DIFF
--- a/cluster-scope/overlays/prod/osc/osc-cl1/groups/odh-admin.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/groups/odh-admin.yaml
@@ -3,13 +3,14 @@ kind: Group
 metadata:
   name: odh-admin
 users:
-  - redmikhail
-  - HumairAK
-  - erikerlandson
   - 4n4nd
-  - rimolive
   - caldeirav
-  - myeung18
-  - harshad16
-  - Gregory-Pereira
+  - codificat
+  - erikerlandson
   - Gkrumbach07
+  - Gregory-Pereira
+  - harshad16
+  - HumairAK
+  - myeung18
+  - redmikhail
+  - rimolive


### PR DESCRIPTION
This is to add myself to the `odh-admin` group, with the goal of getting access to the osc cluster 1 to use it for CD for the ODH CNBi functionality.

Also taking the opportunity to sort the user list in that group alphabetically.

It seems that #2248 did not have the effect I expected - I modified a different odh-admin group there. Let me know if I should revert that change, thanks.