### PR TITLE
[prow] Add branch cleaner plugin configuration

### DIFF
--- a/prow/overlays/smaug/config.yaml
+++ b/prow/overlays/smaug/config.yaml
@@ -47,6 +47,33 @@ in_repo_config:
     "thoth-station": ["api.smaug.na.operate-first.cloud:6443"]
     "redhat-et/homomorphic-learning": ["api.smaug.na.operate-first.cloud:6443"]
 
+branch_cleaner:
+  preserved_branches:
+    AICoE:
+      - main
+      - master
+    aicoe-aiops:
+      - main
+      - master
+    b4mad:
+      - main
+      - master
+    open-services-group:
+      - main
+      - master
+    operate-first:
+      - main
+      - master
+    os-climate:
+      - main
+      - master
+    redhat-et:
+      - main
+      - master
+    thoth-station:
+      - main
+      - master
+
 branch-protection:
   allow_disabled_policies: true
   orgs:

--- a/prow/overlays/smaug/config.yaml
+++ b/prow/overlays/smaug/config.yaml
@@ -104,10 +104,9 @@ branch-protection:
           required_status_checks:
             contexts:
               - aicoe-ci/prow/pre-commit
-          exclude:
-            - "^revert-"
-            - "^kebechet-"
-            - "^dependabot/"
+          include:
+            - "^master"
+            - "^main"
     thoth-station:
       protect: true
       allow_force_pushes: false


### PR DESCRIPTION
## Related Issues and Dependencies

Follows: thoth-station/thoth-application#2605

Fixes thoth-station/prescriptions-refresh-job#172

## Does this require new deployment ?

Just a deployment of the updated prow config.

## Description

<!--- Describe your changes in detail -->

This configures the `branchcleaner` [prow plugin](https://github.com/kubernetes/test-infra/tree/master/prow/plugins/branchcleaner) so that source branches for merged PRs between two branches on the same repository are automatically deleted.

This can help with e.g. Kebechet PRs or prescription-refresh-job runs.

There was a suggestion in thoth-station/thoth-application#2605 to restrict this configuration to the thoth-station org. However, if I understand the [configuration of the plugin](https://github.com/kubernetes/test-infra/blob/e831f6aee73552c33fdc07c5b5ba7dedb29497b4/prow/plugins/plugin-config-documented.yaml#L73-L84) correctly, there is no way to restrict its operation to a specific org: you can configure *branch names* to be preserved org-wide (which is what I did there for `main` and `master`, for all repos on all orgs), but my understanding is that if something is not listed here, then it is not preserved.