### PR TITLE
feat(catalog): Create exeternal secret for service-catalog

### DIFF
--- a/cluster-scope/overlays/prod/moc/smaug/externalsecrets/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/externalsecrets/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - pull-secret.yaml
 - rook-ceph-external-cluster-details.yaml
 - service-catalog-k8s-plugin-tokens.yaml
+- service-catalog.yaml

--- a/cluster-scope/overlays/prod/moc/smaug/externalsecrets/service-catalog.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/externalsecrets/service-catalog.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: service-catalog
+  namespace: service-catalog
+spec:
+  secretStoreRef:
+    name: opf-vault-store
+    kind: SecretStore
+  refreshInterval: "1h"
+  target:
+    name: service-catalog
+  dataFrom:
+    - extract:
+        key: moc/smaug/service-catalog/secrets


### PR DESCRIPTION
Part of https://github.com/operate-first/service-catalog/issues/128

Create an external secret for a secret in vault. The SA `vault-secret-fetcher` has already been created. Namespace has been added to the `smaug-k8s/moc-ops` role.

/cc @tumido 