### PR TITLE
Add Pep to balrog cluster admins, replacing Anand

### DIFF
--- a/cluster-scope/overlays/prod/emea/balrog/groups/cluster-admins.yaml
+++ b/cluster-scope/overlays/prod/emea/balrog/groups/cluster-admins.yaml
@@ -6,5 +6,5 @@ users:
     - tumido
     - humairak
     - HumairAK
-    - 4n4nd
+    - codificat
     - harshad16


### PR DESCRIPTION
This is to add myself as cluster admin for the balrog cluster (where Thoth prod runs).

Removing Anand from the list too.

### Additional context

The trigger for this request was for me to get access to argo workflows running on the cluster, as I currently do not have access to them. 

I know cluster-admin is overkill for that, but... on one hand I could not locate specific group(s) for that specific access (happy to get pointers), and on the other hand I thought it could be handy anyway for other tasks :innocent: