### PR TITLE
Fix limitRanges for okd-team defaults

### DIFF
--- a/cluster-scope/base/core/namespaces/okd-team/limits.yaml
+++ b/cluster-scope/base/core/namespaces/okd-team/limits.yaml
@@ -6,8 +6,8 @@ spec:
   limits:
     - type: Container
       default:
-        cpu: 1000m
-        memory: 4000Mi
+        cpu: 250m
+        memory: 200Mi
       defaultRequest:
-        cpu: 500m
-        memory: 1000Mi
+        cpu: 100m
+        memory: 100Mi


### PR DESCRIPTION
Limit cpu and memory was too high and often blocking new pod creations