### PR TITLE
bumping resource requests for prow jobs

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -13,10 +13,10 @@ presubmits:
           resources:
             requests:
               memory: "256Mi"
-              cpu: "200m"
+              cpu: "1500m"
             limits:
               memory: "500Mi"
-              cpu: "1"
+              cpu: "2"
 
   - name: kubeval-validation
     decorate: true
@@ -32,10 +32,10 @@ presubmits:
           resources:
             requests:
               memory: "512Mi"
-              cpu: "200m"
+              cpu: "1500m"
             limits:
               memory: "2Gi"
-              cpu: "1"
+              cpu: "2"
 
   - name: pre-commit
     decorate: true
@@ -52,7 +52,7 @@ presubmits:
           resources:
             requests:
               memory: "500Mi"
-              cpu: "300m"
+              cpu: "4"
             limits:
-              memory: "1Gi"
-              cpu: "300m"
+              memory: "2Gi"
+              cpu: "4"


### PR DESCRIPTION
pre-commit is heavily parallelized
the other jobs exceed 1cpu a bit

I tested locally with `docker stats` and just looking at mem and CPU usage

cc @Gregory-Pereira