### PR TITLE
Correct vault's smaug backup bucket name.

### DIFF
--- a/vault/overlays/moc/smaug/obc.yaml
+++ b/vault/overlays/moc/smaug/obc.yaml
@@ -4,5 +4,5 @@ metadata:
   name: opf-vault-snapshots
 spec:
   bucketName: opf-vault-snapshots
-  objectBucketName: obc-opf-obcs-opf-vault-snapshots
+  objectBucketName: obc-vault-opf-vault-snapshots
   storageClassName: openshift-storage.noobaa.io


### PR DESCRIPTION
this value differs from the currently deployed bucket, bringing it in sync.