### PR TITLE
enable debug for bq plugin, per request from trino devs

### DIFF
--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/config-coordinator.properties
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/config-coordinator.properties
@@ -17,3 +17,4 @@ http-server.authentication.oauth2.scopes=openid,groups,email
 http-server.authentication.oauth2.principal-field=email
 http-server.authentication.oauth2.additional-audiences=das
 query.max-length=10000000
+io.trino.plugin.bigquery=DEBUG

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/config-worker.properties
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/config-worker.properties
@@ -3,3 +3,4 @@ internal-communication.shared-secret=${ENV:TRINO_INTERNAL_SHARED_SECRET}
 http-server.http.port=8080
 discovery.uri=http://trino-service:8080
 query.max-length=10000000
+io.trino.plugin.bigquery=DEBUG


### PR DESCRIPTION
Trying to debug why the riskthinking catalog is failing on reading data from tables with "table not found" errors