### PR TITLE
Deploy cnbi component on aicoe-meteor namespace

### DIFF
--- a/kfdefs/overlays/osc/osc-cl1/cnbi/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/cnbi/kfdef.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  annotations:
+    kfctl.kubeflow.io/force-delete: "false"
+  name: cnbi
+spec:
+  applications:
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: config
+      name: cnbi-operator
+  repos:
+    - name: manifests
+      uri: https://github.com/thoth-station/meteor-operator/tarball/main
+  version: v1.1.0

--- a/kfdefs/overlays/osc/osc-cl1/cnbi/kustomization.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/cnbi/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: aicoe-meteor
+resources:
+  - kfdef.yaml

--- a/kfdefs/overlays/osc/osc-cl1/jupyterhub-stage/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/jupyterhub-stage/kfdef.yaml
@@ -36,14 +36,7 @@ spec:
           name: manifests
           path: odh-dashboard
       name: odh-dashboard
-    - kustomizeConfig:
-        repoRef:
-          name: meteor-operator
-          path: config/default
-      name: cnbi-operator
   repos:
     - name: manifests
       uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl1-byon
-    - name: meteor-operator
-      uri: https://github.com/thoth-station/meteor-operator/tarball/spike-cnbi-crd
   version: v1.1.0

--- a/kfdefs/overlays/osc/osc-cl1/kustomization.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - cnbi
   - dashboard
   - jupyterhub
   - jupyterhub-stage


### PR DESCRIPTION
Deploy cnbi component on aicoe-meteor namespace
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Related-to: https://github.com/thoth-station/meteor-operator/issues/88

Explicitly separated the cnbi deployment kfdef