### PR TITLE
fix: Unlist Smaug specific storage class from a bundle

### DIFF
--- a/cluster-scope/bundles/odf-external/kustomization.yaml
+++ b/cluster-scope/bundles/odf-external/kustomization.yaml
@@ -4,4 +4,3 @@ resources:
 - ../odf
 - ../../base/odf.openshift.io/storagesystems/ocs-external-storagecluster-storagesystem
 - ../../base/ocs.openshift.io/storageclusters/ocs-external-storagecluster
-- ../../base/storage.k8s.io/storageclasses/ocs-external-storagecluster-ceph-rbd


### PR DESCRIPTION
This is causing problems on Infra, since this is a Smaug specific Storage Class (why is it in the base?, further cleanup necessary...). For now I need to remove it from Infra asap.

Related to: https://github.com/operate-first/apps/issues/2386