### PR TITLE
[prow] Remove legacy presubmit check for from tide config

### DIFF
--- a/prow/overlays/smaug/config.yaml
+++ b/prow/overlays/smaug/config.yaml
@@ -335,7 +335,6 @@ tide:
         repos:
           sefkhet-abwy:
             required-contexts:
-              - aicoe-ci/pre-commit-check
               - aicoe-ci/build-check
       thoth-station:
         repos:


### PR DESCRIPTION
`prow` (`tide`) is not merging pull requests for the `sefkhet-abwy` repository. See for example https://github.com/AICoE/sefkhet-abwy/pull/203

The pre-commit check driven by the aicoe-ci pipelines was removed a while ago, and this is now covered by a prow pre-submit job, so this PR removes that check from the tide query list for that repo.