### PR TITLE
Specify resource limits and requests on kvm-device-plugin containers in DS

### DIFF
--- a/cluster-scope/base/apps/daemonsets/kvm-device-plugin/daemonset.yaml
+++ b/cluster-scope/base/apps/daemonsets/kvm-device-plugin/daemonset.yaml
@@ -30,6 +30,13 @@ spec:
       containers:
       - name: kvm-device-plugin
         image: kvm-device-plugin:latest
+        resources:
+          limits:
+            cpu: 100m
+            memory: 500Mi
+          requests:
+            cpu: 20m
+            memory: 100Mi
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
/cc @HumairAK

I'm not sure how many nodes there are in `smaug`, but I think we can try requesting only 100m CPU for the kvm-device-plugin container. 