### PR TITLE
chore: Fix techdocs CI

### DIFF
--- a/.github/workflows/techdocs.yaml
+++ b/.github/workflows/techdocs.yaml
@@ -11,26 +11,25 @@ on:
 
 jobs:
   send-repo-dispatches:
+    strategy:
+      matrix:
+        include:
+          - filter: 'docs/content/grafana/**'
+            docs_path: 'docs/content/grafana'
+            entity_name: 'opf-monitoring-grafana'
+            entity_kind: 'Component'
+          - filter: 'docs/content/grafana/**'
+            docs_path: 'docs/content/grafana'
+            entity_name: 'opf-monitoring-grafana-operator'
+            entity_kind: 'Component'
     runs-on: ubuntu-latest
     steps:
       - name: Send dispatch for grafana docs
         uses: operate-first/service-catalog/.github/actions/docs-dispatch@main
         with:
-          filter: 'docs/content/grafana/**'
-          docs_path: 'docs/content/grafana'
-          entity_name: 'opf-monitoring-grafana-operator'
-          entity_kind: 'Component'
-          repository: ${{ github.repository }}
-          token: ${{ secrets.SESHETA_TOKEN }}
-  send-repo-dispatches:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Send dispatch for grafana docs
-        uses: operate-first/service-catalog/.github/actions/docs-dispatch@main
-        with:
-          filter: 'docs/content/grafana/**'
-          docs_path: 'docs/content/grafana'
-          entity_name: 'opf-monitoring-grafana'
-          entity_kind: 'Component'
+          filter: ${{ matrix.filter }}
+          docs_path: ${{ matrix.docs_path }}
+          entity_name: ${{ matrix.entity_name }}
+          entity_kind: ${{ matrix.entity_kind }}
           repository: ${{ github.repository }}
           token: ${{ secrets.SESHETA_TOKEN }}


### PR DESCRIPTION
GitHub complains we use invalid workflow file:

https://github.com/operate-first/apps/actions/runs/3462888258/workflow

![image](https://user-images.githubusercontent.com/7453394/201703286-5bb98635-d7fb-4833-bda5-e40b7dd1ffd3.png)


We have multiple definitions of the same key `send-repo-dispatches`. Let's fix this via `matrix` strategy.

/cc @SamoKopecky 