### PR TITLE
fix: Add web terminal already present on infra and change to Automatic

### DIFF
--- a/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
@@ -25,6 +25,7 @@ resources:
   - ../../../../base/operators.coreos.com/subscriptions/cluster-logging
   - ../../../../base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator
   - ../../../../base/operators.coreos.com/subscriptions/rhsso-operator
+  - ../../../../base/operators.coreos.com/subscriptions/web-terminal
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-reader-k8s-annotations-exporter
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/moc-nfs-democratic-csi-controller-rb
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/moc-nfs-democratic-csi-node-rb
@@ -63,6 +64,7 @@ patchesStrategicMerge:
   - storageclasses/moc-nfs-csi_patch.yaml
   - subscriptions/cluster-logging-operator_patch.yaml
   - subscriptions/kubernetes-nmstate-operator_patch.yaml
+  - subscriptions/web-terminal_patch.yaml
   - groups/cluster-admins.yaml
   - clusterrolebindings/self-provisioners_patch.yaml
   - clusterrolebindings/klusteraddonconfig-editor.yaml

--- a/cluster-scope/overlays/prod/moc/infra/subscriptions/web-terminal_patch.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/subscriptions/web-terminal_patch.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: web-terminal
+  namespace: openshift-operators
+spec:
+  channel: fast


### PR DESCRIPTION
Web terminal is already present on Infra cluster, but it's manifests are not tracked... (How come?)

This PR:
1. adds the manifests to this repo
2. changes install approval to `Automatic`
3. changes `alpha` channel to the only currently available `fast` one.

Resolves https://github.com/operate-first/operations/issues/495

![image](https://user-images.githubusercontent.com/7453394/186688164-78925672-8abb-4cb2-b833-b005191322c1.png)
