### PR TITLE
Use external route for trino prom connector.

### DIFF
--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/uwm_prometheus.properties
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/uwm_prometheus.properties
@@ -1,5 +1,5 @@
 connector.name=prometheus
-prometheus.uri=https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
+prometheus.uri=https://thanos-querier-openshift-monitoring.apps.odh-cl2.apps.os-climate.org
 prometheus.query.chunk.size.duration=10m
 prometheus.max.query.range.duration=1h
 prometheus.cache.ttl=30s


### PR DESCRIPTION
Was accidentally left out from: https://github.com/operate-first/apps/pull/2520