### PR TITLE
Add cgwalters to okd-team and okd-wg groups

### DIFF
--- a/cluster-scope/base/user.openshift.io/groups/argocd-readonly/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/argocd-readonly/group.yaml
@@ -6,6 +6,7 @@ users:
   - aleskandro
   - bdlink
   - binnes
+  - cgwalters
   - cheesesashimi
   - dmueller2001
   - GeoEducator

--- a/cluster-scope/base/user.openshift.io/groups/okd-team/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/okd-team/group.yaml
@@ -4,6 +4,7 @@ metadata:
   name: okd-team
 users:
   - aleskandro
+  - cgwalters
   - cheesesashimi
   - dmueller2001
   - lmzuccarelli

--- a/cluster-scope/base/user.openshift.io/groups/okd-wg/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/okd-wg/group.yaml
@@ -6,6 +6,7 @@ users:
   - aleskandro
   - bdlink
   - binnes
+  - cgwalters
   - cheesesashimi
   - dmueller2001
   - GeoEducator


### PR DESCRIPTION
Give @cgwalters access to the `okd-team` and `okd-wg` namespaces.

@cgwalters you'll be able to log onto https://console-openshift-console.apps.smaug.na.operate-first.cloud/k8s/cluster/projects/okd-team after accepting the invitation to the `operate-first` GH org. 