### PR TITLE
feat: Trust renovate and dependabot to run CI in Prow

### DIFF
--- a/prow/overlays/smaug/plugins.yaml
+++ b/prow/overlays/smaug/plugins.yaml
@@ -157,6 +157,11 @@ triggers:
   - operate-first/apps
   trusted_apps:
   - robozome-op1st
+- repos:
+  - operate-first
+  trusted_apps:
+  - renovate
+  - dependabot
 
 repo_milestone:
   "":


### PR DESCRIPTION
As @durandom proved via https://github.com/operate-first/apps/pull/2611 (manifested for example via https://github.com/operate-first/apps/pull/2622 ), `trusted_apps` settings work.

Let's enable it for `dependabot` and `renovate` in the whole `operate-first` org.

Note: It seems the `repos` list can reference whole orgs per inline docs here:

https://github.com/kubernetes/test-infra/blob/780d24ca7b96bdfadc09985d511694efe1929f39/prow/plugins/config.go#L433 

FFR: https://github.com/thoth-station/support/issues/122