### PR TITLE
feat(catalog): Add k8s plugin bundle to osc clusters

### DIFF
--- a/cluster-scope/overlays/prod/osc/osc-cl1/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/kustomization.yaml
@@ -63,6 +63,7 @@ resources:
 - ../../../../bundles/grafana-operator
 - ../../../../bundles/opendatahub-operator-manual
 - ../../../../bundles/openshift-pipelines
+- ../../../../bundles/service-catalog-k8s-plugin
 - ../../../../bundles/training-operator
 - apiserver
 - configmaps/service-catalog-k8s-plugin.yaml

--- a/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/kustomization.yaml
@@ -77,6 +77,7 @@ resources:
 - ../../../../bundles/openshift-pipelines
 - ../../../../bundles/pachyderm-operator
 - ../../../../bundles/reloader
+- ../../../../bundles/service-catalog-k8s-plugin
 - ../../../../bundles/fybrik
 - ../../../../base/user.openshift.io/groups/fybrik
 - apiserver


### PR DESCRIPTION
Part of #2401 

Since the [this common overlay](https://github.com/operate-first/apps/blob/master/cluster-scope/overlays/prod/common/kustomization.yaml) is not added to osc, the `service-catalog-k8s-plugin` bundle needs to be added separately.

/cc @HumairAK 