### PR TITLE
add image patch for airflow that uses trino-0.317.0 client

### DIFF
--- a/openmetadata/overlays/osc/osc-cl2/kustomization.yaml
+++ b/openmetadata/overlays/osc/osc-cl2/kustomization.yaml
@@ -17,6 +17,6 @@ patchesStrategicMerge:
   - patches/deployments/airflow-scheduler.yaml
   - patches/deployments/airflow-db-migrations.yaml
 images:
-- name: quay.io/operate-first/airflow
+- name: quay.io/operate-first/om-airflow
   newName: quay.io/os-climate/ingestion
   newTag: 0.12.1.trino.317

--- a/openmetadata/overlays/osc/osc-cl2/kustomization.yaml
+++ b/openmetadata/overlays/osc/osc-cl2/kustomization.yaml
@@ -16,3 +16,7 @@ patchesStrategicMerge:
   - patches/deployments/airflow-sync-users.yaml
   - patches/deployments/airflow-scheduler.yaml
   - patches/deployments/airflow-db-migrations.yaml
+images:
+- name: quay.io/operate-first/airflow
+  newName: quay.io/os-climate/ingestion
+  newTag: 0.12.1.trino.317


### PR DESCRIPTION
an attempt at upgrading the trino python client in the image used by airflow (via open-metadata).
