### PR TITLE
add trino-secret-env

### DIFF
--- a/kfdefs/overlays/osc/osc-cl2/trino/externalsecrets/kustomization.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/externalsecrets/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - s3buckets.yaml
 - shared-secret.yaml
 - trino-oauth.yaml
+- trino-secret-env.yaml

--- a/kfdefs/overlays/osc/osc-cl2/trino/externalsecrets/trino-secret-env.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/externalsecrets/trino-secret-env.yaml
@@ -1,0 +1,13 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: trino-secret-env
+spec:
+  secretStoreRef:
+    name: opf-vault-store
+    kind: SecretStore
+  target:
+    name: trino-secret-env
+  dataFrom:
+    - extract:
+        key: osc/osc-cl2/odh-trino/trino-secret-env


### PR DESCRIPTION
Adding an external secret where we can provision secrets for trino configurations using `${ENV:SECRET_ENV_VAR}` to inject them, via Vault