### PR TITLE
Add robozome ns

### DIFF
--- a/cluster-scope/base/core/namespaces/robozome/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/robozome/kustomization.yaml
@@ -1,0 +1,9 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+namespace: robozome
+resources:
+    - namespace.yaml
+    - resourcequota.yaml
+components:
+    - ../../../../components/limitranges/default
+    - ../../../../components/project-admin-rolebindings/operate-first

--- a/cluster-scope/base/core/namespaces/robozome/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/robozome/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: robozome
+    annotations:
+        openshift.io/requester: operate-first

--- a/cluster-scope/base/core/namespaces/robozome/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/robozome/resourcequota.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: robozome-custom
+spec:
+  hard:
+    limits.cpu: '8'
+    limits.memory: 32Gi
+    requests.cpu: '8'
+    requests.memory: 32Gi

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -86,6 +86,7 @@ resources:
 - ../../../../base/core/namespaces/ray-bu
 - ../../../../base/core/namespaces/report-system
 - ../../../../base/core/namespaces/rh-curator-eval
+- ../../../../base/core/namespaces/robozome
 - ../../../../base/core/namespaces/service-catalog
 - ../../../../base/core/namespaces/smart-village-view
 - ../../../../base/core/namespaces/stackrox

--- a/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/kustomization.yaml
@@ -28,3 +28,4 @@ resources:
 - stackrox
 - okd-team
 - okd-centos
+- robozome

--- a/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/robozome/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/robozome/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: robozome
+resources:
+  - ../base

--- a/scripts/jsonnet/group.jsonnet
+++ b/scripts/jsonnet/group.jsonnet
@@ -1,0 +1,10 @@
+local name = std.extVar('GROUP');
+local users = std.extVar('USERS');
+{
+  apiVersion: "user.openshift.io/v1",
+  kind: "Group",
+  metadata: {
+    name: name,
+  },
+  users: users,
+}

--- a/scripts/jsonnet/namespace.jsonnet
+++ b/scripts/jsonnet/namespace.jsonnet
@@ -1,0 +1,21 @@
+local namespace = std.extVar('NAMESPACE');
+local requester = std.extVar('REQUESTER');
+local display_name = std.extVar('DISPLAY_NAME');
+local project_owner = std.extVar('PROJECT_OWNER');
+local onboarding_issue = std.extVar('ONBOARDING_ISSUE');
+local docs = std.extVar('DOCS');
+
+{
+  apiVersion: "v1",
+  kind: "Namespace",
+  metadata: {
+    name: namespace,
+    annotations: {
+      'openshift.io/requester': requester,
+      'openshift.io/display-name': display_name,
+      'op1st/project-owner': project_owner,
+      'op1st/onboarding-issue': onboarding_issue,
+      'op1st/docs': docs,
+    }
+  }
+}

--- a/scripts/jsonnet/rbac.jsonnet
+++ b/scripts/jsonnet/rbac.jsonnet
@@ -1,0 +1,21 @@
+local group = std.extVar('GROUP');
+
+{
+  "apiVersion": "rbac.authorization.k8s.io/v1",
+  "kind": "RoleBinding",
+  "metadata": {
+    "name": "namespace-admin-"+group
+  },
+  "roleRef": {
+    "apiGroup": "rbac.authorization.k8s.io",
+    "kind": "ClusterRole",
+    "name": "admin"
+  },
+  "subjects": [
+    {
+      "apiGroup": "rbac.authorization.k8s.io",
+      "kind": "Group",
+      "name": group
+    }
+  ]
+}

--- a/scripts/offboarding.sh
+++ b/scripts/offboarding.sh
@@ -1,0 +1,45 @@
+set -o allexport -o pipefail -ex
+
+# Pre-condition:
+# - Create the config file at location ${PAYLOAD_PATH}
+# - Clone the github.com/operate-first/apps repo at location ${WORKING_DIR}
+# - Working branch should be clean, checked out of upstream default branch.
+
+CONFIG=${PAYLOAD_PATH}
+REPO=${WORKING_DIR}/apps
+
+# Unpack Config file, we will need these environment variables for the remainder of the steps
+PROJECT=$(yq e .project-name ${CONFIG})
+ENVIRONMENT=moc
+CLUSTER=$(yq e '.cluster[0] | downcase' ${CONFIG})
+NAMESPACE=$(yq e '.project-name | downcase' ${CONFIG})
+GROUP=$(yq e '.team-name' ${CONFIG})
+
+# Remove OCP Group for team being onboarded
+GROUP_PATH="${REPO}/cluster-scope/base/user.openshift.io/groups/${GROUP}";
+rm ${GROUP_PATH} -rf
+
+# Remove namespace for team being onboarded
+NAMESPACE_PATH="${REPO}/cluster-scope/base/core/namespaces/${NAMESPACE}/";
+rm ${NAMESPACE_PATH} -rf
+
+# "Give the team being onboarded access to the Namespace via OCP rbac"
+
+RBAC_PATH="${REPO}/cluster-scope/components/project-admin-rolebindings/${GROUP}/"
+rm ${RBAC_PATH} -rf
+
+# Remove from cluster
+cd ${REPO}/cluster-scope/overlays/prod/common
+kustomize edit remove resource ../../../base/user.openshift.io/groups/${GROUP}
+yq -i '.resources |= sort' kustomization.yaml
+
+cd ${REPO}/cluster-scope/overlays/prod/${ENVIRONMENT}/${CLUSTER}
+kustomize edit remove resource ../../../../base/core/namespaces/${NAMESPACE}
+yq -i '.resources |= sort' kustomization.yaml
+
+# Commit changes
+cd ${REPO}
+git add cluster-scope
+git commit -m "Off-boarding team ${GROUP}."
+
+set -o allexport

--- a/scripts/onboarding.sh
+++ b/scripts/onboarding.sh
@@ -1,0 +1,90 @@
+set -o allexport -o pipefail -ex
+
+# Pre-condition:
+# - Create the config file at location ${PAYLOAD_PATH}
+# - Clone the github.com/operate-first/apps repo at location ${WORKING_DIR}
+# - Working branch should be clean, checked out of upstream default branch.
+# - Set Environment variables: ORG_NAME (=operate-first), SOURCE_REPO (=support), ISSUE_NUMBER
+
+CONFIG=${PAYLOAD_PATH}
+REPO=${WORKING_DIR}/apps
+
+# Unpack Config file, we will need these environment variables for the remainder of the steps
+PROJECT=$(yq e .project-name ${CONFIG})
+ENVIRONMENT=$(yq e '.environment[0] | downcase' ${CONFIG})
+CLUSTER=$(yq e '.cluster[0] | downcase' ${CONFIG})
+NAMESPACE=$(yq e '.project-name | downcase' ${CONFIG})
+REQUESTER=$(yq e '.project-owner' ${CONFIG})
+DISPLAY_NAME=$(yq e '.project-name' ${CONFIG})
+PROJECT_OWNER=$(yq e '.project-owner' ${CONFIG})
+ONBOARDING_ISSUE=https://github.com/${ORG_NAME}/${SOURCE_REPO}/issues/${ISSUE_NUMBER}
+DOCS=$(yq e '.project-docs-link' ${CONFIG})
+GROUP=$(yq e '.team-name' ${CONFIG})
+USERS=$(yq '.users | split(",") | map(trim)' -o json -I=0 ${CONFIG})
+QUOTA=$(yq e '.quota[0] | downcase' ${CONFIG})
+
+# Create OCP Group for team being onboarded
+
+GROUP_PATH="${REPO}/cluster-scope/base/user.openshift.io/groups/${GROUP}";
+mkdir ${GROUP_PATH}
+jsonnet --ext-str GROUP --ext-code USERS scripts/jsonnet/group.jsonnet | yq -P > ${GROUP_PATH}/group.yaml
+cd ${GROUP_PATH}
+kustomize init ${GROUP_PATH}
+kustomize edit add resource group.yaml
+
+# Create namespace for team being onboarded
+
+cd ${REPO}
+NAMESPACE_PATH="${REPO}/cluster-scope/base/core/namespaces/${NAMESPACE}/";
+mkdir ${NAMESPACE_PATH}
+jsonnet --ext-str NAMESPACE \
+  --ext-str REQUESTER \
+  --ext-str DISPLAY_NAME \
+  --ext-str PROJECT_OWNER \
+  --ext-str ONBOARDING_ISSUE \
+  --ext-str DOCS \
+  scripts/jsonnet/namespace.jsonnet | yq -P > ${NAMESPACE_PATH}/namespace.yaml
+cd ${NAMESPACE_PATH}
+kustomize init ${NAMESPACE_PATH}
+kustomize edit add resource namespace.yaml
+kustomize edit set namespace ${NAMESPACE}
+kustomize edit add component ../../../../components/limitranges/default
+kustomize edit add component ../../../../components/resourcequotas/${QUOTA}
+
+# "Give the team being onboarded access to the Namespace via OCP rbac"
+
+cd ${REPO}
+RBAC_PATH="${REPO}/cluster-scope/components/project-admin-rolebindings/${GROUP}"
+mkdir ${RBAC_PATH}
+jsonnet --ext-str GROUP --ext-code USERS scripts/jsonnet/rbac.jsonnet | yq -P > ${RBAC_PATH}/rbac.yaml
+cd ${RBAC_PATH}
+kustomize init ${RBAC_PATH}
+kustomize edit add resource rbac.yaml
+
+# Add rbac to the namespace being onboarded.
+
+cd ${NAMESPACE_PATH}
+kustomize edit add resource ../../../../components/project-admin-rolebindings/${GROUP}
+
+# Up until now we have created resources in the base directory
+# We now need to include these resources onto the target cluster for which this team needs to be onboarded.
+# We do this by adding these newly created resources to the target cluster's overlay directory.
+
+cd ${REPO}/cluster-scope/overlays/prod/${ENVIRONMENT}/${CLUSTER}
+kustomize edit add resource ../../../../base/core/namespaces/${NAMESPACE}
+
+# We keep the resources list in kustomization.yaml sorted for human readability
+yq -i '.resources |= sort' kustomization.yaml
+
+cd ${REPO}/cluster-scope/overlays/prod/common
+kustomize edit add resource ../../../base/user.openshift.io/groups/${GROUP}
+
+# Same as before, sort the resources field
+yq -i '.resources |= sort' kustomization.yaml
+
+# Commit changes
+cd ${REPO}
+git add cluster-scope
+git commit -m "Onboarding team ${GROUP}."
+
+set -o allexport

--- a/scripts/payload_examples/offboarding.yaml
+++ b/scripts/payload_examples/offboarding.yaml
@@ -1,0 +1,13 @@
+cluster:
+  - Smaug
+environment:
+  - moc
+team-name: my-team
+project-name: my-project
+project-owner: my-team-member
+project-description: My projects description
+project-docs-link: https://github.com/my-project
+users: member-one, member-two
+quota:
+  - small # either small, medium, large
+custom-quota: "" # not yet supported, will do nothing

--- a/scripts/payload_examples/onboarding.yaml
+++ b/scripts/payload_examples/onboarding.yaml
@@ -1,0 +1,7 @@
+cluster:
+  - Smaug
+environment:
+  - moc
+team-name: my-team
+project-name: my-project
+project-owner: my-team-member


### PR DESCRIPTION
This PR adds robozome namespace, and some starter scripts for onboarding/offboarding projects. The scripts are an alternative implementation to: https://github.com/operate-first/apps/pull/2380 
But still use jsonnet for templating. 

The scripts here are simplified to one script per task (onboarding & offboarding), with documents included. I've removed the dependency on jinja since it's not needed, and the need to create temp folders/files (also not needed). 

I've also added detailed comments in the scripts so it will make it easier to convert them to docs later. 

Scripts consume from a payload file that will be created by the robozome app, when running manually you can create your own payload file by basing it off the examples provided in this PR. 