### PR TITLE
[prow] Switch the merge strategy for thoth-station back to 'merge'

### DIFF
--- a/prow/overlays/smaug/config.yaml
+++ b/prow/overlays/smaug/config.yaml
@@ -206,7 +206,7 @@ tide:
     open-services-group: merge
     operate-first: squash
     os-climate: merge
-    thoth-station: squash
+    thoth-station: merge
 
   queries:
     - orgs:


### PR DESCRIPTION
I noticed that the merge strategy for the thoth-station org switched from `merge` to `squash` recently (commit 24c9bc53e5c5623caabf019a3663a8d9dc8c5b11 from #2251) and I could not identify the reason why.

Assuming that it was an oversight, this PR sets the merge strategy back to `merge`.