### PR TITLE
:recycle: Switch to morty obc for temp fix.

### DIFF
--- a/prow/overlays/smaug/config.yaml
+++ b/prow/overlays/smaug/config.yaml
@@ -64,6 +64,9 @@ branch-protection:
         required_pull_request_reviews:
           dismiss_stale_reviews: false
           required_approving_review_count: 1
+      repos:
+        okr:
+          protect: false
     b4mad:
       repos:
         minecraft:
@@ -93,27 +96,33 @@ branch-protection:
           dismiss_stale_reviews: false
           required_approving_review_count: 1
       repos:
-        tensorflow:
-          protect: false
-        contra-env-infra:
-          protect: false
         statusfy:
           protect: false
         statusfy-ops:
           protect: false
+        stress-tests:
+          protect: false
+        thoth-ops:
+          protect: false
+        twitter-together:
+          protect: false
         website-tooling:
+          protect: false
+        bz1816214-example:
+          protect: false
+        contra-env-infra:
           protect: false
         cuda:
           protect: false
-        stub-api:
-          protect: false
         nvidia-usage-dashboard:
-          protect: false
-        template-project:
           protect: false
         pipelines-catalog:
           protect: false
-        bz1816214-example:
+        stub-api:
+          protect: false
+        template-project:
+          protect: false
+        tensorflow:
           protect: false
     open-services-group:
       protect: true
@@ -132,21 +141,25 @@ branch-protection:
           dismiss_stale_reviews: false
           required_approving_review_count: 1
     os-climate:
-      protect: true
-      allow_force_pushes: false
-      required_status_checks:
-        contexts:
-          - aicoe-ci/prow/pre-commit
-      include:
-        - "^master"
-        - "^main"
-      restrictions:
-        users: []
-        teams:
-          - sourceops
-        required_pull_request_reviews:
-          dismiss_stale_reviews: false
-          required_approving_review_count: 1
+      protect: false
+      repos:
+        aicoe-osc-demo:
+          protect: true
+          allow_force_pushes: false
+          required_status_checks:
+            contexts:
+              - aicoe-ci/prow/pre-commit
+          include:
+            - "^master"
+            - "^main"
+          restrictions:
+            users: []
+            teams:
+              - sourceops
+            required_pull_request_reviews:
+              dismiss_stale_reviews: false
+              required_approving_review_count: 1
+
 deck:
   spyglass:
     size_limit: 100000000    # 100MB

--- a/prow/overlays/smaug/secrets.enc.yaml
+++ b/prow/overlays/smaug/secrets.enc.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 items:
     - apiVersion: v1
       data:
-        oauth: ENC[AES256_GCM,data:k71VkWp9xHMH927KgUYEKygrceJZw3oWF78ESk+MbmLpzwrnwtIlK2GZivClm56/CFnTkBu8CmM=,iv:dNH8y09en9vktr+yhCi2LDYZ6G7d0e068i2DXTXoD0g=,tag:SXgiDo8bhnCp8kTgCAK5ig==,type:str]
+        oauth: ENC[AES256_GCM,data:0PVxHOwsBBp8jGH+8dTTVatijyWvKp/DNzNVuOxn5iyrp7eGrmwkHhM04LF85iy8aJoIq4bL6Ao=,iv:eCZyqpJtJYwiz03cGbnkA0YZlIBsiGzMwt0HGQxvSuA=,tag:ZOXA3UEzuULv+JNbv/1tvw==,type:str]
       kind: Secret
       metadata:
         name: oauth-token
@@ -12,24 +12,24 @@ items:
       metadata:
         name: github-token
       data:
-        token: ENC[AES256_GCM,data:bbZSCMPPWlrC3EoUsO3GFr7rG0haDEYSeQmNEnpxnavFId+V02wOfkQM/TFf+EeYvbPLxBQ6lvs=,iv:+cLunI2pk8mQ2re2NiUHLKJuaG4EvBUNeJhyWCAqxJ4=,tag:B155AsI3iS+KLwqyNiU4pw==,type:str]
+        token: ENC[AES256_GCM,data:txYplwA5PsaHyNMgcjC63plF3R8zUwyeB4VIXSDrM01JTx/saC/Ndkn6qt8o7seNHfwtHIfUVBY=,iv:T/6iJNHjw1epHTugZSmHTdVhzA61vCG+M+IAo6qDu2o=,tag:pM8b+FgLx4Wk2M5DEhMLmw==,type:str]
     - apiVersion: v1
       data:
-        secret: ENC[AES256_GCM,data:1/IS6HPlOZtP+k8W2VstcCpdX9hfgMxHM5YUVCI7Zo1CvDXXilUirlNKx50ypXp+dpekQkrGWpkjnxnn5fq84iEPPEpCGLdaeu6eWqEKhdYxtkXCaWx0JN6buYvD4IJjVpZCUKZiyzM2F/cVf+U+dRsKBN6Ry7YYvSzSrltAPs+F3dlChIFU8VLuKQ3zIoxxxXhPqHBh2ntSR/AzAhEYuMx9lmw/dNrBUtBPOhR2ONyhMvkOSawBvsmvcRwyYyP/cqV1mbCil6kVQNhu8PS5ISDO/dPIQXzTZb+dhn2rC9VGJzj3UgrAe/n3m2xk/IieLcUJrowzwc7D1/40dVQtAEaiGbeBvHZ5w90EjOfE5HQdu7WBiekfzdnHOzVvrd0kTsbGcu7hjI8+jKqG7A2aTA==,iv:qvg/hoYBV/KQgFmXvMlj6FU5AN9+3+WcrtYIBvYOybA=,tag:aAodVbub4NZ5QDZWfIbBew==,type:str]
+        secret: ENC[AES256_GCM,data:tkA7mYBjVEI85rCwno17WC0CwCHtmgNJ+wD8S2pll5//9LgOf5AbIg2zRJXoycKUJl72k5qXd0urPk1HZkIfbWwRU7m/4e3TASBvSiX9D+PUvFAr5++W5fFzqSViZ8PqP/9QgsHgoZkcguUEQQKRDcULqfwm1DysLvsmN5qEPnRc7j99+nk8t9bQlSX+l79br+cxs9VBWzfI7mBjlKKPWBASKeb5WsLlymMc74RHahDH2eQsiZZNenTTsquYyRXmVncDP68lPEeyrVgESBdFZ5s1uAb1pXpjN5APLhQUo8Xj0n9xN4g12r+7+T7FkshQiRxKfrhzL5o2Cxk67hxbBHOV09BJfLZfzmOr8P2ms+Wn0Zn6rlAhvxbXMqC9BP8kAsRQ2deKPzSrZiI3vqNjGA==,iv:HDlC4XbX/H5F7Fc6k/3M+B+RvWfgkLjrSVT7DY6r4TY=,tag:vNQJi9dlnOP+EpeDTYQCeg==,type:str]
       kind: Secret
       metadata:
         name: github-oauth-config
       type: Opaque
     - apiVersion: v1
       data:
-        hmac: ENC[AES256_GCM,data:1/OKOV9/mCUlKBaiOUHkGVac7YmOGc0upauNaoQ49MzEatqbZ0tQHqlE+5spZMlUoN5Jnwz/okA=,iv:4l/Pc8rd0GlmMvsVMLt6I9HD+Bi/EiuzlQrZwHY4W2E=,tag:G3T3Xmlym1zBiDSxoS1Jnw==,type:str]
+        hmac: ENC[AES256_GCM,data:k6EB1p3CZsZkH6gBP4nLaXZSnXxSCm0e9IcC++0QCwgcuOdDJFH2wcx8Gt28lhpfKKiKT9h176A=,iv:gx9A65rfeAdWB8hPC/7sN5mWqr4iP9mbPJ6Jj/o132A=,tag:tA2PQu/bLUIOms5uivxQag==,type:str]
       kind: Secret
       metadata:
         name: hmac-token
       type: Opaque
     - apiVersion: v1
       data:
-        secret: ENC[AES256_GCM,data:l9LYgewRpc47+NzDcmmnEv528XB/4HGiaYrqCrZXY/v0yqnZ66AWU8IUfMFW5zlqvikm0EoaIaK/X89g,iv:lsKnw2pZWDU4Wmj0/IqbAz/ZfUo3UT6Kt2/ykrULDMY=,tag:XU1R/iBuOajwRnn5HOE4rA==,type:str]
+        secret: ENC[AES256_GCM,data:TfB4CLqY06jvvxLaFb15rKNZgWNgADqKjrQ7bEoWcpeeSlTRfcrIFn7ns9Iqy8v6UqGdFqD8WpheTj9Y,iv:DaM4agke1S8RXMHgIGbFFdXDqIM7vXUBtxCsYItzwMc=,tag:8PwCg5sVb9AB/FwVtNmB0Q==,type:str]
       kind: Secret
       metadata:
         name: cookie
@@ -39,10 +39,10 @@ items:
       metadata:
         name: s3-credentials
       stringData:
-        service-account.json: ENC[AES256_GCM,data:ZxORvBrZYv6mCyRGWuXmzs8D6azgx9XOfqznY/BL9Gtp6JrSeq1ZBSBa26EgNH9JRSF6x9zwIb+SWuG7oVt0I8L+PcecLhYNeJxyF3+T/JhdaIfSO8Bh5JMiOhDX0CuO2YvW7YFX3nRcRxYphp6vHXa1lY+DXiDXsy5ETTENKMN59KRVBzuXKk8NrZWfS3IIiCgX6GVaghOeYIuNJUHsegJLoGv9kMxLo15TBYbn/c6I/eGyIDkh4fpxVTTOeof3aT+zfe9fRA+g6Dndc3cSBMWmmVl9t8EpHyIaFVhqW5fmzaNZxD8ca9FS+Urp871ceZPc03W5snJsV1t+OhCzFZo8vGU=,iv:H/jb6VDP/nH6tRFO0CDqh6ci4qK3vRUclGFvCr7QW0g=,tag:86NHz17Y+EXm+MYUThaksQ==,type:str]
+        service-account.json: ENC[AES256_GCM,data:r1YGbP0xRES96I50bYiykCK2pG1kQJoCCUi0otu47j8gDkMk3beDWj7+jyWzyww03ZrdkUcs+Xq3wITwnB7VwZuWAENloXnH+/hmdVmF0JdFZjLotk3hXkrF37dpcyZB6qmwkKPQqpx5CgIZISnskhNgi8Yvt8ODjw0DLaa8vfJ2GN7FEjE3+yVGtnqRVHne1MFDquUd7MnZWZQgeeeNNnC3aoG0XXmuv1Ir4I7hqq4EmxqvsPShN1XgWeU+I46/D64FbqmlRTMFUDxQ4vFobYWluqEqGi3sUCRnTKFPMJV6alvSmPRIiOjQTiSvOiFVoJqIAA7LGTs6fWwPRoYpsyJpcq+gx7SFJWqQ,iv:dKJHK6aWv+0JwFYwF9x8fRGOcLyVKEtaF9cAi8otuZI=,tag:b+kkoAaqW8ZZDlaTOihHrg==,type:str]
     - apiVersion: v1
       data:
-        ssh-privatekey: ENC[AES256_GCM,data:8UPGgNNeUoWW7Km0vupc2c+yxrYFTDrmCu/x9GqRGsxLTWV56kapDSN9ieHnOy5IwGO+lTXJ9Bj8fIuoC3kDsE1+DHkqzGCea9u1pQ9dM2QW+nNETZf1dvbzYqvQcKyCRoFPR0J1rM9BgWT7lCbS1XHcK1PBhsS5Xe24CU8YXJ0vdf5Fo7wBAsV1YFKBxdSxbp6+LUe0MPxexPKNM87IBXy+1VJjCxusJgKWX761pY68GodAO5qcL0kS+PcCIahcmDHjL64Ju+qrgn9aZ2X5jt+L6dgyh/n+HEN6zLTOkhvZO713bLG1ber59ey3CbFTeOboExZu/KKJzV9gzXa5XmnTsqcfDk18Spm9YDpErhJG6FFy7UkDhBRLb8l6J2MeI3UfdjzWWotCzu6CDrL3EGRnRCivBrHCnUczf7zV8Ta27dNr8x1NsXR0j2hit61ETAIYwAqS/CIMX/kRi1GaJsFIU9/8HT93SoJM7KanFt4gpY9mvUHdeDjMCyzbA1sx13VFvOGAZ0myLQN84gKsAU9Pu2/PPdNs9SEDS6X2yaChXThostjuFgM5zuw67A9oJUkZFybXMtT3y2CvkIOUWJ9hJ9lSwBnfQ4y+JWt/hmGysQkepSQ33FTKVbqcib+4s1mNfdaotRY+bTK2G1nE0LY5izf9rcv2HEFJJCRJAIUS7p8cxVA7wu+zOmfuanYGW6nd58G6787U+f44OdlFvV1amnPkGscHfzYFpRzAKkLutGI/ZZPDfmC5y6biVsVkqR+YbcYDMao0qpBGOFzjH4YP9zQTK4l461it971OY7Q6fwdoMOBud5Al3mwarGLxwIl6xI3QntPKo0dy7mi/yBK1xBloQdvmWV418PDloPBVkmeyCJkBsGMqlPOaG/s3kGuchFDsQKwKSner/qnctUTBELtaZSS+VNjN2vE1fH3TS3VkDL5G1HuLgqD4NJB3mFOcGza3Fm+I6JHZu+W7bjxqLFGTU18prjYpa/44QILQPi+ZyVFVLsIScHIE/SMRxfNbS5pePO54s+YJ8KkjBCUBi3NYDXU7RlvMZyMQKKs3uzJ8f7QKX4GsxL39JN1yVmK46mvN+8ptofczYOYueytHBTY9kMUVlW/NBbr5YiQXhUk0Z/HctYsSQJhZijqBhlNEVHARaV/CzTYcA/UceUHXpAMRT44IfM5liBGe+M/IdC5TDG7t5ghI46ln74Nmd1+GtTLyasoXwhT9E2sWvn9JfqHrULhMlO2g0V+FEJxHJ0VB7a7Cmwj5gDDH6mcJ6EM8lXOePQU0wYEtDPljuoKaXzLFNgd9FJH8tuMRGfkn+cO0Ek31r+OtZawA2oED+F5g49Q9toU56bsyUO6fo9qe9+dEFvTqCIPiHfcwSUpEaxKGmLUbJ9w3SxfErxx/ElPAApNy3tUJDb3rP/TsAn4cGC/eO9cn05gkbiXOmXn+ILJQf2A7STgFfUJMRjpa70jNbggBzpjYz9wNrhuFIeHKd5wstvc3ohOZbtBSm+gaJov/E2e6wQyV7o0wnAOrAnRB5lA4WU7oWD1Q5O3hEwmJV+fIyF7KuAYsgyK5bh2lrLIMontJhjEaJYrjlni/TGB0apdqrqkjrlzEWiXSYnsWFMMTVCNMFpm9JGXJlDDuKfyO3u81ByYC51M5V54M1nwOiCdoHT9YjCcPo75cNZsk3+66DDtQBfyiHhRO4YaQHheBjba1jJa5Lxyxtn8YfodApbgxJUh4y6+1nFdZ0uAgjvpCuGPaK7HPW1dv/J/EEzLcKJqYilrAHA8hmY41AN8M1gLwbQ9qlVUSzugH6+Hv92j83iWRj49VzZ8BodJS2Z40YQOGI+IkiepgQE/ubR8ah5E3XJuFUsltpITOhjAjqkatne73DE3Q4Ec83BAusd1M6BDip5i7nknxOP6rfbLFljmZ4hjzVB77od4ZBD4msZeU1tQrQKnoJHQeTEBiIqLaCmxzpCOzm9OVHbtRrBnQxa58vuc/RN+zqZXldfYn/6g4jPbuW9rcXWk8nFxSZwS5LCf13zJQ+E8esgqRG4UIe6+QCpgkXIxurZooQi1C3e52D6DdLJC6V9y6gifR/0bzyGvWZG2D6E+MeJYIAYoWpoSut1AvV4ke74Od9HN0UoQtQ91dm/h8h65HwMG/CeLLtfShBjxN9f2hXhgUD5KPLxsIXrxZu3+QdJcl1xn/YwNZV0oG5EUXjb14imWjeZQP19a8cajXWeUs9Ooozeef35jzsY7WnjM/wcHXJBSxHdYSdqbc3amTeOo+52eOaZ9Gjh1oqSuYxqCsaXCuAAE/bKVtLdZgmfDlr/c6EkqiyVJnwfaqbMULX0gbDKXTXEK0QMfE8dhyTrYBtZrRnB/q59sIQvVKL1bYTC+HbnVNrXHKSjzuq1+HcVeqOUdITjTe4MKncmHzUNrSdSaQNqUqIS8IpUDo6JUxH3NnXMXwtWgqfBMTEqNdSot6K2VixgH2lO42oJ72TDgdMApY2Rmx1fUb06GWfwWstP3K4IsvbaTV3eU3oYXK2NYTHM14Q9nR5lal3pdfJazzBZZoDS/tuCVRh1a/sCwBV387Ym6++VoTuHkCic6L+RzNMX/oduXC0PSnkehbju9cP0HuvWbA2p8YWrIQhhSZfhbRVc/+sGvGMtcolG6KCeTSUAYWuKFFLs6ebw49iBdDP/i0FKXjcZvMJZqONHkySxOj+QzSecv0JQCZtpAhFzdKwXJmTgz3vCXhderxvchU6CB9DOEz8wjEGyI6TLm/w3U/jZucyMun2ooSaRkRaehavt6mTQ26HaORjoTvQTvK450YdPI7A+MofeGs4TmCQ9vy4gQ+RVtrcT7RgJ3WPnOO6pJVaMihdxv21efF75hGoRTHk1v+2Mf5GshccKXrrbxiCHihgWOFgKiGB5T2zcklgmWvVFMMV8i+SuoUNpCkmRFcVZKvhjqvHtUpXYGB6bSPebIkk+c29kMpXqPKYmF0zA9qBfM9rfXyY5/Iy35gqQbQGzMKgqpuRdedIRAsRTyksVDwITEky8E6Wn8N2L1/P6YgdLWsIZB8bY+hLiobUMuhQCRr4jCrxsU2D8Odv0bn+4k/uFcpBjr9ieaSWfWoOALKlVw2m8J0cCJ7LUOIa0uu1XCOBfBT+FTajylkLPz1ndAiDlQN0WnWqUvuLvSg0b/4j/lvx14+qJw1WNPCYvGCPJZh5NQEAdQm8+YA8bvm0h8DQYHlYjc8nhC9Nx6g7Br8UnU6vrOZKTs3fh9pb6cpLsoyQ+pxLMoY+NOUtBv2PsYwn52w8gnqw9v5EOwOKmXQlCFeBiW+PoiiZlVz2PPSlWuIBMeIslRhtp/mk0ZJcfcljuCTPM6Z4mzYo5tUS20ze2ticefWezYVlX7WjGZC4P17lBXd4vvR2vM4dZAvy755c7vVNZZZEvIcjuc0nALKdcFKoEjI3G/5xlEzoWXaXMDahJI1HwUienPVNkV1//XuolYsBnRJAi9JiE6iCeSoeH5/J/8xIX4hQg+0jIOwnvqG1Lq6Gcw6Mp2o4bvG2lvYu1aNwGu0t4WEHuuA6ZSf8rAmHp0fKynPG9mVSDH2SY+Dil2eOUPYz4XAugKuzJSc1Lla622xC9l9TwTDTvp3LlQDwlTPtQH+V1W3AFd+BqoRSf2zxFA5nrHPB+PU3/wJ9eC9IdzMEz/QCxqeYIHgTEp32rE1TYEugBFFgZaCAnB2nLE9XkVthxjbCCjZyX67cAQHNTXyPwQwkR1ynjt6sSS9HRa8Je9b1xWIQ57+bCNecHbh8hmNdpyccqlz/NpcSoVkm4gnBckbzyCKyhXFTPpturdCwIpuzsm7QOUIZy+5DhLCZTqL49tJltcwx4yWbkTagg5fPOwUu9hO2UZQtxsgt+rGR191HqSUGLD0YeQcgfcv7Isq3G5ehmx3aO/Jx/ELvF80tuM7gAS8a+jwYoGsFsb701oEnshnEfWZkhkPUI5+TtsTZaKypOgvEAFDWUIMyQfFiQxoGsa5J2TxKAv0JMjmq7+IketA6LFxMR2DNOpHhjNtsLRaYfzmSGsVLDwj9p7f/N7ry8YUrFVow+JIiTa9y+8RgKWT4tI9MTzvXiV/HzHF0SaUP52iju+1O5RNDDXKfVwXMTKymSu7ruGC/gyo7Fvm0aGMXArzmG/KStIV9DpnOvCYdtjMp5C24OvT+hmBGPnusQOoz9XrGNFjcC6OuB6n7kjTN1DdsW2f1mXk19dwAPKmvPPkDzyLAmy3fGbM5qQmBE098gYrQRnT2k2yVWwsoTte9bviDuVTQ16HjGy+/AO+vPBFxGAniar/GUm9bRH5AxembfYirbRq/95kxI7G+wBTPGNXVtYPty0Dq/NJuMU8XghFpvUYlygreAn2r/zCMy6vCPUr8yF1937qxWsFMAe2Hb9yQvTAxAw5pymWN1nvydjLAJ+O+YLsfAvLI2w9sx8D6KjE0HZbbU43KGB99CKlnNlqyWHBuBncXKB3q+jHklTo8KMFtCeruy/D3dvAxYS2lxXPclIX4pLXPTzWJHCvivIeJo822o5jrhERIBpzJGMjKHRUaqZlRMzlb66RErlb87OQ2raQFPrw4xHo+LWzWWRF3BXvBH0iLXMUpY0N3jOSd2lVyJiv4fXd,iv:BVU/9dF5eFExe4oj242vkxRoF8uCijaT36ExHX1ve/k=,tag:fh1hv9PXIuxvVLCWOr5XXg==,type:str]
+        ssh-privatekey: ENC[AES256_GCM,data:aLJyPO+vtkKXmAfKeBhGgWrvnupXZYpPk1Sj+rzjoN5uOLU+UxB1Xh7J6wkaoQXNxcecfjYUEX3/IXe5OPEpqwS0NiDEq+I00jaHdZGG76SsB1KSQOWwXHUSh16xwLWYutY44v3tBOllBTAxI8BJbmN0z6w75qqEOpVo0+V2TBoi2imsSL1hI/h2Ds06rI094313h9sFraVnbXVlVCTUYfAVORMtAXh443MMFQZYPGwC2lPdHuFY6FvTenMSRopaX64IOhLwPUHmCIzKf6X6YrgdSYsRMUszna0I+2iynvOUQbj3ei/JAEIPTIMCAXasmw/aOvWQmYewiPX4U/KlU2/Xoz4QcForRyFDPURE5+pW3Fzxyu/Q8ucWPBAgttlI0IIGIIoFtZIpZ6eI633PjJKEbAxsmMDyekrv2l7eB8t3vR8pH6GuKnjoHeFS+02ymc1Gapbh0QXc+Yo674OQWpe7Kw/menjSfZkQf42GIE8Uu7EitKxx3bHbbEmXn6/b+A3nzqQR7AA58wAanwMUflj6p4IRy+UG5Z7Q92FfaAUAVxMF41Xse6rX6yUYUtcwFB6JlQjR28wxiC6Pc1Vgmeuv1ira1zuqFaWVwkbzvTT3iEcITjtjaP6o7IdYISrSeGQb0flvixw+NKeicKqkRvM0wsJGqjXSlfkPIWwMme0jmwsPge7xc9WGefN6s0zSLrrU6JWU2QkTiEUwTcSk35Gq2hPkT8OlLukT+GPCs4I0TSVS82WkPqIwVMibDuf1ieeINXAm2SQPW5cQ8WkUWzfAnHuroolXkEBSDxkHK6B4lq3DBOpRHQeJpfIf1BS9gHisEqrghc7dKyTeJgCPXNWjqwPE6m/KACy1FUfZHadcFuYQPWZjvBkIFCKAU0pxnqi3bYNDrCrKxg8CwJIoPXCW3PFGJV2vqMuYstLvAcCviX+WA0cNCwsju/SXRcaegcxO4vYLNEprme8gaDFMBfRTLL7FhyfZ7rOK3TOnBRZukupsWPSqBttejRbJGVfnL1EIWP0vtnOUCDE7u3XmC3tY+/U3HbJpXxgwNjnBaub1GBMjaz82aA31BC7Oeo44v0VCY9BFqM/KRRtTKKrJWSht7GykOrN+fLPMmOzvnS63WQ4Y/Qh7Q9voclHZfExPZD464Y9bMehCh9UIs9SM5nEwnCn9i9X8QriDYjUBdU96MLgiZLQPQMjPLI9CdzvF0KyiWqdlyJQIoqGtDIIxmtkJO1BwThZdWydPIIO/ep8im+DKR6J9pQbYZpi1Zfm4zrq0h5FgopbRk9slOlmUfmo6AorSii+4VGB0oD5O7/NKnjuM/Kc0a2hvO0FxBH5d6ldr8jL8JIw1gbx21asJjFz8fguNXyr/WBOV0KfAQWLpJ5Ax89Jopt/wskc0Tdb3+GcoWlOt5LnlV1DP7y/xFHBqd8uIqzYuAwJ7SqmHsKUMjghYeoGOF/jcwYOf9+RSfsXPtdf38efO9G1+gBsTeMYrdDJDBhQw1yk2j5mReA364YEADm1UUJVxCSoT8A1QM4mhsXxMORLI05IL61Trp4ZMKCIBzJJY7bnSjQ9RL6VahH7cCGo53OEom06+GfL4aDjlPJOVfTbwmtkOZbqkcnEFWzLt6Bgsnmw3u+ULLRir2jpO1zt9OBePL3yXfdDBkMkUv6qUuh6mBSyUvlz2/8EDNh0dGvHr8QwnfFTsZ7z3bSXPXIi/lKxNWPfzOL7pF+dGvVTQypDb5ErsOK+v4+CfzD5p2RYlLEq9e2Qis3cMosnIuP87dlgmsiiq5iwO8Ej8I+deVdKMDeB1eNSHfVmYHNhH1NOhgmXj3hym5dMDSExi8SO8z1qeravGTU31GI0fq28GQ2WYF9qgaF72qW8uEQ62bwwkK9nQfvBnkJy2SMHRrbo5ymRJp9jF63+1eQmNL3I1qh2a7/toTiSxkxYXscAQk2+g+qJ29FAjPO0kVbYCM7mcJjxJp4h+iIcLnnhHr0gB1Ahtae+rzzEIA0kYHhmNncT/py2qYKOPyVXFUZwQds+crUuIqJGlMsEdbUZ+Hyhk8gE7A7VUdSKAKL9/ziuZkCWc6JzhU0JCNGO4fMTUUl6P9m+edXxx8tklNbbeRyKMQAIPFN0zZEdiZ9QKFqeQy79JoEN6Kq0BBJe0WGUd6MKbW8yg3nEuhhPDygDNXItEeI+Alx1ckJJKgFDxGqKyFlpQKQppZJSc6TeQofIfQhySRyyFppcs62/nLYjSmXTMM+DGhhqsFNNBhrOr8fuZ3/omhjQtCNXOms2HKQlDO7rhuQ/mdqKS9blYoj2+cJeUOOzgXUC+6+0W/xtC59hDyPBiFxDEEvJ83tsfzBM6YzLHH+yGzofJtZqUUa+N94Acr16EVbnZjJsw9+Ef40mrDMLornEUEXI1zLfCxNLKT9g1vMu6NhdIdSCOzdubR511OE1JEghjo3NMsnzaKeRLLX4fPNG/qfpiTMSkH0Rf4pB1sVUIPK+IfcvnXf6E3KXbELXaYsycYdVbT+Fom0RIlN2TuvsbNPhiGxGIrXR6b0Y46YGyXHxwWGSwgJUooDhJUAt3ArUKg/AdTaKwqUnTnxXrtk66mAJQV+CHujMPzQZ4/IPJObbuQ0bvZ/7KKl9vjMUu8Ja0oH6ylWfmo8A0KmX4czTdcdstDR2R7+oSXAN03AanS98kqAZakW+p0GWu1aTh39omeKm9DB+KD0XZWVTccmR+IAsZs/hgYJanqpjFOq9cq4VmolmtLyX9omQDUqI3FIhfQqz1L7/2el7r2M8/6DF0YRISzUM3JNqcL5ZJ9omdarCUJOINY1MsnFNTtq8P4pEX//NsGe3nX8DRAJYocgquCruxj0YoR7NN60KeT3MIR3kEFPzE/wpKb8CyDHuzQaA0sG7fgBAijSJd6seIhrI27xOLhGtqela9+/bpl4A7McQ5DwI5tTb/dmu4ck8ZR/u/rZPWXvO3OWEOpf8BAdr7p74OytXmRPJiAjhyYvPN3UVv/tN1VDvBczmh8OOKY437ueXNZmfAUaJN8v1h2eBNgqEEucwj6m5WsqBm1oYrV83XNpRm8bXoEmeqfeSMYv+qBxO0d1SB1UmD0dNeFnLsnbX3Dgy7hhWVg6H+9R90ocMJAuBHzLzAWUdZbl0puhIYT2D+iFYJvtp1D4ms3CdG78y84fyZdj5B0jsu5jiIukV4B7DG/xwCC/kAfgQdMp/HZQP0/kqh5B1QMVRp46Uaoe9E99fpbdUGFFDO9TQwuol8TOmDsJ82PWljd7icSU8Vg4s0LkNJDNny1KEX5aetllvbnbf7C+9iprRL3nDHk6ddZhzHwD/gcgvzQFsnI+cLAtVsKkA55V0tGU9M1lMAjG6pQor79g5RAD+cxHepenCLvOpJN6hKILaNWiig8MK1Kad/8cxYcns2T3+h2kAPkeJlm80G0fXIXzzJubCoCfNl5YIocdjOUuA2O7X9cK62NobpN8RYmPg41d28i4h/SbK65aiuerDw68Jh0j7HEKjb/x+l8RY5mrup7/xxm9owfwwXkhu86OgTGr0x/ZybvVjFyscWRK2qszzN1KN7yN6G6wGwDInK/LpsmO8Lq0LCZiK5j64eIB+6BM3osOy24E0TPgVyrBwjJsFYssBykwk8a4QoNir+s9/HCRIXlwrlXmof2DtgcZxqpV452GcT5stgx/BLKXsrFd5LVd3AsrdtovxSUz4zXbsSEcnuMFQh1hOLc1uJHx0ro8nz1PZly0tn1ZZtv/JqODCuwEg5sQBjDX7rq44JC63cBUY9wcdj1YyDskSyoZwvRjLOavU0ZLe2LCBC1FeHNQltYqwehiHLe0cEDYPH8yQwBpG3a59fIQSqRpaZQMONfZJjY8scoAMjrN6GBGT45neQAZWAL4XBPOWPzX2URqP1pLWvuhM6c7HfuDmlQUUPYc+cddrPAzjlwaVIgk70YTHZgRZtZ5uET7l0h6QMYAiaH+riSAoVLJLS0rrRMztJ89D0NFWizUOG+jFyRbqzOcfNJ4sY6n/EFw/6vrwwk7OMVtdpfUPLiGsIkf/NdraBh4HzjignpmBazKozc0+76FuRUhGWDppbK2fNM7yXHF4u0g9vvWGzG7rQQr+ESULhC/jrnm07oZQ6qjneO0aXZrUzJgvQ/7pNt9uWp+WHuD+TtiEpRJT5vw9FjqOvQYjDoSTSSD+zF9E2okV2CX2HweWN7dwO4aAsLFFKmL3mvhRo8CHHrtRhyS6LnwO5NFkXDuBZD6isFk6hE69jqkPTG5gbRxBfWAmdO1NaVwOVPkqhizv1ODL3P/WQAV8f/NW8p8S/2rzLXGFnp6Q3KbKaVwLiaeZlhojLuOGZdkhzw7kdMqS09s8B68YXlf+LGZPCWcflIuyaOOhbK0sEsp+GEy6g1HWcdQOb6pKEtHz8meIBjy5SQPEsJ+rRUhZd4pvvMvxm59RwFehMerK/wvuEqKFFRcEUUiGFuwnXkwlrPJUuLKVudnkFB2Gy9NndIF4DY650HIYSbgDIw6QsO8m9J5iToyFfP7zwTfkFs/WyLrjq90YBAqZMj/JXo7Nh7IdmyfeLqzmt/X23DVvp/9zcFNbTJxlisqa/8sefFcZFXcPTkWgkmltVJQmmGYUnQfoHFF0W,iv:YcRdnGt08//wty9qM7M3M4QtFC5/gQJ9/xB+iyiuDmE=,tag:FFpC2IEmFzLExGsX4qRNsg==,type:str]
       kind: Secret
       metadata:
         name: ssh-secret
@@ -57,27 +57,27 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2022-08-14T04:49:05Z"
-    mac: ENC[AES256_GCM,data:vRotRlKtNov5Te+Cjkyb408pR8m6lxi0vmiXigZpsBNktqi0IJiUnef4pSvOweG43tilAk6SAKgUmDPU7qKpTByb0EsYdb51jOmQyWAkaDgkECsRy9hn4A38FzAtXN0AHN8VbhguznbGzqBLsYzcQycsWlakdY1hVurfCD+GbQE=,iv:MneUfHalFtS1l6hb/kQ4QlAwzEu/HxsQLYBxpJh4kPQ=,tag:UNSF/EVERunLkoxDqkjSYQ==,type:str]
+    lastmodified: "2022-08-19T15:04:49Z"
+    mac: ENC[AES256_GCM,data:zetBhMYHzOlU0Lh2lHcPZWOYzUB2xG9gPlEEdqhfP2sS0rgrm8k38WwF9/QYmxTP0cyo96HTAobmUon7Uuy2nbRIOllaEsi4eFqnCpsQpZ/HHtFcu0YftPGKY+2FSzHIJXjpZR61rPIrW1av2EmzlWsSsw8cO1s7oimdt9BVHBo=,iv:4xPUZCAmK2T82DBRVJB93SPHoVKMsPjLmFQAJWFfzyA=,tag:iWhiLIESIYCq3QlZCr+MnA==,type:str]
     pgp:
-        - created_at: "2022-08-14T04:49:05Z"
+        - created_at: "2022-08-19T15:04:49Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            wcFMA9aKBcudqifiAQ/8Ce4IFB+eIMp4m+HsLEh+CuH1daZYlwBiJOr+LlPTyLNP
-            E8iIZnk0+mq0f6cw+yx315ScoFP75Jz1rTzaSo3qQ2b9352Vfi5BFOxShJeYSlTY
-            DT9m/x9Vi6nu9frb+m3/RNZScIyqnZl5KD+8TSzajHPs9BW2m2rsaoFw0tb2GQDr
-            1CV7+XifYt/3LJQVU+rC1HffuL/22EHhvBCIsMEgHxH1UYcFG1gpiGPGGmFebqcA
-            0sodS6JOy0Q4ZyOzxBENHf7+HuwogGi5pLJRaekH0bVG1pN1ALpUJDpW8dX0lPXR
-            tSOgoSs0kHEU/JbnCoSjB+UjAzT+ss4qZEpjk22rKdhbJ1adBGlWafQBYKIPGWJT
-            vFtHITs5VeRHvQUMsXUodqYYhCWd6L/aZUQfnEdC5Mp7bCosoR4Qc/UfEbtluymB
-            011DWEM61s4V4lWdhdR3PC001MXPcnGYDDLags0CeGjvZUipgQ6I6x5o8rQxvKKn
-            XoMBXWWkBGCf3NOxhjAlMsVbFWQBHe4kz5GUpGofMMvzNOs+Fk3NxvWMX1mVmnHN
-            JUPtCMRPfRSJ9Y/Z55QRdFRZ1Ncj5HXbF9z2WQJNXSijHWnpM6EKOT3xFg4ydkHL
-            86Ru57g/2uhMd/aSz4nXFC/YOy7qIBXsjze50F871Lmb+0Q+uE9YjbzkMEF/LVDS
-            UQEk73KhoV8rr5SXNoFMBTzyn/P3nahr7uJhE89Rnyqbw3FMb/s0HTULG5odVl0b
-            HIMfu2p5ir9rSoYb34YFDio9V/zdzqk1P10Yt0OFw4UpxQ==
-            =UNGj
+            wcFLA9aKBcudqifiAQ/3WRa9iFQ7/eDD+WreINRhcSSSmDeGUewX/Ybgcq5g1WNv
+            +W2NimJlpJby0IAhwgc0tcfXUGf8iB0Pu9+1c2uQLcMIOsw1DYWVS3Rb+TymfQbn
+            0NxcTg2+fkW05wI9NMVTB0kPVN88lBzPfjhGT0bEgfeNkJ1PCC8+e3IsIqsfZ84T
+            D3qKDUwuxQCS547tdVPF+V0O1w8Rz2w5YF7X6v4UuQrXFWxl0hVwIrOM/vcgvEh9
+            xBEjfQp+0L1HVyJclx5yLp7Kxhlyal0luEl15NkuZIGOfcHgcZPJfOwLln9J9tnw
+            uMwHxrIU5VwkDrdsb78fr8G9CeY3zmeK8VTTIT5s7Kx5Ls3hGgIXPATaoSc0m7BA
+            dlvnJL5xF7xLX4yZgwIZyieuSlx4oSipNsvJZ4D8pAwqmn3MTJz7QuaiW3v72U45
+            /FYmBoafruI0m5vxtJb/UrI/r7qFCEbHHEuiqPtBmngEFU2V3yc1mTvwxWKP80zh
+            TvsqDRcUbyGGNwv00y/c1B2IjXZBus4I544ZQIUkfmO2ds3YcioCfK3aEQM4pRmx
+            fhacWmprSEDDSfWaERQU7e1z4k9QkxXVM3d9DokTMGZlw/090nqezi3KlYb+9mbD
+            P4ajz9NCCCJGWDH5J94uB0PbcTOoCwPhUyK0iVGDXItvCObWrG4wQpim1cszi9JR
+            Aa1a1K40eA2kzx4Bqk/P6zhrW388BvX4LlL/LJ/mRWinPUzy87RLwLdV2IiaS/mz
+            kkOAJc5yT7TlJpJBW48nyylzXoTUHEmAM99V8tiHXbm+
+            =wzO5
             -----END PGP MESSAGE-----
           fp: 0508677DD04952D06A943D5B4DC4116D360E3276
     encrypted_regex: ^(users|data|stringData)$


### PR DESCRIPTION
Switch to morty obc for temp fix.
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Fixes: https://github.com/operate-first/support/issues/615
Related-to: https://github.com/operate-first/apps/issues/2064


- Move obc to morty.
- Removed private repo for the fix of branch protection.