### PR TITLE
Disable observability for os-climate clusters.

### DIFF
--- a/acm/overlays/moc/infra/managedclusters/osc-cl1.yaml
+++ b/acm/overlays/moc/infra/managedclusters/osc-cl1.yaml
@@ -4,3 +4,4 @@ metadata:
   name: osc-cl1
   labels:
     cluster.open-cluster-management.io/clusterset: osc
+    observability: disabled

--- a/acm/overlays/moc/infra/managedclusters/osc-cl2.yaml
+++ b/acm/overlays/moc/infra/managedclusters/osc-cl2.yaml
@@ -4,3 +4,4 @@ metadata:
   name: osc-cl2
   labels:
     cluster.open-cluster-management.io/clusterset: osc
+    observability: disabled


### PR DESCRIPTION
As per office hour discussions, os-climate cluster data moving out of these clusters should require approval from the cluster maintainers/stakeholders

Documentation:
https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.6/html-single/observability/index#disable-observability-on-a-single-cluster