### PR TITLE
adding jerry to acm managedclusters

### DIFF
--- a/acm/overlays/moc/infra/managedclusters/jerry.yaml
+++ b/acm/overlays/moc/infra/managedclusters/jerry.yaml
@@ -1,0 +1,7 @@
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  name: jerry
+  labels:
+    cluster.open-cluster-management.io/clusterset: argocd-managed
+    authdeployment: primary

--- a/acm/overlays/moc/infra/managedclusters/kustomization.yaml
+++ b/acm/overlays/moc/infra/managedclusters/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 - osc-cl2.yaml
 - smaug.yaml
 - morty.yaml
+- jerry.yaml


### PR DESCRIPTION
I added jerry to ACM via the ACM web ui and it successfully got imported.

Now following https://www.operate-first.cloud/apps/content/notebooks/onboarding_new_cluster.html#enable-argocd-management-in-acm

Not sure what this does. 🤷 

@HumairAK @tumido can you explain why we need to add it here too? Is this just for state keeping?