### PR TITLE
Switch remotewrite configs to uwm in osc.

### DIFF
--- a/cluster-scope/overlays/prod/osc/osc-cl2/configmaps/cluster-monitoring-config.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/configmaps/cluster-monitoring-config.yaml
@@ -10,10 +10,3 @@ data:
     prometheusK8s:
       externalLabels:
         cluster: osc/osc-cl2
-      remoteWrite:
-        - url: "http://prometheus-kafka-adapter.kafka.svc.cluster.local/receive"
-          writeRelabelConfigs:
-          - sourceLabels: [service]
-            name: prometheus-kafka-adapter
-            regex: 'kepler-exporter'
-            action: keep

--- a/cluster-scope/overlays/prod/osc/osc-cl2/configmaps/user-workload-monitoring-config.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/configmaps/user-workload-monitoring-config.yaml
@@ -8,3 +8,10 @@ data:
     prometheus:
       externalLabels:
         cluster: osc/osc-cl2
+      remoteWrite:
+        - url: "http://prometheus-kafka-adapter.kafka.svc.cluster.local/receive"
+          writeRelabelConfigs:
+          - sourceLabels: [service]
+            name: prometheus-kafka-adapter
+            regex: 'kepler-exporter'
+            action: keep


### PR DESCRIPTION
Incorrectly added to openshift-monitoring, added to uwm instead.