### PR TITLE
Add prometheus to kafka pipeline configs for osc.

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/cluster-management/kafka.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/cluster-management/kafka.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kafka
+spec:
+  destination:
+    name: osc-cl2
+    namespace: kafka
+  project: os-climate
+  source:
+    path: kafka/overlays/osc/osc-cl2
+    repoURL: https://github.com/operate-first/apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - Validate=false
+    - ApplyOutOfSyncOnly=true

--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/cluster-management/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/cluster-management/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - dex-secondary.yaml
   - external-secrets.yaml
   - grafana.yaml
+  - kafka.yaml
   - kepler.yaml
   - k8s-annotations-exporter.yaml
   - kfdefs.yaml

--- a/cluster-scope/overlays/prod/osc/osc-cl1/secret-mgmt/kafka/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/secret-mgmt/kafka/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: kafka
 resources:
-  - kafka
-  - topics
-  - prometheus-kafka-adapter
+  - ../base

--- a/cluster-scope/overlays/prod/osc/osc-cl1/secret-mgmt/kepler-monitoring/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/secret-mgmt/kepler-monitoring/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: kepler-monitoring
 resources:
-  - kafka
-  - topics
-  - prometheus-kafka-adapter
+  - ../base

--- a/cluster-scope/overlays/prod/osc/osc-cl1/secret-mgmt/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/secret-mgmt/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 resources:
   - dex
   - dex-secondary
+  - kafka
+  - kepler-monitoring
   - odh-superset
   - odh-trino
   - odh-trino-dev

--- a/cluster-scope/overlays/prod/osc/osc-cl2/configmaps/cluster-monitoring-config.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/configmaps/cluster-monitoring-config.yaml
@@ -10,3 +10,10 @@ data:
     prometheusK8s:
       externalLabels:
         cluster: osc/osc-cl2
+      remoteWrite:
+        - url: "http://prometheus-kafka-adapter.kafka.svc.cluster.local/receive"
+          writeRelabelConfigs:
+          - sourceLabels: [service]
+            name: prometheus-kafka-adapter
+            regex: 'kepler-exporter'
+            action: keep

--- a/cluster-scope/overlays/prod/osc/osc-cl2/secret-mgmt/kafka/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/secret-mgmt/kafka/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: kafka
 resources:
-  - kafka
-  - topics
-  - prometheus-kafka-adapter
+  - ../base

--- a/cluster-scope/overlays/prod/osc/osc-cl2/secret-mgmt/kepler-monitoring/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/secret-mgmt/kepler-monitoring/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: kepler-monitoring
 resources:
-  - kafka
-  - topics
-  - prometheus-kafka-adapter
+  - ../base

--- a/cluster-scope/overlays/prod/osc/osc-cl2/secret-mgmt/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/secret-mgmt/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 resources:
   - dex
   - dex-secondary
+  - kafka
+  - kepler-monitoring
   - kubeflow
   - odh-superset
   - odh-trino

--- a/kafka/overlays/osc/osc-cl2/kafka/kustomization.yaml
+++ b/kafka/overlays/osc/osc-cl2/kafka/kustomization.yaml
@@ -1,6 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - kafka
-  - topics
-  - prometheus-kafka-adapter
+  - my-cluster.yaml

--- a/kafka/overlays/osc/osc-cl2/kafka/my-cluster.yaml
+++ b/kafka/overlays/osc/osc-cl2/kafka/my-cluster.yaml
@@ -1,0 +1,33 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}
+  kafka:
+    config:
+      default.replication.factor: 3
+      inter.broker.protocol.version: '3.2'
+      min.insync.replicas: 2
+      offsets.topic.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      transaction.state.log.replication.factor: 3
+    listeners:
+      - name: plain
+        port: 9092
+        tls: false
+        type: internal
+      - name: tls
+        port: 9093
+        tls: true
+        type: internal
+    replicas: 3
+    storage:
+      type: ephemeral
+    version: 3.2.0
+  zookeeper:
+    replicas: 3
+    storage:
+      type: ephemeral

--- a/kafka/overlays/osc/osc-cl2/prometheus-kafka-adapter/deployment.yaml
+++ b/kafka/overlays/osc/osc-cl2/prometheus-kafka-adapter/deployment.yaml
@@ -1,0 +1,46 @@
+# Source: prometheus-kafka-adapter/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-kafka-adapter
+  labels:
+    app.kubernetes.io/name: prometheus-kafka-adapter
+    app.kubernetes.io/instance: kepler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-kafka-adapter
+      app.kubernetes.io/instance: kepler
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: prometheus-kafka-adapter
+        app.kubernetes.io/instance: kepler
+      annotations:
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+    spec:
+      serviceAccountName: prometheus-kafka-adapter
+      securityContext: {}
+      containers:
+        - name: prometheus-kafka-adapter
+          securityContext: {}
+          image: "telefonica/prometheus-kafka-adapter:1.8.0"
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - secretRef:
+                name: prometheus-kafka-adapter
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources: {}

--- a/kafka/overlays/osc/osc-cl2/prometheus-kafka-adapter/external-secret.yaml
+++ b/kafka/overlays/osc/osc-cl2/prometheus-kafka-adapter/external-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: prometheus-kafka-adapter
+spec:
+  secretStoreRef:
+    name: opf-vault-store
+    kind: SecretStore
+  target:
+    name: prometheus-kafka-adapter
+  dataFrom:
+    - extract:
+        key: osc/osc-cl2/kafka/prometheus-kafka-adapter
+
+# Vault data should include:
+#  KAFKA_BROKER_LIST: ""
+#  KAFKA_TOPIC: ""
+#  KAFKA_COMPRESSION: ""
+#  KAFKA_BATCH_NUM_MESSAGES: ""
+#  SERIALIZATION_FORMAT: ""
+#  PORT: ""
+#  LOG_LEVEL: ""
+#  GIN_MODE: ""

--- a/kafka/overlays/osc/osc-cl2/prometheus-kafka-adapter/kustomization.yaml
+++ b/kafka/overlays/osc/osc-cl2/prometheus-kafka-adapter/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonAnnotations:
+  helm.sh/chart: prometheus-kafka-adapter-0.1.0
+resources:
+- deployment.yaml
+- external-secret.yaml
+- service.yaml
+- serviceaccount.yaml

--- a/kafka/overlays/osc/osc-cl2/prometheus-kafka-adapter/service.yaml
+++ b/kafka/overlays/osc/osc-cl2/prometheus-kafka-adapter/service.yaml
@@ -1,0 +1,19 @@
+# Source: prometheus-kafka-adapter/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-kafka-adapter
+  labels:
+    app.kubernetes.io/name: prometheus-kafka-adapter
+    helm.sh/chart: prometheus-kafka-adapter-0.1.0
+    app.kubernetes.io/instance: kepler
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: prometheus-kafka-adapter
+    app.kubernetes.io/instance: kepler

--- a/kafka/overlays/osc/osc-cl2/prometheus-kafka-adapter/serviceaccount.yaml
+++ b/kafka/overlays/osc/osc-cl2/prometheus-kafka-adapter/serviceaccount.yaml
@@ -1,0 +1,8 @@
+# Source: prometheus-kafka-adapter/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-kafka-adapter
+  labels:
+    app.kubernetes.io/name: prometheus-kafka-adapter
+    app.kubernetes.io/instance: kepler

--- a/kafka/overlays/osc/osc-cl2/topics/kepler-metrics.yaml
+++ b/kafka/overlays/osc/osc-cl2/topics/kepler-metrics.yaml
@@ -1,0 +1,12 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  labels:
+    strimzi.io/cluster: my-cluster
+  name: kepler-metrics
+  namespace: kafka
+spec:
+  config: {}
+  partitions: 1
+  replicas: 3
+  topicName: kepler-metrics

--- a/kafka/overlays/osc/osc-cl2/topics/kustomization.yaml
+++ b/kafka/overlays/osc/osc-cl2/topics/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - kafka
-  - topics
-  - prometheus-kafka-adapter
+  - my-topic.yaml
+  - kepler-metrics.yaml

--- a/kafka/overlays/osc/osc-cl2/topics/my-topic.yaml
+++ b/kafka/overlays/osc/osc-cl2/topics/my-topic.yaml
@@ -1,0 +1,12 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  labels:
+    strimzi.io/cluster: my-cluster
+  name: my-topic
+  namespace: kafka
+spec:
+  config: {}
+  partitions: 1
+  replicas: 3
+  topicName: my-topic

--- a/kepler/overlays/osc/osc-cl2/CO2Signal-producer/external-secret-dot-env.yaml
+++ b/kepler/overlays/osc/osc-cl2/CO2Signal-producer/external-secret-dot-env.yaml
@@ -1,0 +1,13 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: dotenv
+spec:
+  secretStoreRef:
+    name: opf-vault-store
+    kind: SecretStore
+  target:
+    name: dotenv
+  dataFrom:
+    - extract:
+        key: osc/osc-cl2/kepler-monitoring/dotenv

--- a/kepler/overlays/osc/osc-cl2/CO2Signal-producer/kafka-producer.yaml
+++ b/kepler/overlays/osc/osc-cl2/CO2Signal-producer/kafka-producer.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: co2signal-producer
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name.app.kubernetes: co2signal-producer
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name.app.kubernetes: co2signal-producer
+    spec:
+      containers:
+        - name: co2signal-producer
+          image: quay.io/sustainable_computing_io/co2signal_producer:latest
+          imagePullPolicy: Always
+          resources: {}
+          volumeMounts:
+            - mountPath: /opt/producer.env
+              subPath: producer.env
+              name: dotenv
+      restartPolicy: Always
+      volumes:
+        - name: dotenv
+          secret:
+            secretName: co2signal-config

--- a/kepler/overlays/osc/osc-cl2/CO2Signal-producer/kustomization.yaml
+++ b/kepler/overlays/osc/osc-cl2/CO2Signal-producer/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - kafka
-  - topics
-  - prometheus-kafka-adapter
+- kafka-producer.yaml
+- external-secret-dot-env.yaml

--- a/kepler/overlays/osc/osc-cl2/kustomization.yaml
+++ b/kepler/overlays/osc/osc-cl2/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: kepler-monitoring
 resources:
   - ../../../base


### PR DESCRIPTION
This change adds the deployed kafka resources in osc-cl2 to git.
It also adds a prometheus-to-kafka producer, OCP monitoring configs are
updated to remote write kepler metrics to this producer, and the
producer sends these to the kepler-metrics topic.

The commit also adds `CO2Signal-producer` producer, but is not currently deployed, as this will be next.