### PR TITLE
Pin custom elyra image until 0.2.x bug is fixed

### DIFF
--- a/kfdefs/overlays/osc/osc-cl1/jupyterhub/notebook-images/elyra-image.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/jupyterhub/notebook-images/elyra-image.yaml
@@ -19,7 +19,7 @@ spec:
         openshift.io/imported-from: quay.io/thoth-station/s2i-lab-elyra
       from:
         kind: DockerImage
-        name: 'quay.io/thoth-station/s2i-lab-elyra:latest'
+        name: 'quay.io/thoth-station/s2i-lab-elyra:v0.1.5'
       importPolicy:
         scheduled: true
       referencePolicy:

--- a/kfdefs/overlays/osc/osc-cl2/jupyterhub/notebook-images/elyra-image.yaml
+++ b/kfdefs/overlays/osc/osc-cl2/jupyterhub/notebook-images/elyra-image.yaml
@@ -19,7 +19,7 @@ spec:
         openshift.io/imported-from: quay.io/thoth-station/s2i-lab-elyra
       from:
         kind: DockerImage
-        name: 'quay.io/thoth-station/s2i-lab-elyra:latest'
+        name: 'quay.io/thoth-station/s2i-lab-elyra:v0.1.5'
       importPolicy:
         scheduled: true
       referencePolicy:


### PR DESCRIPTION
The most recent versions of the image, 0.2.0 and 0.2.1, have a bug that is causing the notebook to fail to load. An issue has been opened with the upstream project, but until it is fixed and new image is released, we need to pin to last working version. Fixes operate-first/support#1137

Signed-off-by: Eric Ball <eball@linuxfoundation.org>