### PR TITLE
feat(catalog): Add extra permisions to SA on infra

### DIFF
--- a/cluster-scope/overlays/prod/moc/infra/clusterroles/service-catalog-k8s-plugin.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/clusterroles/service-catalog-k8s-plugin.yaml
@@ -1,0 +1,13 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: service-catalog-k8s-plugin
+rules:
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  verbs:
+  - get
+  - watch
+  - list

--- a/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
@@ -58,6 +58,7 @@ patchesStrategicMerge:
   - subscriptions/odf-operator_patch.yaml
   - subscriptions/web-terminal_patch.yaml
   - groups/cluster-admins.yaml
+  - clusterroles/service-catalog-k8s-plugin.yaml
   - clusterrolebindings/self-provisioners_patch.yaml
   - clusterrolebindings/klusteraddonconfig-editor.yaml
   - consoles/cluster_patch.yaml


### PR DESCRIPTION
Part of https://github.com/operate-first/service-catalog/issues/102

Add the required permissions to query ACM for cluster status.