### PR TITLE
Update after meteor-operator repo move

### DIFF
--- a/cluster-scope/base/core/namespaces/aicoe-meteor/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/aicoe-meteor/namespace.yaml
@@ -7,4 +7,4 @@ metadata:
         openshift.io/requester: operate-first
         op1st/project-owner: operate-first
         op1st/onboarding-issue: "https://github.com/AICoE/meteor/issues/46"
-        op1st/docs: "https://github.com/AICoE/meteor-operator"
+        op1st/docs: "https://github.com/thoth-station/meteor-operator"

--- a/kfdefs/overlays/osc/osc-cl1/jupyterhub-stage/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/jupyterhub-stage/kfdef.yaml
@@ -45,5 +45,5 @@ spec:
     - name: manifests
       uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl1-byon
     - name: meteor-operator
-      uri: https://github.com/AICoE/meteor-operator/tarball/spike-cnbi-crd
+      uri: https://github.com/thoth-station/meteor-operator/tarball/spike-cnbi-crd
   version: v1.1.0

--- a/prow/overlays/smaug/config.yaml
+++ b/prow/overlays/smaug/config.yaml
@@ -295,7 +295,6 @@ tide:
     - repos:
         - AICoE/common
         - AICoE/meteor
-        - AICoE/meteor-operator
       labels:
         - approved
         - lgtm


### PR DESCRIPTION
The [meteor-operator repository](https://github.com/thoth-station/meteor-operator) moved from the AICoE org to the thoth-station org.

This updates references accordingly.