### PR TITLE
fix: Match ghproxy resource request and limit

### DIFF
--- a/prow/overlays/smaug/ghproxy.yaml
+++ b/prow/overlays/smaug/ghproxy.yaml
@@ -64,8 +64,8 @@ spec:
               memory: "128Mi"
               cpu: "10m"
             limits:
-              memory: "256Mi"
-              cpu: "50m"
+              memory: "128Mi"
+              cpu: "10m"
       volumes:
         - name: cache
           persistentVolumeClaim:


### PR DESCRIPTION
After #2619  it seems `ghproxy` has stabilized. Utilization is below request so let's match limits to request.

Memory utilization averages around `50Mi` and CPU around `2m`. I think `128Mi` and `10m` (matching the limit to request values) is quite generous with a large enough buffer.