### PR TITLE
Give kerpler admins access to osc-cl1 grafana.

### DIFF
--- a/grafana/overlays/osc/osc-cl1/grafana_oauth_patch.yaml
+++ b/grafana/overlays/osc/osc-cl1/grafana_oauth_patch.yaml
@@ -34,5 +34,6 @@ spec:
       token_url: https://dex-dex.apps.odh-cl1.apps.os-climate.org/token
       role_attribute_path: >-
         contains(groups[*], 'cluster-admins') && 'Admin' ||
+        contains(groups[*], 'kepler-admins') && 'Editor' ||
         'Deny'
       role_attribute_strict: true


### PR DESCRIPTION
Atm grafana is still configured with openshift-monitoring namespace as I've been unsuccessfull in adding data source directly from UWM (thus a little bit more isolated from cluster-wide metrics). As such kepler-admins will have access to openshift-monitoring metrics (more than UWM), we can address this afterwards. 

Rellated: https://github.com/os-climate/os_c_data_commons/issues/190