### PR TITLE
updating verison of k8s webhook configurations to v1beta1

### DIFF
--- a/cluster-scope/base/admissionregistration.k8s.io/mutatingwebhookconfigurations/cosigned.sigstore.dev/mutatingwebhookconfiguration.yaml
+++ b/cluster-scope/base/admissionregistration.k8s.io/mutatingwebhookconfigurations/cosigned.sigstore.dev/mutatingwebhookconfiguration.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: admissionregistration.k8s.io/v1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   name: cosigned.sigstore.dev

--- a/cluster-scope/base/admissionregistration.k8s.io/validatingwebhookconfigurations/cosigned.sigstore.dev/validatingwebhookconfiguration.yaml
+++ b/cluster-scope/base/admissionregistration.k8s.io/validatingwebhookconfigurations/cosigned.sigstore.dev/validatingwebhookconfiguration.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: admissionregistration.k8s.io/v1
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: cosigned.sigstore.dev


### PR DESCRIPTION
Signed-off-by: greg pereira <grpereir@redhat.com>

Think this should address #2316. Can I get @tumido or @HumairAK to take a look and verify this is the correct solution for enabling that api version in infra?