### PR TITLE
fix: Change apicurio Vault role

### DIFF
--- a/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/api-designer/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/api-designer/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: api-designer
 resources:
   - ../base
+patches:
+  - opf-vault-store.yaml

--- a/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/api-designer/opf-vault-store.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/api-designer/opf-vault-store.yaml
@@ -1,0 +1,10 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: opf-vault-store
+spec:
+  provider:
+    vault:
+      auth:
+        kubernetes:
+          role: apicurio

--- a/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/apicurio-apicurio-registry/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/apicurio-apicurio-registry/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: apicurio-apicurio-registry
 resources:
   - ../base
+patches:
+  - opf-vault-store.yaml

--- a/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/apicurio-apicurio-registry/opf-vault-store.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/apicurio-apicurio-registry/opf-vault-store.yaml
@@ -1,0 +1,10 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: opf-vault-store
+spec:
+  provider:
+    vault:
+      auth:
+        kubernetes:
+          role: apicurio


### PR DESCRIPTION
Addresses https://github.com/operate-first/apps/pull/2430#issuecomment-1252897561

Use `apicurio` role in Vault once it's created. Requires a Vault role and Vault policy for `apicurio` team.