### PR TITLE
fix: Thanos storage on Infra

### DIFF
--- a/cluster-scope/overlays/prod/moc/infra/externalsecrets/multiclusterhub-operator-pull-secret.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/externalsecrets/multiclusterhub-operator-pull-secret.yaml
@@ -2,6 +2,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: multiclusterhub-operator-pull-secret
+  namespace: open-cluster-management-observability
 spec:
   secretStoreRef:
     name: opf-vault-store

--- a/cluster-scope/overlays/prod/moc/infra/externalsecrets/thanos-object-storage.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/externalsecrets/thanos-object-storage.yaml
@@ -2,6 +2,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: thanos-object-storage
+  namespace: open-cluster-management-observability
 spec:
   secretStoreRef:
     name: opf-vault-store

--- a/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
@@ -52,6 +52,7 @@ resources:
   - nodes/os-ctrl-1.moc-infra.massopen.cloud.yaml
   - nodes/os-ctrl-2.moc-infra.massopen.cloud.yaml
   - oauth
+  - objectbucketclaims/thanos.yaml
   - secrets
   - secret-mgmt
   - storageclasses/ocs-external-storagecluster-ceph-rbd.yaml

--- a/cluster-scope/overlays/prod/moc/infra/objectbucketclaims/thanos.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/objectbucketclaims/thanos.yaml
@@ -1,0 +1,8 @@
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: thanos
+  namespace: open-cluster-management-observability
+spec:
+  generateBucketName: thanos
+  storageClassName: openshift-storage.noobaa.io

--- a/cluster-scope/overlays/prod/moc/infra/secret-mgmt/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/secret-mgmt/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - acm
   - argocd
   - idp-auth-primary
+  - open-cluster-management-observability
   - openshift-config
   - openshift-ingress
   - openshift-logging


### PR DESCRIPTION
- Adds `SecretStore` to `open-cluster-management-observability` namespace (was missing in `kustomization.yaml`
- Adds namespace to `ExternalSecrets` which should be in `open-cluster-management-observability` instead of default `open-cluster-management-agent`
- Adds `ObjectBucketClaim` for Thanos - its creds are already [synced in Vault](https://vault-ui-vault.apps.smaug.na.operate-first.cloud/ui/vault/secrets/k8s_secrets/show/moc/infra/open-cluster-management-observability/thanos-object-storage)

Note: Due to the missing External Secrets the MCO is using some [old obscure pull secret](https://console-openshift-console.apps.moc-infra.massopen.cloud/k8s/ns/open-cluster-management-observability/secrets/multiclusterhub-operator-pull-secret) (using ipolonsk's email) which should have been overwriten before installing MCO.. not sure if that's a issue or not.