### PR TITLE
feat(service catalog): Add service account with role for prometheus plugin

### DIFF
--- a/cluster-scope/base/core/serviceaccounts/service-catalog-prometheus-plugin/kustomization.yaml
+++ b/cluster-scope/base/core/serviceaccounts/service-catalog-prometheus-plugin/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- serviceaccount.yaml

--- a/cluster-scope/base/core/serviceaccounts/service-catalog-prometheus-plugin/serviceaccount.yaml
+++ b/cluster-scope/base/core/serviceaccounts/service-catalog-prometheus-plugin/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: service-catalog-prometheus-plugin
+  namespace: default

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/service-catalog-prometheus-plugin/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/service-catalog-prometheus-plugin/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: service-catalog-prometheus-plugin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+- kind: ServiceAccount
+  name: service-catalog-prometheus-plugin
+  namespace: default

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/service-catalog-prometheus-plugin/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/service-catalog-prometheus-plugin/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - clusterrolebinding.yaml

--- a/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ../../../../base/core/namespaces/openshift-nmstate
   - ../../../../base/core/namespaces/opf-alertreceiver
   - ../../../../base/core/namespaces/vault
+  - ../../../../base/core/serviceaccounts/service-catalog-prometheus-plugin
   - ../../../../base/nmstate.io/nmstates/nmstate
   - ../../../../base/operator.openshift.io/ingresscontrollers/default
   - ../../../../base/operators.coreos.com/operatorgroups/openshift-nmstate
@@ -30,6 +31,7 @@ resources:
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:managedclusterset:admin:octo-ushift-dev
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/open-cluster-management:managedclusterset:admin:osc
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/service-catalog-k8s-plugin-acm
+  - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/service-catalog-prometheus-plugin
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/vault
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/apirequest-count-read-cr
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/service-catalog-k8s-plugin-acm


### PR DESCRIPTION
Adds SA, Clusterrole and binding for prometheus plugin that this token to access rbac-query-proxy of MCO. More information can be found [here](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.3/html-single/observability/index#external-metric-query)
Part of https://github.com/operate-first/service-catalog/issues/16
Unblocks https://github.com/operate-first/service-catalog/pull/189

