### PR TITLE
Add grafana operator to osc, and grafana to osccl1

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl1/cluster-management/grafana.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl1/cluster-management/grafana.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: grafana
+spec:
+  destination:
+    name: osc-cl1
+    namespace: opf-monitoring
+  project: operate-first
+  source:
+    path: grafana/overlays/osc/osc-cl1
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false

--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl1/cluster-management/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl1/cluster-management/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - dex-secondary.yaml
   - external-secrets.yaml
   - kepler.yaml
+  - grafana.yaml
   - k8s-annotations-exporter.yaml
   - kfdefs.yaml
   - odh-operator.yaml

--- a/cluster-scope/base/user.openshift.io/groups/grafana-admin/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/grafana-admin/group.yaml
@@ -1,0 +1,5 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+    name: grafana-admin
+users: []

--- a/cluster-scope/base/user.openshift.io/groups/grafana-admin/kustomization.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/grafana-admin/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+    - group.yaml

--- a/cluster-scope/overlays/prod/osc/osc-cl1/groups/grafana-admin.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/groups/grafana-admin.yaml
@@ -1,0 +1,7 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: grafana-admin
+users:
+  - erikerlandson
+  - redmikhail

--- a/cluster-scope/overlays/prod/osc/osc-cl1/groups/grafana-editor.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/groups/grafana-editor.yaml
@@ -1,0 +1,7 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: grafana-editor
+users:
+  - rootfs
+  - husky-parul

--- a/cluster-scope/overlays/prod/osc/osc-cl1/groups/grafana-viewer.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/groups/grafana-viewer.yaml
@@ -1,0 +1,5 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: grafana-admin
+users: []

--- a/cluster-scope/overlays/prod/osc/osc-cl1/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/kustomization.yaml
@@ -6,6 +6,9 @@ patchesStrategicMerge:
 - configmaps/user-workload-monitoring-config.yaml
 - groups/cluster-admins.yaml
 - groups/cluster-readers.yaml
+- groups/grafana-admin.yaml
+- groups/grafana-editor.yaml
+- groups/grafana-viewer.yaml
 - groups/inception-admins.yaml
 - groups/kubeflow-admin.yaml
 - groups/odh-admin.yaml
@@ -42,6 +45,9 @@ resources:
 - ../../../../base/rbac.authorization.k8s.io/clusterroles/acme-operator
 - ../../../../base/user.openshift.io/groups/cluster-admins
 - ../../../../base/user.openshift.io/groups/cluster-readers
+- ../../../../base/user.openshift.io/groups/grafana-admin
+- ../../../../base/user.openshift.io/groups/grafana-editor
+- ../../../../base/user.openshift.io/groups/grafana-viewer
 - ../../../../base/user.openshift.io/groups/inception-admins
 - ../../../../base/user.openshift.io/groups/kubeflow-admin
 - ../../../../base/user.openshift.io/groups/multinode-demo
@@ -52,9 +58,10 @@ resources:
 - ../../../../base/user.openshift.io/groups/sostrades
 - ../../../../bundles/external-secrets-operator
 - ../../../../bundles/kepler
+- ../../../../bundles/grafana-operator
 - ../../../../bundles/opendatahub-operator-manual
-- ../../../../bundles/training-operator
 - ../../../../bundles/openshift-pipelines
+- ../../../../bundles/training-operator
 - apiserver
 - externalsecrets
 - ingresscontroller

--- a/cluster-scope/overlays/prod/osc/osc-cl2/groups/grafana-admin.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/groups/grafana-admin.yaml
@@ -1,0 +1,7 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: grafana-admin
+users:
+  - erikerlandson
+  - redmikhail

--- a/cluster-scope/overlays/prod/osc/osc-cl2/groups/grafana-editor.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/groups/grafana-editor.yaml
@@ -1,0 +1,7 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: grafana-editor
+users:
+  - rootfs
+  - husky-parul

--- a/cluster-scope/overlays/prod/osc/osc-cl2/groups/grafana-viewer.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/groups/grafana-viewer.yaml
@@ -1,0 +1,5 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: grafana-admin
+users: []

--- a/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
@@ -7,6 +7,9 @@ patchesStrategicMerge:
 - configmaps/user-workload-monitoring-config.yaml
 - groups/cluster-admins.yaml
 - groups/cluster-readers.yaml
+- groups/grafana-admin.yaml
+- groups/grafana-editor.yaml
+- groups/grafana-viewer.yaml
 - groups/inception-admins.yaml
 - groups/kafka-admins.yaml
 - groups/kubeflow-admin.yaml
@@ -45,6 +48,9 @@ resources:
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-rb
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-reader-k8s-annotations-exporter
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-readers
+- ../../../../base/user.openshift.io/groups/grafana-admin
+- ../../../../base/user.openshift.io/groups/grafana-editor
+- ../../../../base/user.openshift.io/groups/grafana-viewer
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners
 - ../../../../base/rbac.authorization.k8s.io/clusterroles/acme-operator
 - ../../../../base/rbac.authorization.k8s.io/clusterroles/pytorchjobs-create-aggregate-to-admin
@@ -62,6 +68,7 @@ resources:
 - ../../../../base/user.openshift.io/groups/seldon-admin
 - ../../../../base/user.openshift.io/groups/sostrades
 - ../../../../bundles/external-secrets-operator
+- ../../../../bundles/grafana-operator
 - ../../../../bundles/kfp-tekton
 - ../../../../bundles/opendatahub-operator-manual
 - ../../../../bundles/openshift-pipelines

--- a/dex/overlays/osc/osc-cl1/configmaps/files/config.yaml
+++ b/dex/overlays/osc/osc-cl1/configmaps/files/config.yaml
@@ -46,6 +46,13 @@ staticClients:
       - https://das-odh-trino.apps.odh-cl1.apps.os-climate.org/callback
     secretEnv: DAS_SECRET
 
+  - id: grafana
+    name: Grafana
+    redirectURIs:
+      - https://grafana-opf-monitoring.apps.odh-cl1.apps.os-climate.org/login/generic_oauth
+      - http://grafana-opf-monitoring.apps.odh-cl1.apps.os-climate.org/login/generic_oauth
+    secretEnv: GRAFANA_SECRET
+
 expiry:
   idTokens: "168h"
 

--- a/dex/overlays/osc/osc-cl2/configmaps/files/config.yaml
+++ b/dex/overlays/osc/osc-cl2/configmaps/files/config.yaml
@@ -46,6 +46,13 @@ staticClients:
       - https://das-odh-trino.apps.odh-cl2.apps.os-climate.org/callback
     secretEnv: DAS_SECRET
 
+  - id: grafana
+    name: Grafana
+    redirectURIs:
+      - https://grafana-opf-monitoring.apps.odh-cl2.apps.os-climate.org/login/generic_oauth
+      - http://grafana-opf-monitoring.apps.odh-cl2.apps.os-climate.org/login/generic_oauth
+    secretEnv: GRAFANA_SECRET
+
 expiry:
   idTokens: "168h"
 

--- a/grafana/base/grafana-route.yaml
+++ b/grafana/base/grafana-route.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
 spec:
-  host: grafana.operate-first.cloud
   to:
     kind: Service
     name: grafana-service

--- a/grafana/overlays/moc/smaug/route_patch.yaml
+++ b/grafana/overlays/moc/smaug/route_patch.yaml
@@ -1,0 +1,6 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: grafana
+spec:
+  host: grafana.operate-first.cloud

--- a/grafana/overlays/osc/osc-cl1/dashboards/kepler/kepler.yaml
+++ b/grafana/overlays/osc/osc-cl1/dashboards/kepler/kepler.yaml
@@ -1,0 +1,767 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  labels:
+    app: grafana
+  name: kepler
+spec:
+  customFolderName: kepler
+  json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "Dashboard for Kepler Exporter",
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": 1,
+      "iteration": 1661529024904,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 11,
+          "panels": [],
+          "title": "Carbon Emissions",
+          "type": "row"
+        },
+        {
+          "datasource": "${datasource}",
+          "description": "Using CO2 emissions  by power generation type as reported by US Energy Information Administration https://www.eia.gov/tools/faqs/faq.php?id=74&t=11",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 60
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 21,
+            "x": 2,
+            "y": 1
+          },
+          "id": 12,
+          "options": {
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "text": {}
+          },
+          "pluginVersion": "7.5.16",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "emea-morty"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(pod_energy_total{pod_namespace='$namespace'}[24h])/3600000000*$coal)",
+              "legendFormat": "CO2 Coal",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "emea-morty"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(pod_energy_total{pod_namespace='$namespace'}[24h])/3600000000*$petroleum)",
+              "hide": false,
+              "legendFormat": "CO2 Petroleum",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "emea-morty"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(pod_energy_total{pod_namespace='$namespace'}[24h])/3600000000*$natural_gas)",
+              "hide": false,
+              "legendFormat": "CO2 Natural Gas",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Namespace Carbon Footprint (pounds per kWh in 24hrs)",
+          "transparent": true,
+          "type": "gauge"
+        },
+        {
+          "collapsed": false,
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 12
+          },
+          "id": 8,
+          "panels": [],
+          "title": "Energy Consumption",
+          "type": "row"
+        },
+        {
+          "datasource": "${datasource}",
+          "description": "The mW per second",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "graph": false,
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 13
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            },
+            "tooltipOptions": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "emea-morty"
+              },
+              "editorMode": "code",
+              "expr": "rate(pod_energy_current{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[1m])/3",
+              "legendFormat": "Total",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "emea-morty"
+              },
+              "editorMode": "code",
+              "expr": "rate(pod_cpu_energy_current{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[1m])/3",
+              "hide": false,
+              "legendFormat": "CPU",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "emea-morty"
+              },
+              "editorMode": "code",
+              "expr": "rate(pod_dram_energy_current{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[1m])/3",
+              "hide": false,
+              "legendFormat": "DRAM",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "emea-morty"
+              },
+              "editorMode": "code",
+              "expr": "rate(pod_gpu_energy_current{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[1m])/3",
+              "hide": false,
+              "legendFormat": "GPU",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "emea-morty"
+              },
+              "editorMode": "code",
+              "expr": "rate(pod_other_energy_joule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[1m])/3",
+              "hide": false,
+              "legendFormat": "Other",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "E"
+            }
+          ],
+          "title": "Pod Current Energy Consumption (mW*s)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "${datasource}",
+          "description": "Total W*s Consumed",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "graph": false,
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            },
+            "tooltipOptions": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "7.5.15",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "emea-morty"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum_over_time(pod_energy_current{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
+              "instant": false,
+              "legendFormat": "Total",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "emea-morty"
+              },
+              "editorMode": "code",
+              "expr": "sum_over_time(pod_cpu_energy_current{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
+              "hide": false,
+              "legendFormat": "CPU",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "emea-morty"
+              },
+              "editorMode": "code",
+              "expr": "sum_over_time(pod_dram_energy_current{pod_namespace=\"monitoring\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
+              "hide": false,
+              "legendFormat": "DRAM",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "emea-morty"
+              },
+              "editorMode": "code",
+              "expr": "sum_over_time(pod_gpu_energy_current{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
+              "hide": false,
+              "legendFormat": "GPU",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "emea-morty"
+              },
+              "editorMode": "code",
+              "expr": "sum_over_time(pod_other_energy_joule{pod_namespace=\"$namespace\", pod_name=\"$pod\"}[24h])*15/3/3600000000",
+              "hide": false,
+              "legendFormat": "Other",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "E"
+            }
+          ],
+          "title": "Total Pod Energy Consumption (kW*h)",
+          "transformations": [],
+          "type": "timeseries"
+        },
+        {
+          "datasource": "${datasource}",
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 0.1
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 22
+          },
+          "id": 5,
+          "options": {
+            "displayMode": "gradient",
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true,
+            "text": {}
+          },
+          "pluginVersion": "7.5.16",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "emea-morty"
+              },
+              "editorMode": "code",
+              "expr": "sum_over_time(pod_energy_current{pod_namespace=\"$namespace\"}[24h])*15/3/3600000000",
+              "legendFormat": "{{pod_name}}",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total Pod Energy Consumption (kW*h) in $namespace in 24 hours",
+          "type": "bargauge"
+        },
+        {
+          "datasource": "${datasource}",
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "color-text",
+                "filterable": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 0.01
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "pod_namespace"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Namespace"
+                  },
+                  {
+                    "id": "custom.filterable",
+                    "value": true
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "kW*h"
+                  },
+                  {
+                    "id": "custom.displayMode",
+                    "value": "lcd-gauge"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "continuous-GrYlRd"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 22
+          },
+          "id": 6,
+          "maxPerRow": 8,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "frameIndex": 0,
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "kW*h"
+              }
+            ]
+          },
+          "pluginVersion": "7.5.16",
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "emea-morty"
+              },
+              "editorMode": "code",
+              "expr": "sum by (pod_namespace) (sum_over_time(pod_energy_current[24h])*15/3/3600000000)",
+              "legendFormat": "__auto",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Total Energy Consumption (kW*h) by Namespace in 24 hours",
+          "type": "table"
+        }
+      ],
+      "refresh": "",
+      "schemaVersion": 27,
+      "style": "dark",
+      "tags": [
+        "kepler",
+        "energy consumption"
+      ],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "selected": true,
+              "text": "open-cluster-management-agent-addon",
+              "value": "open-cluster-management-agent-addon"
+            },
+            "datasource": "${datasource}",
+            "definition": "label_values(pod_energy_stat, pod_namespace)",
+            "description": "Namespace for pods to choose",
+            "error": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": "Namespace",
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": {
+              "query": "label_values(pod_energy_stat, pod_namespace)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "selected": true,
+              "text": "klusterlet-addon-search-68b64c74d6-twkq6",
+              "value": "klusterlet-addon-search-68b64c74d6-twkq6"
+            },
+            "datasource": "${datasource}",
+            "definition": "label_values(pod_energy_stat{pod_namespace=\"$namespace\"}, pod_name)",
+            "description": null,
+            "error": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": "Pod",
+            "multi": false,
+            "name": "pod",
+            "options": [],
+            "query": {
+              "query": "label_values(pod_energy_stat{pod_namespace=\"$namespace\"}, pod_name)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "description": null,
+            "error": null,
+            "hide": 2,
+            "label": null,
+            "name": "coal",
+            "query": "2.23",
+            "skipUrlSync": false,
+            "type": "constant"
+          },
+          {
+            "description": null,
+            "error": null,
+            "hide": 2,
+            "label": null,
+            "name": "natural_gas",
+            "query": "0.91",
+            "skipUrlSync": false,
+            "type": "constant"
+          },
+          {
+            "description": null,
+            "error": null,
+            "hide": 2,
+            "label": null,
+            "name": "petroleum",
+            "query": "2.13",
+            "skipUrlSync": false,
+            "type": "constant"
+          },
+          {
+            "current": {
+              "selected": false,
+              "text": "emea-morty",
+              "value": "emea-morty"
+            },
+            "description": null,
+            "error": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "queryValue": "",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-3h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "Kepler Exporter Dashboard",
+      "uid": "feedc0ffee",
+      "version": 4
+    }

--- a/grafana/overlays/osc/osc-cl1/dashboards/kepler/kustomization.yaml
+++ b/grafana/overlays/osc/osc-cl1/dashboards/kepler/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kepler.yaml

--- a/grafana/overlays/osc/osc-cl1/dashboards/kustomization.yaml
+++ b/grafana/overlays/osc/osc-cl1/dashboards/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app: grafana
+resources:
+  - kepler

--- a/grafana/overlays/osc/osc-cl1/datasources/grafanadatasource.yaml
+++ b/grafana/overlays/osc/osc-cl1/datasources/grafanadatasource.yaml
@@ -1,0 +1,17 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDataSource
+metadata:
+  name: datasource
+spec:
+  datasources:
+    - editable: false
+      jsonData:
+        httpHeaderName1: Authorization
+        timeInterval: 5s
+        tlsSkipVerify: true
+      name: osc-cl1
+      secureJsonData:
+        httpHeaderValue1: $UWM_BEARER_TOKEN
+      type: prometheus
+      url: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
+  name: prometheus-grafanadatasource.yaml

--- a/grafana/overlays/osc/osc-cl1/externalsecrets/grafana-secret-config.yaml
+++ b/grafana/overlays/osc/osc-cl1/externalsecrets/grafana-secret-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-secret-config
+spec:
+  secretStoreRef:
+    name: opf-vault-store
+    kind: SecretStore
+  target:
+    name: grafana-secret-config
+  dataFrom:
+    - extract:
+        key: osc/osc-cl1/opf-grafana/grafana-secret-config

--- a/grafana/overlays/osc/osc-cl1/externalsecrets/kustomization.yaml
+++ b/grafana/overlays/osc/osc-cl1/externalsecrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- grafana-secret-config.yaml

--- a/grafana/overlays/osc/osc-cl1/grafana_oauth_patch.yaml
+++ b/grafana/overlays/osc/osc-cl1/grafana_oauth_patch.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: integreatly.org/v1alpha1
+kind: Grafana
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  name: grafana
+spec:
+  baseImage: quay.io/operate-first/grafana:9.1.1
+  deployment:
+    envFrom:
+      - secretRef:
+          name: grafana-secret-config
+      - configMapRef:
+          name: grafana-config-overrides
+  configMaps:
+    - grafana-landing-page
+  serviceAccount:
+    labels:
+      app.kubernetes.io/instance: cluster-resources-osc
+  config:
+    server:
+      root_url: https://grafana-opf-monitoring.apps.odh-cl1.apps.os-climate.org
+    dashboards:
+      default_home_dashboard_path: "/etc/grafana-configmaps/grafana-landing-page/landingpage.json"
+    auth.generic_oauth:
+      enabled: true
+      scopes: openid email groups profile
+      email_attribute_path: name
+      client_id: grafana
+      client_secret: "${GRAFANA_CLIENT_SECRET}"
+      api_url: https://dex-dex.apps.odh-cl1.apps.os-climate.org/userinfo
+      auth_url: https://dex-dex.apps.odh-cl1.apps.os-climate.org/auth
+      token_url: https://dex-dex.apps.odh-cl1.apps.os-climate.org/token
+      role_attribute_path: >-
+        contains(groups[*], 'cluster-admins') && 'Admin' ||
+        'Deny'
+      role_attribute_strict: true

--- a/grafana/overlays/osc/osc-cl1/kustomization.yaml
+++ b/grafana/overlays/osc/osc-cl1/kustomization.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: opf-monitoring
@@ -11,13 +10,8 @@ configMapGenerator:
 resources:
   - ../../../base
   - dashboards
-  - datasources
-  - ./blackbox-exporter
-  - landingpage-dashboard-configmap.yaml
+  - landingpage.yaml
 
 patchesStrategicMerge:
-  - grafana-oauth.yaml
-  - route_patch.yaml
-
-generators:
-  - secrets-generator.yaml
+  - ./grafana_oauth_patch.yaml
+  - ./datasources/grafanadatasource.yaml

--- a/grafana/overlays/osc/osc-cl1/landingpage.yaml
+++ b/grafana/overlays/osc/osc-cl1/landingpage.yaml
@@ -1,0 +1,103 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: grafana-landing-page
+data:
+  landingpage.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": 44,
+      "iteration": 1661531127276,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 8,
+          "panels": [],
+          "title": "Welcome page and links",
+          "type": "row"
+        },
+        {
+          "description": "",
+          "gridPos": {
+            "h": 19,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "id": 4,
+          "options": {
+            "content": "<img src=\"https://github.com/operate-first/operate-first.github.io/raw/main/src/assets/opf-logo.png\" width=\"350px\">\n<h3>Welcome to the Operate First Grafana Dashboard</h2>\n<ul style=\"font-size: 1.2em\">\n  <li>Checkout out our <a href=\"https://www.operate-first.cloud/\">website</a></li>\n  <li>Browse our <a href=\"https://github.com/operate-first/apps\">GitHub repository</a></li>\n</ul>\n<h3>Want to contribute to the dashboards?</h2>\n<ul style=\"font-size: 1.2em\">\n  <li>Check our <a href=\"https://www.operate-first.cloud/apps/content/grafana/add_grafana_dashboard.html\">docs</a> to learn how to add your own dashboard</li>\n  <li>Join our <a href=\"https://join.slack.com/t/operatefirst/shared_invite/zt-o2gn4wn8-O39g7sthTAuPCvaCNRnLww\">Slack</a> if you have any questions or concerns \n</ul>\n<p style=\"font-size: 1.1em\">(<b>Note:</b> Grafana reboots frequently, please make sure to backup your dashboards. Check out our <a href=\"https://www.operate-first.cloud/apps/content/grafana/add_grafana_dashboard.html\">Grafana docs</a> for more information on how to backup your dashboard) </p>",
+            "mode": "html"
+          },
+          "pluginVersion": "8.4.3",
+          "title": "Welcome to Operate First Dashboard",
+          "type": "text"
+        }
+      ],
+      "refresh": "",
+      "schemaVersion": 35,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "thanos-frontend",
+              "value": "thanos-frontend"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "queryValue": "",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Landing Page Copy",
+      "uid": "N7NlI0W4z",
+      "version": 1,
+      "weekStart": ""
+    }


### PR DESCRIPTION
This PR deploys grafana operator to osc-cl1 and osc-cl2 clusters. It
also setups up a grafana instance in osc-cl1, with a datasource backed
by openshift-monitoring prometheus instance. It also has a basic landing
page and the kepler dashboards starting out.

Related:
* https://github.com/os-climate/os_c_data_commons/issues/190
* https://github.com/operate-first/apps/pull/1841
* https://github.com/operate-first/support/issues/502