### PR TITLE
fix: NFD channel '4.8' no longer exist on Smaug, use 'stable' instead

### DIFF
--- a/cluster-scope/overlays/prod/moc/smaug/subscriptions/nfd_patch.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/subscriptions/nfd_patch.yaml
@@ -5,4 +5,4 @@ metadata:
   name: nfd
   namespace: openshift-nfd
 spec:
-  channel: "4.8"
+  channel: stable


### PR DESCRIPTION
Since Smaug is on OCP 4.9, there's no `4.8` channel for NFD operator... There are `4.9` and `stable` channels. I think switching to `stable` gives us more recent version and is also more future proof.

![image](https://user-images.githubusercontent.com/7453394/188874152-db971d62-53ae-4038-8e1c-2da62025d62f.png)
