### PR TITLE
Add the Custom Notebook Image (CNBi) operator to osc-cl1 stage

### DIFF
--- a/cluster-scope/overlays/prod/osc/osc-cl1/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
 - ../../../../base/core/configmaps/cluster-monitoring-config
 - ../../../../base/core/configmaps/user-workload-monitoring-config
 - ../../../../base/core/namespaces/acme-operator
+- ../../../../base/core/namespaces/aicoe-meteor
 - ../../../../base/core/namespaces/datahub-linkedin
 - ../../../../base/core/namespaces/dex
 - ../../../../base/core/namespaces/dex-secondary

--- a/kfdefs/overlays/osc/osc-cl1/jupyterhub-stage/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/jupyterhub-stage/kfdef.yaml
@@ -36,7 +36,14 @@ spec:
           name: manifests
           path: odh-dashboard
       name: odh-dashboard
+    - kustomizeConfig:
+        repoRef:
+          name: meteor-operator
+          path: config/default
+      name: cnbi-operator
   repos:
     - name: manifests
       uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl1-byon
+    - name: meteor-operator
+      uri: https://github.com/AICoE/meteor-operator/tarball/spike-cnbi-crd
   version: v1.1.0


### PR DESCRIPTION
The [custom notebook image functionality for ODH](https://github.com/thoth-station/opendatahub-cnbi/) is being developed based on [meteor-operator](https://github.com/AICoE/meteor-operator/).

This work is the continuation of the [Bring your own notebook (BYON)](https://github.com/open-services-group/byon/) effort.

The `opf-jupyterhub-stage` namespace in the *odh-cl1* cluster is hosting the staging environment for this development.

This PR adds the `spike-cnbi-crd` branch of the `meteor-operator` repo as a source for deployment configuration, and adds the default operator configuration to the `KfDef`.

Related to: https://github.com/open-services-group/scrum/issues/37
Should be documented in https://github.com/open-services-group/scrum/issues/32