### PR TITLE
add goern to odh-admin group on osc cl1

### DIFF
--- a/cluster-scope/overlays/prod/osc/osc-cl1/groups/odh-admin.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/groups/odh-admin.yaml
@@ -8,6 +8,7 @@ users:
   - codificat
   - erikerlandson
   - Gkrumbach07
+  - goern
   - Gregory-Pereira
   - harshad16
   - HumairAK


### PR DESCRIPTION
Signed-off-by: Christoph Görn <goern@redhat.com>
