### PR TITLE
feat(catalog): Add ConfigMap for jerry in service catalog

### DIFF
--- a/cluster-scope/overlays/prod/emea/jerry/configmaps/service-catalog-k8s-plugin.yaml
+++ b/cluster-scope/overlays/prod/emea/jerry/configmaps/service-catalog-k8s-plugin.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-catalog-k8s-plugin
+  namespace: service-catalog-k8s-plugin
+data:
+  ENV: emea
+  CLUSTER: jerry

--- a/cluster-scope/overlays/prod/emea/jerry/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/jerry/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../../../../bundles/external-secrets-operator
   - ../common
   - apiserver
+  - configmaps/service-catalog-k8s-plugin.yaml
   - ingresscontrollers
   - secret-mgmt
 patchesStrategicMerge:


### PR DESCRIPTION
Part of https://github.com/operate-first/service-catalog/issues/113

Add a ConfigMap that is needed for the cronjob on jerry cluster for uploading secrets to vault so that the service catalog can query this cluster.