### PR TITLE
fix(service-catalog): Invalid description in Prow needs rebase

### DIFF
--- a/service-catalog/components/prow-needs-rebase.yaml
+++ b/service-catalog/components/prow-needs-rebase.yaml
@@ -3,7 +3,6 @@ kind: Component
 metadata:
   name: prow-needs-rebase
   title: Needs-rebase
-  description:
   annotations:
     operate-first.cloud/logo-url: https://prow.operate-first.cloud/static/logo-light.png
     argocd/app-name: ci-prow-prod-smaug


### PR DESCRIPTION
This was causing:

```
[2] 2022-10-18T13:48:01.429Z catalog warn Policy check failed for component:default/prow-needs-rebase; caused by Error: Malformed envelope, /metadata/description must be string type=plugin entity=component:default/prow-needs-rebase
[2] 2022-10-18T13:50:28.493Z catalog warn Policy check failed for component:default/prow-needs-rebase; caused by Error: Malformed envelope, /metadata/description must be string type=plugin entity=component:default/prow-needs-rebase
[2] 2022-10-18T13:52:43.538Z catalog warn Policy check failed for component:default/prow-needs-rebase; caused by Error: Malformed envelope, /metadata/description must be string type=plugin entity=component:default/prow-needs-rebase
```