### PR TITLE
set case insensitivity to true for riskthinking

### DIFF
--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/riskthinking.properties
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/riskthinking.properties
@@ -1,3 +1,4 @@
 connector.name=bigquery
 bigquery.project-id=os-climate
 bigquery.credentials-key=${ENV:OSC_RISKTHINKING_BQ_SA}
+bigquery.case-insensitive-name-matching=true


### PR DESCRIPTION
BigQuery object names are case sensitive, which is different than most SQL dbs, apparently including trino.
The trino BQ connector has this parameter, apparently as a workaround:
`bigquery.case-insensitive-name-matching=true`

(defaults to false)