### PR TITLE
feat: Upgrade camel-k to stable channel

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/camel-k/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/camel-k/subscription.yaml
@@ -3,7 +3,7 @@ kind: Subscription
 metadata:
   name: camel-k
 spec:
-  channel: stable-1.7
+  channel: stable
   installPlanApproval: Automatic
   name: camel-k
   source: community-operators


### PR DESCRIPTION
Upgrade to `stable` which keeps track with minor version upgrades

![image](https://user-images.githubusercontent.com/7453394/201939767-bb5671fe-3269-487a-944f-1ef817daf956.png)