### PR TITLE
Add machineconfig and machineconfigpool to enable nested-virtualization 

### DIFF
--- a/cluster-scope/base/apps/daemonsets/kvm-device-plugin/daemonset.yaml
+++ b/cluster-scope/base/apps/daemonsets/kvm-device-plugin/daemonset.yaml
@@ -43,6 +43,17 @@ spec:
           - name: device-plugin
             mountPath: /var/lib/kubelet/device-plugins
       volumes:
-        - name: device-plugin
-          hostPath:
-            path: /var/lib/kubelet/device-plugins
+      - name: device-plugin
+        hostPath:
+          path: /var/lib/kubelet/device-plugins
+      nodeSelector:
+        node-role.kubernetes.io/mcp-kvm-device-plugin: ""
+        # This label should match the one in the machineConfigPool
+        # so that the daemonset is only deployed
+        # to nodes where nested-virt is applied as a
+        # machineconfig
+        # ATTENTION: OperateFirst operations can choose to use
+        # a different label, but we need to keep the link to the
+        # machineconfigpool.
+        # Applying this machineconfig to the selected nodes will
+        # cause those nodes to restart

--- a/cluster-scope/base/machineconfiguration.openshift.io/machineconfigpools/mcp-kvm-device-plugin/kustomization.yaml
+++ b/cluster-scope/base/machineconfiguration.openshift.io/machineconfigpools/mcp-kvm-device-plugin/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- machineconfigpool.yaml

--- a/cluster-scope/base/machineconfiguration.openshift.io/machineconfigpools/mcp-kvm-device-plugin/machineconfigpool.yaml
+++ b/cluster-scope/base/machineconfiguration.openshift.io/machineconfigpools/mcp-kvm-device-plugin/machineconfigpool.yaml
@@ -1,0 +1,21 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: mcp-kvm-device-plugin
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker, mcp-kvm-device-plugin]}
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/mcp-kvm-device-plugin: ""
+      # Give us at least 2 or 3 nodes that have this label.
+      # This label should match the one in the daemonset
+      # so that the machineconfig is only deployed
+      # to nodes where nested-virt is needed for the daemonset.
+      # ATTENTION: OperateFirst operations can choose to use
+      # a different label, but we need to keep the link to the
+      # daemonset.
+      # Applying this machineconfig through the pool to the selected
+      # nodes will cause those nodes to restart
+  paused: false

--- a/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/80-enable-nested-virt/kustomization.yaml
+++ b/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/80-enable-nested-virt/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- machineconfig.yaml

--- a/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/80-enable-nested-virt/machineconfig.yaml
+++ b/cluster-scope/base/machineconfiguration.openshift.io/machineconfigs/80-enable-nested-virt/machineconfig.yaml
@@ -1,0 +1,19 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: "mcp-kvm-device-plugin"
+  name: 80-enable-nested-virt
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,b3B0aW9ucyBrdm1faW50ZWwgbmVzdGVkPTEKb3B0aW9ucyBrdm1fYW1kIG5lc3RlZD0xCg==
+          verification: {}
+        filesystem: root
+        mode: 420
+        path: /etc/modprobe.d/kvm.conf
+  osImageURL: ""

--- a/cluster-scope/bundles/kvm-device-plugin/kustomization.yaml
+++ b/cluster-scope/bundles/kvm-device-plugin/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - ../../base/core/namespaces/kvm-device-plugin
   - ../../base/rbac.authorization.k8s.io/rolebindings/kvm-device-plugin
   - ../../base/rbac.authorization.k8s.io/roles/kvm-device-plugin
+  - ../../base/machineconfiguration.openshift.io/machineconfigs/80-enable-nested-virt
+  - ../../base/machineconfiguration.openshift.io/machineconfigpools/mcp-kvm-device-plugin


### PR DESCRIPTION
Add machineconfig and machineconfigpool to enable nested-virtualization on nodes where kvm-device-plugin daemonset is deployed, so that the okd-team tekton pipeline for SCOS build runs faster.