### PR TITLE
[prow] Fix command path for prow commenter image

### DIFF
--- a/prow/overlays/smaug/config.yaml
+++ b/prow/overlays/smaug/config.yaml
@@ -369,7 +369,7 @@ periodics:
       containers:
         - image: commenter
           command:
-            - /app/robots/commenter/app.binary
+            - /ko-app/commenter
           args:
             - |-
               --query=org:thoth-station org:AICoE org:operate-first org:open-services-group
@@ -403,7 +403,7 @@ periodics:
       containers:
         - image: commenter
           command:
-            - /app/robots/commenter/app.binary
+            - /ko-app/commenter
           args:
             - |-
               --query=org:thoth-station org:AICoE org:operate-first org:open-services-group
@@ -440,7 +440,7 @@ periodics:
       containers:
         - image: commenter
           command:
-            - /app/robots/commenter/app.binary
+            - /ko-app/commenter
           args:
             - |-
               --query=org:thoth-station org:AICoE org:operate-first org:open-services-group


### PR DESCRIPTION
The [periodic prow jobs](https://prow.operate-first.cloud/?type=periodic) for issue lifecycle management are currently failing with:

``` json
{
  "component": "entrypoint",
  "error": "could not start the process: fork/exec /app/robots/commenter/app.binary: no such file or directory",
  "file": "prow/entrypoint/run.go:80",
  "func": "k8s.io/test-infra/prow/entrypoint.Options.Run",
  "level": "error",
  "msg": "Error executing test process",
  "severity": "error",
  "time": "2022-08-17T06:56:09Z"
}

```

The entry point for the images [changed on February 22nd, 2022](https://github.com/kubernetes/test-infra/blob/master/prow/ANNOUNCEMENTS.md#breaking-changes). This PR updates the path to the command based on the announcement.