### PR TITLE
Apply trino optimizations and monitoring visuals.

### DIFF
--- a/grafana/overlays/osc/common/dashboards/data-pipeline-resources.yaml
+++ b/grafana/overlays/osc/common/dashboards/data-pipeline-resources.yaml
@@ -1,0 +1,11 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  labels:
+    app: grafana
+  name: data-pipeline-resources
+spec:
+  customFolderName: General
+  configMapRef:
+    name: data-pipeline-resources
+    key: data-pipeline-resources.json

--- a/grafana/overlays/osc/common/dashboards/json/data-pipeline-resources.json
+++ b/grafana/overlays/osc/common/dashboards/json/data-pipeline-resources.json
@@ -1,0 +1,2334 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 4,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 11,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "id": 18,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "container_memory_working_set_bytes{pod=~'airflow-web-.*',namespace='openmetadata',container='',}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "instant": false,
+              "legendFormat": "Usage {{ pod }}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "expr": "kube_pod_resource_limit{resource='memory',pod=~'airflow-web-.*',namespace='openmetadata'}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "hide": false,
+              "legendFormat": "Limits {{ pod }}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "expr": "kube_pod_resource_request{resource='memory',pod=~'airflow-web-.*',namespace='openmetadata'}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "hide": false,
+              "legendFormat": "Requests {{pod}}",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Airflow Web Memory Usage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "id": 9,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "pod:container_cpu_usage:sum{pod=~'airflow-web-.*',namespace='openmetadata',container='',}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "instant": false,
+              "legendFormat": "Usage {{ pod }}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "expr": "kube_pod_resource_limit{resource='cpu',pod=~'airflow-web-.*',namespace='openmetadata'}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "hide": false,
+              "legendFormat": "Limits {{ pod }}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "expr": "kube_pod_resource_request{resource='cpu',pod=~'airflow-web-.*',namespace='openmetadata'}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "hide": false,
+              "legendFormat": "Requests {{pod}}",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Airflow Web CPU Usage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "id": 16,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "container_memory_working_set_bytes{pod=~'airflow-sync-users-.*',namespace='openmetadata',container='',}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "instant": false,
+              "legendFormat": "Usage {{ pod }}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "expr": "kube_pod_resource_limit{resource='memory',pod=~'airflow-sync-users-.*',namespace='openmetadata'}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "hide": false,
+              "legendFormat": "Limits {{ pod }}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "expr": "kube_pod_resource_request{resource='memory',pod=~'airflow-sync-users-.*',namespace='openmetadata'}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "hide": false,
+              "legendFormat": "Requests {{pod}}",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Airflow Sync Users Memory Usage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "id": 19,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "pod:container_cpu_usage:sum{pod=~'airflow-sync-users-.*',namespace='openmetadata',container='',}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "instant": false,
+              "legendFormat": "Usage {{ pod }}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "expr": "kube_pod_resource_limit{resource='cpu',pod=~'airflow-sync-users-.*',namespace='openmetadata'}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "hide": false,
+              "legendFormat": "Limits {{ pod }}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "expr": "kube_pod_resource_request{resource='cpu',pod=~'airflow-sync-users-.*',namespace='openmetadata'}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "hide": false,
+              "legendFormat": "Requests {{pod}}",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Airflow Sync Users CPU Usage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "id": 14,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "container_memory_working_set_bytes{pod=~'airflow-scheduler-.*',namespace='openmetadata',container='',}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}\n",
+              "instant": false,
+              "legendFormat": "Usage {{ pod }}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "expr": "kube_pod_resource_limit{resource='memory',pod=~'airflow-scheduler-.*',namespace='openmetadata'}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "hide": false,
+              "legendFormat": "Limits {{ pod }}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "expr": "kube_pod_resource_request{resource='memory',pod=~'airflow-scheduler-.*',namespace='openmetadata'}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}\n",
+              "hide": false,
+              "legendFormat": "Requests {{pod}}",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Airflow Scheduler Memory Usage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 17
+          },
+          "id": 17,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "pod:container_cpu_usage:sum{pod=~'airflow-scheduler-.*',namespace='openmetadata',container='',}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "instant": false,
+              "legendFormat": "Usage {{ pod }}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "expr": "kube_pod_resource_limit{resource='cpu',pod=~'airflow-scheduler-.*',namespace='openmetadata'}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "hide": false,
+              "legendFormat": "Limits {{ pod }}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "expr": "kube_pod_resource_request{resource='cpu',pod=~'airflow-scheduler-.*',namespace='openmetadata'}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "hide": false,
+              "legendFormat": "Requests {{pod}}",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Airflow Scheduler CPU Usage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 25
+          },
+          "id": 12,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "container_memory_working_set_bytes{pod=~'airflow-db-.*',namespace='openmetadata',container='',}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "instant": false,
+              "legendFormat": "Usage {{ pod }}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "expr": "kube_pod_resource_limit{resource='memory',pod=~'airflow-db-.*',namespace='openmetadata'}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "hide": false,
+              "legendFormat": "Limits {{ pod }}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "expr": "kube_pod_resource_request{resource='memory',pod=~'airflow-db-.*',namespace='openmetadata'}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "hide": false,
+              "legendFormat": "Requests {{pod}}",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Airflow DB Memory Usage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 25
+          },
+          "id": 15,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "pod:container_cpu_usage:sum{pod=~'airflow-db-.*',namespace='openmetadata',container='',}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "instant": false,
+              "legendFormat": "Usage {{ pod }}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "expr": "kube_pod_resource_limit{resource='cpu',pod=~'airflow-db-.*',namespace='openmetadata'}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "hide": false,
+              "legendFormat": "Limits {{ pod }}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "expr": "kube_pod_resource_request{resource='cpu',pod=~'airflow-db-.*',namespace='openmetadata'}\n* on (pod)\nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "hide": false,
+              "legendFormat": "Requests {{pod}}",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Airflow DB CPU Usage",
+          "type": "timeseries"
+        }
+      ],
+      "title": "AirFlow",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 8,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 2
+          },
+          "id": 6,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(\n    container_memory_working_set_bytes{pod=~'openmetadata-.*',namespace='openmetadata',container='',}\n    * on (pod) \n    kube_pod_status_phase{namespace='openmetadata', phase='Running'}\n    ) \n\nBY (pod, namespace)",
+              "instant": false,
+              "legendFormat": "Usage {{ pod }}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "expr": "kube_pod_resource_limit{resource='memory',pod=~'openmetadata-.*',namespace='openmetadata'} \n* on (pod) \nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "hide": false,
+              "legendFormat": "Limits {{ pod }}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "expr": "avg(\n    kube_pod_resource_request{resource='memory',pod=~'openmetadata-.*',namespace='openmetadata'} \n    * on (pod) \n    kube_pod_status_phase{namespace='openmetadata', phase='Running'}\n    )",
+              "hide": false,
+              "legendFormat": "Requests {{pod}}",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "OM Memory Usage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 2
+          },
+          "id": 13,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "pod:container_cpu_usage:sum{pod=~'openmetadata-.*',namespace='openmetadata',container='',}\n* on (pod) \nkube_pod_status_phase{namespace='openmetadata', phase='Running'}\n",
+              "instant": false,
+              "legendFormat": "Usage {{ pod }}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "expr": "kube_pod_resource_limit{resource='cpu',pod=~'openmetadata-.*',namespace='openmetadata'} \n* on (pod) \nkube_pod_status_phase{namespace='openmetadata', phase='Running'}",
+              "hide": false,
+              "legendFormat": "Limits {{ pod }}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P64AA24F3884B5DA2"
+              },
+              "editorMode": "code",
+              "expr": "kube_pod_resource_request{resource='cpu',pod=~'openmetadata-.*',namespace='openmetadata'} \n* on (pod) \nkube_pod_status_phase{namespace='openmetadata', phase='Running'}\n",
+              "hide": false,
+              "legendFormat": "Requests {{pod}}",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "OM CPU Usage",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Open Metadata",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 4,
+      "panels": [],
+      "title": "Trino",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P64AA24F3884B5DA2"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 3
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "expr": "container_memory_working_set_bytes{pod=~'trino-coordinator-.*',namespace='odh-trino',container='',}\n* on (pod) \nkube_pod_status_phase{namespace='odh-trino', phase='Running'}",
+          "hide": false,
+          "legendFormat": "Usage {{ pod }}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(\n    container_memory_working_set_bytes{pod=~'trino-worker-.*',namespace='odh-trino',container='',}\n    * on (pod) \n    kube_pod_status_phase{namespace='odh-trino', phase='Running'}\n    ) \n\nBY (pod, namespace)",
+          "instant": false,
+          "legendFormat": "Usage {{ pod }}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "expr": "avg(\n    \n    kube_pod_resource_limit{resource='memory',pod=~'trino-worker-.*',namespace='odh-trino'} \n    * on (pod) \n    kube_pod_status_phase{namespace='odh-trino', phase='Running'}\n    \n    ) ",
+          "hide": false,
+          "legendFormat": "Limits {{ pod }}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "expr": "avg(\n    kube_pod_resource_request{resource='memory',pod=~'trino-worker-.*',namespace='odh-trino'} \n    * on (pod) \n    kube_pod_status_phase{namespace='odh-trino', phase='Running'}\n    )",
+          "hide": false,
+          "legendFormat": "Requests {{pod}}",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Trino Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P64AA24F3884B5DA2"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 3
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "expr": "pod:container_cpu_usage:sum{pod=~'trino-coordinator-.*',namespace='odh-trino',container='',}\n* on (pod) \nkube_pod_status_phase{namespace='odh-trino', phase='Running'}",
+          "hide": false,
+          "legendFormat": "Usage {{ pod }}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(\n    pod:container_cpu_usage:sum{pod=~'trino-worker-.*',namespace='odh-trino',container='',}\n    * on (pod) \n    kube_pod_status_phase{namespace='odh-trino', phase='Running'}\n    )\n\nBY (pod, namespace)",
+          "instant": false,
+          "legendFormat": "Usage {{ pod }}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "expr": "avg(\n    \n    kube_pod_resource_limit{resource='cpu',pod=~'trino-worker-.*',namespace='odh-trino'} \n    * on (pod) \n    kube_pod_status_phase{namespace='odh-trino', phase='Running'}\n    \n    ) ",
+          "hide": false,
+          "legendFormat": "Limits {{ pod }}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "expr": "avg(\n    kube_pod_resource_request{resource='cpu',pod=~'trino-worker-.*',namespace='odh-trino'} \n    * on (pod) \n    kube_pod_status_phase{namespace='odh-trino', phase='Running'}\n    )",
+          "hide": false,
+          "legendFormat": "Requests {{pod}}",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Trino CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P64AA24F3884B5DA2"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "container_memory_working_set_bytes{pod=~'trino-db-.*',namespace='odh-trino',container='',}\n* on (pod)\nkube_pod_status_phase{namespace='odh-trino', phase='Running'}\n",
+          "instant": false,
+          "legendFormat": "Usage {{ pod }}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "expr": "kube_pod_resource_limit{resource='memory',pod=~'trino-db-.*',namespace='odh-trino'}\n* on (pod)\nkube_pod_status_phase{namespace='odh-trino', phase='Running'}",
+          "hide": false,
+          "legendFormat": "Limits {{ pod }}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "expr": "kube_pod_resource_request{resource='memory',pod=~'trino-db-.*',namespace='odh-trino'}\n* on (pod)\nkube_pod_status_phase{namespace='odh-trino', phase='Running'}",
+          "hide": false,
+          "legendFormat": "Requests {{pod}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Trino DB",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P64AA24F3884B5DA2"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "pod:container_cpu_usage:sum{pod=~'trino-db-.*',namespace='odh-trino',container='',}\n* on (pod)\nkube_pod_status_phase{namespace='odh-trino', phase='Running'}",
+          "instant": false,
+          "legendFormat": "Usage {{ pod }}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "expr": "kube_pod_resource_limit{resource='cpu',pod=~'trino-db-.*',namespace='odh-trino'}\n* on (pod)\nkube_pod_status_phase{namespace='odh-trino', phase='Running'}",
+          "hide": false,
+          "legendFormat": "Limits {{ pod }}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "expr": "kube_pod_resource_request{resource='cpu',pod=~'trino-db-.*',namespace='odh-trino'}\n* on (pod)\nkube_pod_status_phase{namespace='odh-trino', phase='Running'}",
+          "hide": false,
+          "legendFormat": "Requests {{pod}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Trino DB CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P64AA24F3884B5DA2"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 19
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "container_memory_working_set_bytes{pod=~'hive-metastore-osc-datacommons-dev-0',namespace='odh-trino',container='',}\n* on (pod)\nkube_pod_status_phase{namespace='odh-trino', phase='Running'}\n",
+          "instant": false,
+          "legendFormat": "Usage {{ pod }}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "expr": "kube_pod_resource_limit{resource='memory',pod=~'hive-metastore-osc-datacommons-dev-0',namespace='odh-trino'}\n* on (pod)\nkube_pod_status_phase{namespace='odh-trino', phase='Running'}\n",
+          "hide": false,
+          "legendFormat": "Limits {{ pod }}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "expr": "kube_pod_resource_request{resource='memory',pod=~'hive-metastore-osc-datacommons-dev-0',namespace='odh-trino'}\n* on (pod)\nkube_pod_status_phase{namespace='odh-trino', phase='Running'}\n",
+          "hide": false,
+          "legendFormat": "Requests {{pod}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Hive Metastore osc-datacommons-dev-0 Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P64AA24F3884B5DA2"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "pod:container_cpu_usage:sum{pod=~'hive-metastore-osc-datacommons-dev-0',namespace='odh-trino',container='',}\n* on (pod)\nkube_pod_status_phase{namespace='odh-trino', phase='Running'}",
+          "instant": false,
+          "legendFormat": "Usage {{ pod }}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "expr": "kube_pod_resource_limit{resource='cpu',pod=~'hive-metastore-osc-datacommons-dev-0',namespace='odh-trino'}\n* on (pod)\nkube_pod_status_phase{namespace='odh-trino', phase='Running'}",
+          "hide": false,
+          "legendFormat": "Limits {{ pod }}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "expr": "kube_pod_resource_request{resource='cpu',pod=~'hive-metastore-osc-datacommons-dev-0',namespace='odh-trino'}\n* on (pod)\nkube_pod_status_phase{namespace='odh-trino', phase='Running'}",
+          "hide": false,
+          "legendFormat": "Requests {{pod}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Hive Metastore osc-datacommons-dev-0 CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P64AA24F3884B5DA2"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "container_memory_working_set_bytes{pod=~'hive-metastore-osc-datacommons-hive-ingest-0',namespace='odh-trino',container='',}\n* on (pod)\nkube_pod_status_phase{namespace='odh-trino', phase='Running'}",
+          "instant": false,
+          "legendFormat": "Usage {{ pod }}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "expr": "kube_pod_resource_limit{resource='memory',pod=~'hive-metastore-osc-datacommons-hive-ingest-0',namespace='odh-trino'}\n* on (pod)\nkube_pod_status_phase{namespace='odh-trino', phase='Running'}",
+          "hide": false,
+          "legendFormat": "Limits {{ pod }}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "expr": "kube_pod_resource_request{resource='memory',pod=~'hive-metastore-osc-datacommons-hive-ingest-0',namespace='odh-trino'}\n* on (pod)\nkube_pod_status_phase{namespace='odh-trino', phase='Running'}",
+          "hide": false,
+          "legendFormat": "Requests {{pod}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Hive Metastore osc-datacommons-hive-ingest-0 Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P64AA24F3884B5DA2"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "pod:container_cpu_usage:sum{pod=~'hive-metastore-osc-datacommons-hive-ingest-0',namespace='odh-trino',container='',}\n* on (pod)\nkube_pod_status_phase{namespace='odh-trino', phase='Running'}",
+          "instant": false,
+          "legendFormat": "Usage {{ pod }}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "expr": "kube_pod_resource_limit{resource='cpu',pod=~'hive-metastore-osc-datacommons-hive-ingest-0',namespace='odh-trino'}\n* on (pod)\nkube_pod_status_phase{namespace='odh-trino', phase='Running'}",
+          "hide": false,
+          "legendFormat": "Limits {{ pod }}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "expr": "kube_pod_resource_request{resource='cpu',pod=~'hive-metastore-osc-datacommons-hive-ingest-0',namespace='odh-trino'}\n* on (pod)\nkube_pod_status_phase{namespace='odh-trino', phase='Running'}",
+          "hide": false,
+          "legendFormat": "Requests {{pod}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Hive Metastore hive-metastore-osc-datacommons-hive-ingest-0 CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P64AA24F3884B5DA2"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P64AA24F3884B5DA2"
+          },
+          "editorMode": "code",
+          "expr": "sum(container_threads{namespace=\"odh-trino\", pod=~'trino-coordinator-.*', container=\"trino-coordinator\"})",
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Coordinator Threads",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Data Pipeline Resource Consumption Copy",
+  "uid": "eC_1bFS4z",
+  "version": 1,
+  "weekStart": ""
+}

--- a/grafana/overlays/osc/common/dashboards/kustomization.yaml
+++ b/grafana/overlays/osc/common/dashboards/kustomization.yaml
@@ -7,6 +7,7 @@ commonLabels:
   app: grafana
 resources:
   - kepler.yaml
+  - data-pipeline-resources.yaml
 configMapGenerator:
   - files:
       - json/landingpage.json
@@ -14,3 +15,6 @@ configMapGenerator:
   - files:
       - json/kepler.json
     name: kepler
+  - files:
+      - json/data-pipeline-resources.json
+    name: data-pipeline-resources

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/kafka_fx.properties
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/kafka_fx.properties
@@ -1,5 +1,5 @@
 connector.name=kafka
-kafka.table-names=tpch.FX,kepler.KeplerExporterMetrics,ecb-fx.FX
+kafka.table-names=tpch.FX,kepler.KeplerExporterMetrics,ecb-fx.FX,electricitymap.co2signal
 kafka.nodes=fx-kafka-bootstrap.kafka.svc.cluster.local:9092
 kafka.hide-internal-columns=false
 kafka.table-description-supplier=FILE

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/kafka_fx.properties
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/kafka_fx.properties
@@ -1,5 +1,5 @@
 connector.name=kafka
-kafka.table-names=tpch.FX,kepler.KeplerExporterMetrics,ECB-FX.FX
+kafka.table-names=tpch.FX,kepler.KeplerExporterMetrics,ecb-fx.FX
 kafka.nodes=fx-kafka-bootstrap.kafka.svc.cluster.local:9092
 kafka.hide-internal-columns=false
 kafka.table-description-supplier=FILE

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/jvm-coordinator.config
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/jvm-coordinator.config
@@ -12,3 +12,4 @@
 -XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
+-javaagent:/usr/lib/trino/lib/jmx_exporter.jar=8082:/etc/trino/prometheus/config.yaml

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/jvm-coordinator.config
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/jvm-coordinator.config
@@ -12,4 +12,4 @@
 -XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
--javaagent:/usr/lib/trino/lib/jmx_exporter.jar=8082:/etc/trino/prometheus/config.yaml
+-javaagent:/usr/lib/trino/lib/jmx_exporter.jar=8082:/etc/trino/prometheus/monitoring-config.yaml

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/jvm-worker.config
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/jvm-worker.config
@@ -12,3 +12,4 @@
 -XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
+-javaagent:/usr/lib/trino/lib/jmx_exporter.jar=8082:/etc/trino/prometheus/config.yaml

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/jvm-worker.config
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/jvm-worker.config
@@ -12,4 +12,4 @@
 -XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
--javaagent:/usr/lib/trino/lib/jmx_exporter.jar=8082:/etc/trino/prometheus/config.yaml
+-javaagent:/usr/lib/trino/lib/jmx_exporter.jar=8082:/etc/trino/prometheus/monitoring-config.yaml

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/kafka-table-description-dir/co2signal-trino-schema.json
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/kafka-table-description-dir/co2signal-trino-schema.json
@@ -1,0 +1,62 @@
+{
+    "tableName": "co2signal",
+    "schemaName": "electricitymap",
+    "topicName": "co2signaldotcom",
+    "key": {
+        "dataFormat": "json",
+        "fields": [
+            {
+                "name": "country_code",
+                "type": "VARCHAR",
+                "hidden": "false"
+            }
+        ]
+    },
+    "message": {
+        "dataFormat" :"json",
+        "fields" : [
+            {
+                "name": "country_name",
+                "mapping": "country_name",
+                "type": "VARCHAR"
+            },
+            {
+                "name": "zone_name",
+                "mapping": "zone_name",
+                "type": "VARCHAR"
+            },
+            {
+                "name": "status",
+                "mapping": "status",
+                "type": "VARCHAR"
+            },
+            {
+                "name": "datetime",
+                "mapping": "datetime",
+                "type": "TIMESTAMP",
+                "dataFormat" :"custom-date-time",
+                "formatHint":"yyyy-MM-dd'T'HH:mm:ss.SSSZZ"
+            },
+            {
+                "name": "carbon_intensity",
+                "mapping": "carbon_intensity",
+                "type": "DOUBLE"
+            },
+            {
+                "name": "fossel_fuel_percentage",
+                "mapping": "fossel_fuel_percentage",
+                "type": "DOUBLE"
+            },
+            {
+                "name": "unit_name",
+                "mapping": "unit_name",
+                "type": "VARCHAR"
+            },
+            {
+                "name": "unit_value",
+                "mapping": "unit_value",
+                "type": "VARCHAR"
+            }
+        ]
+    }
+}

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/kafka-table-description-dir/co2signal-trino-schema.json
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/kafka-table-description-dir/co2signal-trino-schema.json
@@ -1,7 +1,7 @@
 {
     "tableName": "co2signal",
     "schemaName": "electricitymap",
-    "topicName": "co2signaldotcom",
+    "topicName": "co2signal",
     "key": {
         "dataFormat": "json",
         "fields": [

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/kafka-table-description-dir/ecb-trino-schema.json
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/kafka-table-description-dir/ecb-trino-schema.json
@@ -1,7 +1,7 @@
 {
     "tableName": "FX",
     "schemaName": "ecb-fx",
-    "topicName": "ECB-FX",
+    "topicName": "ecb-fx",
     "key": {
         "dataFormat": "json",
         "fields": [

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/kustomization.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/kustomization.yaml
@@ -31,3 +31,6 @@ configMapGenerator:
       - kafka-table-description-dir/fx.json
       - kafka-table-description-dir/kepler.json
       - kafka-table-description-dir/ecb-trino-schema.json
+  - name: trino-config-monitoring
+    files:
+      - monitoring-config.yaml

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/kustomization.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/kustomization.yaml
@@ -31,6 +31,7 @@ configMapGenerator:
       - kafka-table-description-dir/fx.json
       - kafka-table-description-dir/kepler.json
       - kafka-table-description-dir/ecb-trino-schema.json
+      - kafka-table-description-dir/co2signal-trino-schema.json
   - name: trino-config-monitoring
     files:
       - monitoring-config.yaml

--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/monitoring-config.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/monitoring-config.yaml
@@ -1,0 +1,73 @@
+---
+lowercaseOutputName: true
+lowercaseOutputLabelNames: true
+attrNameSnakeCase: false
+rules:
+  # capture percentile and set quantile label
+  - pattern: 'trino.plugin.hive<type=(.+), name=hive><>(.+AllTime).P(\\d+): (.*)'
+    name: 'trino_hive_$1_$2_seconds'
+    type: GAUGE
+    valueFactor: 0.001
+    labels:
+      quantile: '0.$3'
+  # match non-percentiles
+  - pattern: 'trino.plugin.hive<type=(.+), name=hive><>(.+AllTime.+): (.*)'
+    name: 'trino_hive_$1_$2_seconds'
+    type: GAUGE
+    valueFactor: 0.001
+  # counts
+  - pattern: 'trino.plugin.hive<type=(.+), name=hive><>(.+TotalCount.*): (.*)'
+    name: 'trino_hive_$1_$2_total'
+    type: COUNTER
+  # capture percentile and set quantile label
+  - pattern: 'trino.plugin.hive.s3<type=(.+), name=hive><>(.+AllTime).P(\\d+): (.*)'
+    name: 'trino_hive_s3_$1_$2_seconds'
+    type: GAUGE
+    valueFactor: 0.001
+    labels:
+      quantile: '0.$3'
+  # match non-percentiles
+  - pattern: 'trino.plugin.hive.s3<type=(.+), name=hive><>(.+AllTime.+): (.*)'
+    name: 'trino_hive_s3_$1_$2_seconds'
+    type: GAUGE
+    valueFactor: 0.001
+  # counts
+  - pattern: 'trino.plugin.hive.s3<type=(.+), name=hive><>(.+TotalCount.*): (.*)'
+    name: 'trino_hive_s3_$1_$2_total'
+    type: COUNTER
+  # capture percentile and set quantile label
+  - pattern: 'trino.plugin.hive.metastore.thrift<type=(.+), name=hive><>(.+AllTime).P(\\d+): (.*)'
+    name: 'trino_hive_metastore_thrift_$1_$2_seconds'
+    type: GAUGE
+    valueFactor: 0.001
+    labels:
+      quantile: '0.$3'
+  # match non-percentiles
+  - pattern: 'trino.plugin.hive.metastore.thrift<type=(.+), name=hive><>(.+AllTime.+): (.*)'
+    name: 'trino_hive_metastore_thrift_$1_$2_count_seconds'
+    type: GAUGE
+    valueFactor: 0.001
+  # counts
+  - pattern: 'trino.plugin.hive.metastore.thrift<type=(.+), name=hive><>(.+TotalCount.*): (.*)'
+    name: 'trino_hive_metastore_thrift_$1_$2_total'
+    type: COUNTER
+  - pattern: 'trino.execution<name=(.+)><>(.+AllTime).P(\d+): (.*)'
+    name: 'trino_execution_$1_$2_seconds'
+    type: GAUGE
+    valueFactor: 0.001
+    labels:
+      quantile: '0.$3'
+  - pattern: 'trino.execution<name=(.+)><>(.+AllTime.+): (.*)'
+    name: 'trino_execution_$1_$2_seconds'
+    type: GAUGE
+    valueFactor: 0.001
+  # counts
+  - pattern: 'trino.execution<name=(.+)><>(.+TotalCount.*): (.*)'
+    name: 'trino_execution_$1_$2_total'
+    type: COUNTER
+  - pattern: 'trino.memory<type=(.*), name=(.*)><>(.+): (.*)'
+    name: 'trino_memory_$1_$2_$3'
+    type: GAUGE
+  - pattern: 'trino.failuredetector<name=HeartbeatFailureDetector><>ActiveCount: (.*)'
+    name: 'trino_heartbeatdetector_activecount'
+    type: GAUGE

--- a/kfdefs/overlays/osc/osc-cl2/trino/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/kfdef.yaml
@@ -20,9 +20,9 @@ spec:
           - name: s3_credentials_secret
             value: odh-datacatalog-bucket
           - name: trino_memory_request
-            value: 8Gi
-          - name: trino_memory_limit
             value: 10Gi
+          - name: trino_memory_limit
+            value: 12Gi
           - name: trino_cpu_request
             value: '2'
           - name: trino_cpu_limit

--- a/kfdefs/overlays/osc/osc-cl2/trino/kustomization.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
   - hive-metastores
   - kfdef.yaml
   - secure-route.yaml
+  - servicemonitors
 generatorOptions:
   disableNameSuffixHash: true

--- a/kfdefs/overlays/osc/osc-cl2/trino/servicemonitors/OSC_DataCommons_Dev.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/servicemonitors/OSC_DataCommons_Dev.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: hive-metastore-osc-datacommons-dev
+  labels:
+    trino-catalog: hive-metastore-osc-datacommons-dev
+spec:
+  endpoints:
+    - interval: 3s
+      port: metrics
+      scheme: http
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchLabels:
+      trino-catalog: hive-metastore-osc-datacommons-dev

--- a/kfdefs/overlays/osc/osc-cl2/trino/servicemonitors/kustomization.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/servicemonitors/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - OSC_DataCommons_Dev.yaml
+  - osc_datacommons_hive_ingest.yaml
+  - trino-coordinator.yaml
+  - trino-workers.yaml

--- a/kfdefs/overlays/osc/osc-cl2/trino/servicemonitors/osc_datacommons_hive_ingest.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/servicemonitors/osc_datacommons_hive_ingest.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: hive-metastore-osc-datacommons-hive-ingest
+  labels:
+    trino-catalog: hive-metastore-osc-datacommons-hive-ingest
+spec:
+  endpoints:
+    - interval: 3s
+      port: metrics
+      scheme: http
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchLabels:
+      trino-catalog: hive-metastore-osc-datacommons-hive-ingest

--- a/kfdefs/overlays/osc/osc-cl2/trino/servicemonitors/trino-coordinator.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/servicemonitors/trino-coordinator.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    role: trino-coordinator
+  name: trino-coordinator
+spec:
+  endpoints:
+    - interval: 3s
+      port: metrics
+      scheme: http
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchLabels:
+      role: trino-coordinator

--- a/kfdefs/overlays/osc/osc-cl2/trino/servicemonitors/trino-workers.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/trino/servicemonitors/trino-workers.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    role: trino-worker
+  name: trino-worker
+spec:
+  endpoints:
+    - interval: 3s
+      port: metrics
+      scheme: http
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchLabels:
+      role: trino-worker


### PR DESCRIPTION
This change adds servicemonitors to the hive metastores and trino, this will allow us to monitor the JMX metrics exposed by these components. Trino's jmx java agent exporter is also enabled in this PR.

To help better visualize these metrics, a grafana dashaboard is also provided.

Possibly related: https://github.com/operate-first/support/issues/1113

Also adds a fix to ecb-fx kafka topic and converts it to lower case for: https://github.com/os-climate/os_c_data_commons/issues/203

also adds co2signal topic to kafka connector: https://github.com/os-climate/os_c_data_commons/issues/213