### PR TITLE
set uniq table loc and increase max partitions

### DIFF
--- a/kfdefs/overlays/osc/osc-cl1/trino/configs/catalogs/osc_datacommons_iceberg_dev.properties
+++ b/kfdefs/overlays/osc/osc-cl1/trino/configs/catalogs/osc_datacommons_iceberg_dev.properties
@@ -1,7 +1,8 @@
 connector.name=iceberg
 iceberg.file-format=PARQUET
 iceberg.compression-codec=GZIP
-iceberg.max-partitions-per-writer=100
+iceberg.max-partitions-per-writer=300
+iceberg.unique-table-location=true
 hive.metastore.uri=thrift://hive-metastore-osc-datacommons-iceberg-dev:9083
 hive.s3.endpoint=${ENV:OSC_DATACOMMONS_ICEBERG_DEV_S3_ENDPOINT_URL_PREFIX}${ENV:OSC_DATACOMMONS_ICEBERG_DEV_S3_ENDPOINT}
 hive.s3.signer-type=S3SignerType

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/osc_datacommons_dev.properties
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/osc_datacommons_dev.properties
@@ -1,7 +1,8 @@
 connector.name=iceberg
 iceberg.file-format=PARQUET
 iceberg.compression-codec=GZIP
-iceberg.max-partitions-per-writer=100
+iceberg.max-partitions-per-writer=300
+iceberg.unique-table-location=true
 hive.metastore.uri=thrift://hive-metastore-osc-datacommons-dev:9083
 hive.s3.endpoint=${ENV:OSC_DATACOMMONS_DEV_S3_ENDPOINT_URL_PREFIX}${ENV:OSC_DATACOMMONS_DEV_S3_ENDPOINT}
 hive.s3.signer-type=S3SignerType


### PR DESCRIPTION
- increase maximum partitions from 100 to 300
- set `iceberg.unique-table-location=true`

note: `unique-table-location` defaults to `true` in newer releases, but it does no harm.