### PR TITLE
add secret store to prow

### DIFF
--- a/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 - openshift-logging
 - openshift-monitoring
 - openshift-storage
+- opf-ci-prow
 - opf-alertreceiver
 - opf-grafana-public
 - opf-jupyterhub

--- a/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/opf-ci-prow/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/opf-ci-prow/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: opf-ci-prow
+resources:
+  - ../base

--- a/prow/overlays/smaug/externalsecrets/cookie.yaml
+++ b/prow/overlays/smaug/externalsecrets/cookie.yaml
@@ -8,6 +8,7 @@ spec:
     kind: SecretStore
   target:
     name: cookie
+  refreshInterval: "1h"
   dataFrom:
     - extract:
         key: moc/smaug/opf-ci-prow/cookie

--- a/prow/overlays/smaug/externalsecrets/github-oauth-config.yaml
+++ b/prow/overlays/smaug/externalsecrets/github-oauth-config.yaml
@@ -6,6 +6,7 @@ spec:
   secretStoreRef:
     name: opf-vault-store
     kind: SecretStore
+  refreshInterval: "1h"
   target:
     name: github-oauth-config
   dataFrom:

--- a/prow/overlays/smaug/externalsecrets/github-token.yaml
+++ b/prow/overlays/smaug/externalsecrets/github-token.yaml
@@ -6,6 +6,7 @@ spec:
   secretStoreRef:
     name: opf-vault-store
     kind: SecretStore
+  refreshInterval: "1h"
   target:
     name: github-token
   dataFrom:

--- a/prow/overlays/smaug/externalsecrets/hmac-token.yaml
+++ b/prow/overlays/smaug/externalsecrets/hmac-token.yaml
@@ -6,6 +6,7 @@ spec:
   secretStoreRef:
     name: opf-vault-store
     kind: SecretStore
+  refreshInterval: "1h"
   target:
     name: hmac-token
   dataFrom:

--- a/prow/overlays/smaug/externalsecrets/oauth-token.yaml
+++ b/prow/overlays/smaug/externalsecrets/oauth-token.yaml
@@ -6,6 +6,7 @@ spec:
   secretStoreRef:
     name: opf-vault-store
     kind: SecretStore
+  refreshInterval: "1h"
   target:
     name: oauth-token
   dataFrom:

--- a/prow/overlays/smaug/externalsecrets/s3-credentials.yaml
+++ b/prow/overlays/smaug/externalsecrets/s3-credentials.yaml
@@ -6,6 +6,7 @@ spec:
   secretStoreRef:
     name: opf-vault-store
     kind: SecretStore
+  refreshInterval: "1h"
   target:
     name: s3-credentials
   dataFrom:

--- a/prow/overlays/smaug/externalsecrets/ssh-secret.yaml
+++ b/prow/overlays/smaug/externalsecrets/ssh-secret.yaml
@@ -6,6 +6,7 @@ spec:
   secretStoreRef:
     name: opf-vault-store
     kind: SecretStore
+  refreshInterval: "1h"
   target:
     name: ssh-secret
   dataFrom:


### PR DESCRIPTION
the SecretStore was missing from opf-ci-prow namespace

```
Status:
  Conditions:
    Last Transition Time:  2022-11-15T13:37:15Z
    Message:               could not get store reference
    Reason:                SecretSyncedError
    Status:                False
    Type:                  Ready
Events:
  Type     Reason           Age                  From              Message
  ----     ------           ----                 ----              -------
  Warning  InvalidStoreRef  2m2s (x20 over 36m)  external-secrets  could not get SecretStore "opf-vault-store", SecretStore.external-secrets.io "opf-vault-store" not found
```