### PR TITLE
feat(infra): ODF - set default storage class and enable NooBaa scheduling

### DIFF
--- a/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
@@ -48,9 +48,13 @@ resources:
   - nodenetworkconfigurationpolicies/ocp-prod-provisioning-vlan.yaml
   - nodenetworkconfigurationpolicies/vlan-211-nese.yaml
   - nodenetworkconfigurationpolicies/zero-provisioning-vlan.yaml
+  - nodes/os-ctrl-0.moc-infra.massopen.cloud.yaml
+  - nodes/os-ctrl-1.moc-infra.massopen.cloud.yaml
+  - nodes/os-ctrl-2.moc-infra.massopen.cloud.yaml
   - oauth
   - secrets
   - secret-mgmt
+  - storageclasses/ocs-external-storagecluster-ceph-rbd.yaml
 generators:
   - secret-generator.yaml
 

--- a/cluster-scope/overlays/prod/moc/infra/nodes/os-ctrl-0.moc-infra.massopen.cloud.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/nodes/os-ctrl-0.moc-infra.massopen.cloud.yaml
@@ -1,0 +1,6 @@
+kind: Node
+apiVersion: v1
+metadata:
+  name: os-ctrl-0.moc-infra.massopen.cloud
+  labels:
+    cluster.ocs.openshift.io/openshift-storage: ''

--- a/cluster-scope/overlays/prod/moc/infra/nodes/os-ctrl-1.moc-infra.massopen.cloud.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/nodes/os-ctrl-1.moc-infra.massopen.cloud.yaml
@@ -1,0 +1,6 @@
+kind: Node
+apiVersion: v1
+metadata:
+  name: os-ctrl-1.moc-infra.massopen.cloud
+  labels:
+    cluster.ocs.openshift.io/openshift-storage: ''

--- a/cluster-scope/overlays/prod/moc/infra/nodes/os-ctrl-2.moc-infra.massopen.cloud.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/nodes/os-ctrl-2.moc-infra.massopen.cloud.yaml
@@ -1,0 +1,6 @@
+kind: Node
+apiVersion: v1
+metadata:
+  name: os-ctrl-2.moc-infra.massopen.cloud
+  labels:
+    cluster.ocs.openshift.io/openshift-storage: ''

--- a/cluster-scope/overlays/prod/moc/infra/storageclasses/ocs-external-storagecluster-ceph-rbd.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/storageclasses/ocs-external-storagecluster-ceph-rbd.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ocs-external-storagecluster-ceph-rbd
+  annotations:
+    storageclass.kubernetes.io/is-default-class: 'true'
+provisioner: openshift-storage.rbd.csi.ceph.com


### PR DESCRIPTION
1. NooBaa requires nodes to be labeled (will be part of our ODF documentation) otherwise it's stuck in pending

![image](https://user-images.githubusercontent.com/7453394/193886246-3a8473a0-548b-4f64-926f-80bac0a3dd85.png)

This is obscurely documented here: https://github.com/red-hat-storage/ocs-operator#prerequisites 
Not in the official ODF docs

2. Set `ocs-external-storagecluster-ceph-rbd` storage class as default.