### PR TITLE
Add authentication overlay to odh-dashboard in osc cl1 CNBi stage

### DIFF
--- a/kfdefs/overlays/osc/osc-cl1/jupyterhub-stage/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/jupyterhub-stage/kfdef.yaml
@@ -32,6 +32,8 @@ spec:
           path: jupyterhub/notebook-images
       name: notebook-images
     - kustomizeConfig:
+        overlays:
+          - authentication
         repoRef:
           name: manifests
           path: odh-dashboard


### PR DESCRIPTION
The new dev version of the odh-dashboard in the _stage_ namespace in osc's odh-cl1 (ref https://github.com/operate-first/odh-manifests/pull/40) is failing to start:

``` text
Environment:
	DEV_MODE=false
	NODE_ENV=production
	DEBUG_PORT=5858
Launching via npm...
npm info it worked if it ends with ok
npm info using npm@6.14.17
npm info using node@v14.20.0
npm info lifecycle ods-dashboard@1.0.0~prestart: ods-dashboard@1.0.0
npm info lifecycle ods-dashboard@1.0.0~start: ods-dashboard@1.0.0

> ods-dashboard@1.0.0 start /opt/app-root/src
> run-p start:*

npm info it worked if it ends with ok
npm info using npm@6.14.17
npm info using node@v14.20.0
npm info it worked if it ends with ok
npm info using npm@6.14.17
npm info using node@v14.20.0
npm info lifecycle ods-dashboard@1.0.0~prestart:frontend: ods-dashboard@1.0.0
npm info lifecycle ods-dashboard@1.0.0~start:frontend: ods-dashboard@1.0.0
npm info lifecycle ods-dashboard@1.0.0~prestart:backend: ods-dashboard@1.0.0

> ods-dashboard@1.0.0 start:frontend /opt/app-root/src
> echo "...available at ./frontend/public"

npm info lifecycle ods-dashboard@1.0.0~start:backend: ods-dashboard@1.0.0

> ods-dashboard@1.0.0 start:backend /opt/app-root/src
> cd ./backend && npm start

...available at ./frontend/public
npm info lifecycle ods-dashboard@1.0.0~poststart:frontend: ods-dashboard@1.0.0
npm timing npm Completed in 495ms
npm info ok
npm info it worked if it ends with ok
npm info using npm@6.14.17
npm info using node@v14.20.0
npm info lifecycle ods-dashboard-backend@1.0.0~prestart: ods-dashboard-backend@1.0.0
npm info lifecycle ods-dashboard-backend@1.0.0~start: ods-dashboard-backend@1.0.0

> ods-dashboard-backend@1.0.0 start /opt/app-root/src/backend
> npm run tsc && NODE_ENV=production node ./dist/server.js --log=1 --registry=localhost:50051

npm info it worked if it ends with ok
npm info using npm@6.14.17
npm info using node@v14.20.0
npm info lifecycle ods-dashboard-backend@1.0.0~pretsc: ods-dashboard-backend@1.0.0
npm info lifecycle ods-dashboard-backend@1.0.0~tsc: ods-dashboard-backend@1.0.0

> ods-dashboard-backend@1.0.0 tsc /opt/app-root/src/backend
> tsc -p .

npm info lifecycle ods-dashboard-backend@1.0.0~posttsc: ods-dashboard-backend@1.0.0
npm timing npm Completed in 45593ms
npm info ok
ERROR:  subscriptions.operators.coreos.com is forbidden: User "system:serviceaccount:opf-jupyterhub-stage:odh-dashboard" cannot list resource "subscriptions" in API group "operators.coreos.com" at the cluster scope
{"level":50,"time":1666700355136,"pid":80,"hostname":"odh-dashboard-d7554cc64-6nbgt","msg":"Error fetching applications: odhapplications.dashboard.opendatahub.io is forbidden: User \"system:serviceaccount:opf-jupyterhub-stage:odh-dashboard\" cannot list resource \"odhapplications\" in API group \"dashboard.opendatahub.io\" in the namespace \"opf-jupyterhub-stage\""}
{"level":50,"time":1666700355138,"pid":80,"hostname":"odh-dashboard-d7554cc64-6nbgt","msg":"Error fetching applications: odhapplications.dashboard.opendatahub.io is forbidden: User \"system:serviceaccount:opf-jupyterhub-stage:odh-dashboard\" cannot list resource \"odhapplications\" in API group \"dashboard.opendatahub.io\" in the namespace \"opf-jupyterhub-stage\""}
Fastify Connected...
Server listening on >>>  0.0.0.0:8080
{"level":50,"time":1666700355398,"pid":80,"hostname":"odh-dashboard-d7554cc64-6nbgt","msg":"Error fetching applications: odhapplications.dashboard.opendatahub.io is forbidden: User \"system:serviceaccount:opf-jupyterhub-stage:odh-dashboard\" cannot list resource \"odhapplications\" in API group \"dashboard.opendatahub.io\" in the namespace \"opf-jupyterhub-stage\""}
{"level":40,"time":1666700355399,"pid":80,"hostname":"odh-dashboard-d7554cc64-6nbgt","msg":"Received error (odhdashboardconfigs.opendatahub.io \"odh-dashboard-config\" is forbidden: User \"system:serviceaccount:opf-jupyterhub-stage:odh-dashboard\" cannot get resource \"odhdashboardconfigs\" in API group \"opendatahub.io\" in the namespace \"opf-jupyterhub-stage\") fetching OdhDashboardConfig, creating new."}
{"level":50,"time":1666700355505,"pid":80,"hostname":"odh-dashboard-d7554cc64-6nbgt","msg":"Error fetching documentation resources: odhdocuments.dashboard.opendatahub.io is forbidden: User \"system:serviceaccount:opf-jupyterhub-stage:odh-dashboard\" cannot list resource \"odhdocuments\" in API group \"dashboard.opendatahub.io\" in the namespace \"opf-jupyterhub-stage\""}
{"level":50,"time":1666700355507,"pid":80,"hostname":"odh-dashboard-d7554cc64-6nbgt","msg":"Error fetching quick starts: odhquickstarts.console.openshift.io is forbidden: User \"system:serviceaccount:opf-jupyterhub-stage:odh-dashboard\" cannot list resource \"odhquickstarts\" in API group \"console.openshift.io\" in the namespace \"opf-jupyterhub-stage\""}
{"level":50,"time":1666700355513,"pid":80,"hostname":"odh-dashboard-d7554cc64-6nbgt","msg":"Error creating Dashboard CR: "}
{"level":50,"time":1666700382961,"pid":80,"hostname":"odh-dashboard-d7554cc64-6nbgt","msg":"Error retrieving username: Error getting Oauth Info for user, undefined - missing x-forwarded-access-token header"}
{"level":50,"time":1666700382964,"pid":80,"hostname":"odh-dashboard-d7554cc64-6nbgt","msg":"Error retrieving username: Error getting Oauth Info for user, undefined - missing x-forwarded-access-token header"}
{"level":50,"time":1666700412957,"pid":80,"hostname":"odh-dashboard-d7554cc64-6nbgt","msg":"Error retrieving username: Error getting Oauth Info for user, undefined - missing x-forwarded-access-token header"}
{"level":50,"time":1666700412958,"pid":80,"hostname":"odh-dashboard-d7554cc64-6nbgt","msg":"Error retrieving username: Error getting Oauth Info for user, undefined - missing x-forwarded-access-token header"}
npm info lifecycle ods-dashboard@1.0.0~poststart: ods-dashboard@1.0.0
npm timing npm Completed in 108757ms
npm info ok
```

There might be more problems here, but the last few entries ("Error getting Oauth Info...") point to the missing oauth proxy, which the `authentication` overlay adds.