### PR TITLE
Deploy stackrox via a helm chart using argocd

### DIFF
--- a/stackrox/base/deployments/kustomization.yaml
+++ b/stackrox/base/deployments/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- stackrox-central-deployment.yaml
+- stackrox-secured-cluster-services-deployment.yaml
+ 

--- a/stackrox/base/deployments/stackrox-central-deployment.yaml
+++ b/stackrox/base/deployments/stackrox-central-deployment.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: stackrox-central-deployment
+  namespace: stackrox
+spec:
+  project: stackrox
+  source:
+    chart: stackrox/stackrox-central-services  
+    repoURL: https://raw.githubusercontent.com/stackrox/helm-charts/main/opensource/
+    targetRevision: 71.0.0
+    helm:
+      releaseName: stackrox-central-services
+  destination:
+    server: " "
+    namespace: stackrox

--- a/stackrox/base/deployments/stackrox-secured-cluster-services-deployment.yaml
+++ b/stackrox/base/deployments/stackrox-secured-cluster-services-deployment.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: stackrox-secured-cluster-services-deployment
+  namespace: stackrox
+spec:
+  project: stackrox
+  source:
+    chart: stackrox/stackrox-secured-cluster-services
+    repoURL: https://raw.githubusercontent.com/stackrox/helm-charts/main/opensource/
+    targetRevision: 71.0.0
+    helm:
+      releaseName: stackrox-secured-cluster-services
+  destination:
+    server: " "
+    namespace: stackrox

--- a/stackrox/base/kustomization.yaml
+++ b/stackrox/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployments/

--- a/stackrox/overlays/moc/smaug/kustomization.yaml
+++ b/stackrox/overlays/moc/smaug/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base
+namespace: stackrox
+patchesStrategicMerge:
+- set-server.yaml

--- a/stackrox/overlays/moc/smaug/set-server.yaml
+++ b/stackrox/overlays/moc/smaug/set-server.yaml
@@ -1,0 +1,10 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: stackrox-central-deployment
+  namespace: stackrox
+spec:
+  destination:
+    server: "smaug"
+    namespace: stackrox
+


### PR DESCRIPTION
This is an alternative way to deploy Stackrox onto the smaug cluster. This is because using the other method (getting the templates from helm directly and managing it) could lead to some problems down the road from an upgrading standpoint. This also seems to remove the need for external secrets because the chart itself generates the secrets and place the secrets on the open-shift cluster.