### PR TITLE
Update the prow entrypoint image to work with new standards

### DIFF
--- a/prow/overlays/smaug/imagestreamtags.yaml
+++ b/prow/overlays/smaug/imagestreamtags.yaml
@@ -120,7 +120,7 @@ spec:
   tags:
   - from:
       kind: ImageStreamTag
-      name: v20211027-fe152eb205
+      name: v20220812-9414716697
     name: latest
   - from:
       kind: DockerImage
@@ -134,6 +134,10 @@ spec:
       kind: DockerImage
       name: gcr.io/k8s-prow/entrypoint:v20211027-fe152eb205
     name: v20211027-fe152eb205
+  - from:
+      kind: DockerImage
+      name: 'gcr.io/k8s-prow/entrypoint:v20220812-9414716697'
+    name: v20220812-9414716697
 ---
 apiVersion: image.openshift.io/v1
 kind: ImageStream


### PR DESCRIPTION
Update the prow entrypoint image to work with new standards
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Fixes: https://github.com/operate-first/apps/issues/2460