### PR TITLE
feat(catalog): Allow CronJob to write secrets to vault

### DIFF
--- a/cluster-scope/base/batch/cronjobs/service-catalog-k8s-plugin/cronjob.yaml
+++ b/cluster-scope/base/batch/cronjobs/service-catalog-k8s-plugin/cronjob.yaml
@@ -45,5 +45,5 @@ spec:
               requests:
                 cpu: 50m
                 memory: 128Mi
-          serviceAccountName: vault-secret-fetcher
+          serviceAccountName: vault-secret-writer
           restartPolicy: OnFailure

--- a/cluster-scope/base/batch/cronjobs/service-catalog-k8s-plugin/cronjob.yaml
+++ b/cluster-scope/base/batch/cronjobs/service-catalog-k8s-plugin/cronjob.yaml
@@ -25,8 +25,8 @@ spec:
             - |
               echo "Authenticating with vault using SA JWT token ..."
               VAULT_AUTH_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-              VAULT_CLIENT_TOKEN=$(vault write auth/$CLUSTER-k8s/login role=$ENV-ops jwt="$VAULT_AUTH_TOKEN" -format=json | jq -r '.auth.client_token')
-              vault login -no-print $VAULT_CLIENT_TOKEN
+              VAULT_CLIENT_TOKEN=$(vault write auth/$CLUSTER-k8s/login role=$ENV-ops-rw jwt="$VAULT_AUTH_TOKEN" -format=json | yq e '.auth.client_token' -)
+              VAULT_TOKEN=$(vault login -token-only $VAULT_CLIENT_TOKEN)
 
               echo "Pushing k8s plugin SA token to vault ..."
               vault kv put -mount=k8s_secrets moc/smaug/service-catalog/k8s-plugin-tokens $ENV_$CLUSTER_token=$token

--- a/cluster-scope/base/core/serviceaccounts/vault-secret-writer/kustomization.yaml
+++ b/cluster-scope/base/core/serviceaccounts/vault-secret-writer/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- serviceaccount.yaml

--- a/cluster-scope/base/core/serviceaccounts/vault-secret-writer/serviceaccount.yaml
+++ b/cluster-scope/base/core/serviceaccounts/vault-secret-writer/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-secret-writer
+  namespace: service-catalog-k8s-plugin

--- a/cluster-scope/overlays/prod/common/kustomization.yaml
+++ b/cluster-scope/overlays/prod/common/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - ../../../base/core/secrets/service-catalog-k8s-plugin-token
 - ../../../base/core/serviceaccounts/service-catalog-k8s-plugin
 - ../../../base/core/serviceaccounts/schemastore-ci
+- ../../../base/core/serviceaccounts/vault-secret-writer
 - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-rb
 - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/self-provisioners
 - ../../../base/rbac.authorization.k8s.io/clusterrolebindings/sre

--- a/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/kustomization.yaml
@@ -7,4 +7,3 @@ resources:
   - openshift-logging
   - openshift-monitoring
   - openshift-user-workload-monitoring
-  - service-catalog-k8s-plugin

--- a/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/service-catalog-k8s-plugin/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/balrog/secret-mgmt/service-catalog-k8s-plugin/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: service-catalog-k8s-plugin
-resources:
-  - ../base

--- a/cluster-scope/overlays/prod/moc/curator/secret-mgmt/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/curator/secret-mgmt/kustomization.yaml
@@ -4,4 +4,3 @@ resources:
   - openshift-config
   - openshift-ingress
   - openshift-monitoring
-  - service-catalog-k8s-plugin

--- a/cluster-scope/overlays/prod/moc/curator/secret-mgmt/service-catalog-k8s-plugin/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/curator/secret-mgmt/service-catalog-k8s-plugin/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: service-catalog-k8s-plugin
-resources:
-  - ../base

--- a/cluster-scope/overlays/prod/moc/infra/secret-mgmt/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/secret-mgmt/kustomization.yaml
@@ -10,4 +10,3 @@ resources:
   - openshift-monitoring
   - openshift-storage
   - opf-alertreceiver
-  - service-catalog-k8s-plugin

--- a/cluster-scope/overlays/prod/moc/infra/secret-mgmt/service-catalog-k8s-plugin/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/secret-mgmt/service-catalog-k8s-plugin/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: service-catalog-k8s-plugin
-resources:
-  - ../base

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -161,6 +161,7 @@ resources:
 - bucketclasses/noobaa-default-bucket-class.yaml
 - clusterversion.yaml
 - configmaps
+- configmaps/service-catalog-k8s-plugin.yaml
 - externalsecrets
 - groups
 - ingresscontrollers/default.yaml

--- a/cluster-scope/overlays/prod/osc/osc-cl1/secret-mgmt/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/secret-mgmt/kustomization.yaml
@@ -12,4 +12,3 @@ resources:
   - openshift-ingress
   - openshift-monitoring
   - opf-monitoring
-  - service-catalog-k8s-plugin

--- a/cluster-scope/overlays/prod/osc/osc-cl1/secret-mgmt/service-catalog-k8s-plugin/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/secret-mgmt/service-catalog-k8s-plugin/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: service-catalog-k8s-plugin
-resources:
-  - ../base

--- a/cluster-scope/overlays/prod/osc/osc-cl2/secret-mgmt/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/secret-mgmt/kustomization.yaml
@@ -14,4 +14,3 @@ resources:
   - openshift-monitoring
   - opf-monitoring
   - pachyderm
-  - service-catalog-k8s-plugin

--- a/cluster-scope/overlays/prod/osc/osc-cl2/secret-mgmt/service-catalog-k8s-plugin/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/secret-mgmt/service-catalog-k8s-plugin/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: service-catalog-k8s-plugin
-resources:
-  - ../base


### PR DESCRIPTION
Changes to `CronJob`:
* Save the final vault token to an env variable instead of a file by default
* Change role to one that allows writing of secrets
* Switch from `jq` to `yq` which is installed in toolbox image
* Switch from running as `vault-secret-fetcher` to `vault-secret-writer`

Changes to manifests:
* Add `service-catalog-k8s-plugin` config map for moc/smaug to kustomization file
* Remove the addition of `vault-secret-fetcher` SA from clusters other then smaug
* Create `vault-secret-writer` SA for all clusters
