### PR TITLE
Fix grafana invalid uid error for landing page.

### DIFF
--- a/grafana/overlays/moc/smaug/landingpage-dashboard-configmap.yaml
+++ b/grafana/overlays/moc/smaug/landingpage-dashboard-configmap.yaml
@@ -1787,7 +1787,6 @@ data:
       "timepicker": {},
       "timezone": "",
       "title": "Landing Page",
-      "uid": "_kVajXf7t",
       "version": 0,
       "weekStart": ""
     }

--- a/grafana/overlays/osc/common/dashboards/json/landingpage.json
+++ b/grafana/overlays/osc/common/dashboards/json/landingpage.json
@@ -90,8 +90,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Landing Page Copy",
-  "uid": "N7NlI0W4z",
+  "title": "Landing Page",
   "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
Fixes the UUID error that occurs when hitting the landing page in grafana.

![image](https://user-images.githubusercontent.com/10904967/195944707-1fe27980-e1a6-4cf1-93b0-834a2773e1e0.png)
