### PR TITLE
Add uwm prometheus connector to osc-cl2 trino.

### DIFF
--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/uwm_prometheus.properties
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/uwm_prometheus.properties
@@ -1,0 +1,7 @@
+connector.name=prometheus
+prometheus.uri=https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
+prometheus.query.chunk.size.duration=10m
+prometheus.max.query.range.duration=1h
+prometheus.cache.ttl=30s
+prometheus.bearer.token.file=/etc/trino/secrets/prom-bearer-token.txt
+prometheus.read-timeout=10s

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/kustomization.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/kustomization.yaml
@@ -11,6 +11,7 @@ configMapGenerator:
       - catalogs/osc_datacommons_hive_ingest.properties
       - catalogs/kafka_fx.properties
       - catalogs/riskthinking.properties
+      - catalogs/uwm_prometheus.properties
   - name: trino-configfiles
     files:
       - config-coordinator.properties

--- a/kfdefs/overlays/osc/osc-cl2/trino/externalsecrets/kustomization.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/externalsecrets/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - shared-secret.yaml
 - trino-oauth.yaml
 - trino-secret-env.yaml
+- trino-secret-files.yaml

--- a/kfdefs/overlays/osc/osc-cl2/trino/externalsecrets/trino-secret-files.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/externalsecrets/trino-secret-files.yaml
@@ -1,0 +1,13 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: trino-secret-files
+spec:
+  secretStoreRef:
+    name: opf-vault-store
+    kind: SecretStore
+  target:
+    name: trino-secret-files
+  dataFrom:
+    - extract:
+        key: osc/osc-cl2/odh-trino/trino-secret-files


### PR DESCRIPTION
This catalog will allow trino users to query against metrics exposed by openshift-monitoring.

An external route is used intentionally instead of internal cluster service url. When attempting to use internal cluster route -- cert errors were encountered.