### PR TITLE
allow robozome-op1st for prow trigger plugin

### DIFF
--- a/prow/overlays/smaug/plugins.yaml
+++ b/prow/overlays/smaug/plugins.yaml
@@ -152,6 +152,12 @@ approve:
     ignore_review_state: false
     lgtm_acts_as_approve: false
 
+triggers:
+- repos:
+  - operate-first/apps
+  trusted_apps:
+  - robozome-op1st
+
 repo_milestone:
   "":
     maintainers_id: 4924960


### PR DESCRIPTION
Allow robozome-op1st app to trigger prow tests.

already discussed at
https://github.com/thoth-station/support/issues/122


@tumido you mentioned a prow upgrade, but it looks like we're pulling always the master images and the dashboard reports version v20220812-9414716697

so I guess this would work?