### PR TITLE
chore: Set prow to skip yaml checks on docs/aux files

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -2,7 +2,7 @@ presubmits:
   - name: kustomize-build
     decorate: true
     max_concurrency: 1
-    run_if_changed: ".*yaml"
+    skip_if_only_changed: "^docs/|\\.md$|^(OWNERS|LICENSE)$|^\\."
     skip_report: false
     context: aicoe-ci/prow/kustomize-build
     spec:
@@ -21,7 +21,7 @@ presubmits:
   - name: kubeval-validation
     decorate: true
     max_concurrency: 1
-    run_if_changed: ".*yaml"
+    skip_if_only_changed: "^docs/|\\.md$|^(OWNERS|LICENSE)$|^\\."
     skip_report: false
     context: aicoe-ci/prow/kubeval-validation
     spec:


### PR DESCRIPTION
Trying to solve https://github.com/operate-first/apps/pull/2273#issuecomment-1230027023

Make Prow skip `kubeval`/`kustomize build` on:

- `docs/` changes
- Markdown changes
- `OWNERS` changes
- `LICENSE` changes
- Files in repo root starting with `.` like `.prow.yaml`, `.pre-commit-config.yaml` etc. 