### PR TITLE
fix(catalog): Add bundle and change configmap

### DIFF
--- a/cluster-scope/overlays/prod/moc/curator/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/curator/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - ../../../../base/storage.k8s.io/storageclasses/hostpath-provisioner
   - ../../../../base/user.openshift.io/groups/cluster-admins
   - ../../../../bundles/external-secrets-operator
+  - ../../../../bundles/service-catalog-k8s-plugin
   - apiserver
   - externalsecrets
   - machineconfigs/50-ipmi-route.yaml

--- a/cluster-scope/overlays/prod/osc/osc-cl1/configmaps/service-catalog-k8s-plugin.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/configmaps/service-catalog-k8s-plugin.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: service-catalog-k8s-plugin
 data:
   ENV: osc
-  CLUSTER: osc-cli1
+  CLUSTER: osc-cl1

--- a/cluster-scope/overlays/prod/osc/osc-cl2/configmaps/service-catalog-k8s-plugin.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl2/configmaps/service-catalog-k8s-plugin.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: service-catalog-k8s-plugin
 data:
   ENV: osc
-  CLUSTER: osc-cli2
+  CLUSTER: osc-cl2


### PR DESCRIPTION
The `service-catalog-k8s-plugin` bundle is missing from the curator overlay since it doesn't import the `common` overlay.
ConfigMaps for OSC clusters contain a typo.

/cc @tumido 