### PR TITLE
feat: Add copilot-ops to vaul secret management

### DIFF
--- a/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/copilot-ops/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/copilot-ops/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: copilot-ops
+resources:
+  - ../base
+patches:
+  - opf-vault-store.yaml

--- a/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/copilot-ops/opf-vault-store.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/copilot-ops/opf-vault-store.yaml
@@ -1,0 +1,10 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: opf-vault-store
+spec:
+  provider:
+    vault:
+      auth:
+        kubernetes:
+          role: copilot-ops

--- a/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - aiops-tools-workshop
   - api-designer
   - apicurio-apicurio-registry
+  - copilot-ops
   - dex
   - kubeflow
   - openshift-config


### PR DESCRIPTION
Adds project Copilot ops to vault secret management

Part of: https://github.com/operate-first/support/issues/973