### PR TITLE
add opf-obcs namespace and obcs to smaug

### DIFF
--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -59,6 +59,7 @@ resources:
 - ../../../../base/core/namespaces/opf-jupyterhub
 - ../../../../base/core/namespaces/opf-jupyterhub-stage
 - ../../../../base/core/namespaces/opf-kafka
+- ../../../../base/core/namespaces/opf-obcs
 - ../../../../base/core/namespaces/opf-observatorium
 - ../../../../base/core/namespaces/opf-pulp
 - ../../../../base/core/namespaces/opf-seldon
@@ -166,6 +167,6 @@ resources:
 - ingresscontrollers/default.yaml
 - nodenetworkconfigurationpolicies/vlan-210-nfs.yaml
 - nodenetworkconfigurationpolicies/vlan-211-nese.yaml
-- objectbucketclaims/openshift-image-registry-bucket.yaml
+- objectbucketclaims
 - secret-mgmt
 - snapshotschedules/schedule.yaml

--- a/cluster-scope/overlays/prod/moc/smaug/objectbucketclaims/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/objectbucketclaims/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - openshift-image-registry-bucket.yaml
+  - opf-datacatalog-noobaa.yaml

--- a/cluster-scope/overlays/prod/moc/smaug/objectbucketclaims/opf-datacatalog-noobaa.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/objectbucketclaims/opf-datacatalog-noobaa.yaml
@@ -1,0 +1,16 @@
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: opf-datacatalog-noobaa
+  finalizers:
+    - objectbucket.io/finalizer
+  labels:
+    app: noobaa
+    bucket-provisioner: openshift-storage.noobaa.io-obc
+    noobaa-domain: openshift-storage.noobaa.io
+spec:
+  additionalConfig:
+    maxSize: 50G
+  bucketName: opf-datacatalog-noobaa
+  objectBucketName: obc-opf-datacatalog
+  storageClassName: openshift-storage.noobaa.io

--- a/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/opf-obcs/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/opf-obcs/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: opf-obcs
+resources:
+  - ../base


### PR DESCRIPTION
Related to: https://github.com/operate-first/apps/issues/2064

This PR:
  1. adds the `opf-obcs` namespace to smaug
  2. allows external secrets to be created and used in the `opf-obcs` namespace
  3. recreates the `OBC`s avaiable in morty into smaug

/cc @HumairAK 
/cc @harshad16 