### PR TITLE
whitelist grafana resources for b4mad

### DIFF
--- a/argocd/overlays/moc-infra/projects/b4mad.yaml
+++ b/argocd/overlays/moc-infra/projects/b4mad.yaml
@@ -24,3 +24,10 @@ spec:
       groups:
         - b4mad
         - operate-first
+  namespaceResourceWhitelist:
+    - group: integreatly.org
+      kind: GrafanaDashboard
+    - group: integreatly.org
+      kind: GrafanaDataSource
+    - group: integreatly.org
+      kind: Grafana


### PR DESCRIPTION
otherwise, I get 
`Resource integreatly.org:Grafana is not permitted in project b4mad.`

<img width="1205" alt="image" src="https://user-images.githubusercontent.com/161888/189167431-25e02870-33c0-4501-b31a-ac76e535f207.png">
