### PR TITLE
fix(infra): eno1 connection renamed on node/ctrl-1

### DIFF
--- a/cluster-scope/overlays/prod/moc/infra/nodenetworkconfigurationpolicies/vlan-211-nese.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/nodenetworkconfigurationpolicies/vlan-211-nese.yaml
@@ -7,6 +7,9 @@ spec:
     node-role.kubernetes.io/worker: ""
   desiredState:
     interfaces:
+      - name: eno1
+        state: up
+        type: ethernet
       - name: eno1.211
         description: zero cluster provisioning network
         type: vlan


### PR DESCRIPTION
Resolves: https://github.com/operate-first/operations/issues/496

Turn on ArgoCD autosync back on after merge: https://argocd.operate-first.cloud/applications/cluster-resources-infra 