### PR TITLE
fix: Increase ghproxy resources to avoid OOM kills

### DIFF
--- a/prow/overlays/smaug/ghproxy.yaml
+++ b/prow/overlays/smaug/ghproxy.yaml
@@ -61,11 +61,11 @@ spec:
               mountPath: /cache
           resources:
             requests:
-              memory: "64Mi"
-              cpu: "2m"
+              memory: "128Mi"
+              cpu: "10m"
             limits:
-              memory: "64Mi"
-              cpu: "2m"
+              memory: "256Mi"
+              cpu: "50m"
       volumes:
         - name: cache
           persistentVolumeClaim:


### PR DESCRIPTION
ghproxy is being OOMKilled and is raising TLS handshake errors/timeouts.

OOM kills should be solved by increasing memory request/limit from the original really restrictive `64Mi` (upstream [has none](https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/ghproxy.yaml)).

I think TLS handshakes errors can be caused by delays due to really low CPU limit - 2 milicores (upstream [has no limit](https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/ghproxy.yaml)).