### PR TITLE
Add GeoEducator to OKD WG group

### DIFF
--- a/cluster-scope/base/user.openshift.io/groups/argocd-readonly/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/argocd-readonly/group.yaml
@@ -8,6 +8,7 @@ users:
   - binnes
   - cheesesashimi
   - dmueller2001
+  - GeoEducator
   - Gkrumbach07
   - gkrumbach07
   - JaimeMagiera

--- a/cluster-scope/base/user.openshift.io/groups/okd-wg/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/okd-wg/group.yaml
@@ -8,6 +8,7 @@ users:
   - binnes
   - cheesesashimi
   - dmueller2001
+  - GeoEducator
   - JaimeMagiera
   - lmzuccarelli
   - LorbusChris


### PR DESCRIPTION
Give @GeoEducator access to the `okd-wg` namespace