### PR TITLE
Add dex oauth sa annotations to argocd dex.

### DIFF
--- a/argocd/overlays/moc-infra/kustomization.yaml
+++ b/argocd/overlays/moc-infra/kustomization.yaml
@@ -24,3 +24,5 @@ configMapGenerator:
   - configs/argo_rbac_cm/policy.default
 generatorOptions:
   disableNameSuffixHash: true
+patchesStrategicMerge:
+  - serviceaccounts/argocd-dex-server.yaml


### PR DESCRIPTION
Accidentally removed here: https://github.com/operate-first/apps/pull/2448/files#diff-825202f32a50d376d91bcb81d562f0d9d3b36580ce2871d387b6689bd5262596