### PR TITLE
fix(catalog): Add description to needs-rebase component

### DIFF
--- a/service-catalog/components/prow-needs-rebase.yaml
+++ b/service-catalog/components/prow-needs-rebase.yaml
@@ -3,7 +3,7 @@ kind: Component
 metadata:
   name: prow-needs-rebase
   title: Needs-rebase
-  description:
+  description: Add needs-rebase label to PRs if necessary
   annotations:
     operate-first.cloud/logo-url: https://prow.operate-first.cloud/static/logo-light.png
     argocd/app-name: ci-prow-prod-smaug

--- a/service-catalog/systems/prow.yaml
+++ b/service-catalog/systems/prow.yaml
@@ -20,6 +20,9 @@ metadata:
     - url: https://github.com/operate-first/apps/tree/master/prow
       title: Configuration
       icon: web
+    - url: https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/docs/pr-interactions-sequence.svg?sanitize=true
+      title: PR interaction sequence
+      icon: web
 spec:
   owner: group:operate-first
   domain: sre


### PR DESCRIPTION
- `needs-rebase` entity was not showing up because it didn't have a description.
- Add useful link for prow PR interaction sequence

/cc @tumido 