### PR TITLE
fix: Backstage cluster role for ACM on Infra

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/service-catalog-k8s-plugin-acm/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/service-catalog-k8s-plugin-acm/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: service-catalog-k8s-plugin-acm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: service-catalog-k8s-plugin-acm
+subjects:
+- kind: ServiceAccount
+  name: service-catalog-k8s-plugin
+  namespace: service-catalog-k8s-plugin

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/service-catalog-k8s-plugin-acm/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/service-catalog-k8s-plugin-acm/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - clusterrolebinding.yaml

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/service-catalog-k8s-plugin-acm/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/service-catalog-k8s-plugin-acm/clusterrole.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: service-catalog-k8s-plugin
+  name: service-catalog-k8s-plugin-acm
 rules:
 - apiGroups:
   - cluster.open-cluster-management.io

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/service-catalog-k8s-plugin-acm/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/service-catalog-k8s-plugin-acm/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- clusterrole.yaml

--- a/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
@@ -23,14 +23,16 @@ resources:
   - ../../../../base/operators.coreos.com/subscriptions/cluster-logging
   - ../../../../base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator
   - ../../../../base/operators.coreos.com/subscriptions/web-terminal
+  - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/apirequest-count-reader
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-reader-k8s-annotations-exporter
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:admin:osc-cl1
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:managedclusterset:admin:drvbw
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:managedclusterset:admin:octo-ushift-dev
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:managedclusterset:admin:osc
-  - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/apirequest-count-reader
+  - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/service-catalog-k8s-plugin-acm
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/vault
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/apirequest-count-read-cr
+  - ../../../../base/rbac.authorization.k8s.io/clusterroles/service-catalog-k8s-plugin-acm
   - ../../../../base/user.openshift.io/groups/cluster-admins
   - ../../../../bundles/acme-operator
   - ../../../../bundles/external-secrets-operator
@@ -58,7 +60,6 @@ patchesStrategicMerge:
   - subscriptions/odf-operator_patch.yaml
   - subscriptions/web-terminal_patch.yaml
   - groups/cluster-admins.yaml
-  - clusterroles/service-catalog-k8s-plugin.yaml
   - clusterrolebindings/self-provisioners_patch.yaml
   - clusterrolebindings/klusteraddonconfig-editor.yaml
   - consoles/cluster_patch.yaml


### PR DESCRIPTION
Fixes: https://github.com/operate-first/apps/pull/2439

Previous PR merged the `ClusterRoles` by replacing the `rules` list. We want to join those - hence we rather create a separate role + a binding.