### PR TITLE
chore: Change cert manager server to prod server

### DIFF
--- a/cert-manager/overlays/emea/jerry/api/issuer.yaml
+++ b/cert-manager/overlays/emea/jerry/api/issuer.yaml
@@ -8,7 +8,7 @@ spec:
     email: ops-team@operate-first.cloud
     privateKeySecretRef:
       name: letsencrypt-key
-    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    server: https://acme-v02.api.letsencrypt.org/directory
     solvers:
     - dns01:
         cloudDNS:

--- a/cert-manager/overlays/emea/jerry/ingress/issuer.yaml
+++ b/cert-manager/overlays/emea/jerry/ingress/issuer.yaml
@@ -8,7 +8,7 @@ spec:
     email: ops-team@operate-first.cloud
     privateKeySecretRef:
       name: letsencrypt-key
-    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    server: https://acme-v02.api.letsencrypt.org/directory
     solvers:
     - dns01:
         cloudDNS:


### PR DESCRIPTION
Resolved #2508 

Since we are integrating jerry to the service-catalog (https://github.com/operate-first/service-catalog/issues/113), a prod certificate is needed.

/cc @tumido @HumairAK @durandom 