### PR TITLE
feat(catalog): Add new resource permissions for k8s plugin

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/service-catalog-k8s-plugin/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/service-catalog-k8s-plugin/clusterrole.yaml
@@ -9,6 +9,7 @@ rules:
   - pods
   - services
   - configmaps
+  - limitranges
   verbs:
   - get
   - watch
@@ -24,6 +25,7 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - daemonsets
   - deployments
   - replicasets
   - statefulsets


### PR DESCRIPTION
Part of https://github.com/operate-first/service-catalog/issues/86

New resource permissions are required for an updated k8s plugin in the service catalog.

/cc @tumido 