### PR TITLE
Exclude kvm daemonset img field in argocd app.

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/cluster-resources.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/cluster-management/cluster-resources.yaml
@@ -22,6 +22,11 @@ spec:
         - /spec/rolloutStrategy
       kind: Config
       name: cluster
+    - group: apps
+      jsonPointers:
+        - /spec/template/spec/containers/0/image
+      kind: DaemonSet
+      name: kvm-device-plugin
   project: cluster-management
   source:
     path: cluster-scope/overlays/prod/moc/smaug


### PR DESCRIPTION
This is to ignore the image value change when OCP replaces it with the registry path. For context it's [this resource](https://github.com/operate-first/apps/blob/master/cluster-scope/base/apps/daemonsets/kvm-device-plugin/daemonset.yaml#L32).