### PR TITLE
Roeorder volumes in kepler scc.

### DIFF
--- a/cluster-scope/base/security.openshift.io/securitycontextconstraints/kepler-scc/securitycontextconstraints.yaml
+++ b/cluster-scope/base/security.openshift.io/securitycontextconstraints/kepler-scc/securitycontextconstraints.yaml
@@ -19,8 +19,8 @@ fsGroup:
   type: RunAsAny
 volumes:
   - configMap
-  - projected
   - emptyDir
   - hostPath
+  - projected
 users:
   - system:serviceaccount:kepler-monitoring:kepler-sa


### PR DESCRIPTION
Argocd seems to really not want to work with ocp's ordering on this: 

![image](https://user-images.githubusercontent.com/10904967/186710529-848045e0-b3b1-4074-af0e-606b2e80e815.png)
