### PR TITLE
Move the OSC cl1 staging ODH deployment to the meteor namespace

### DIFF
--- a/kfdefs/overlays/osc/osc-cl1/cnbi/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/cnbi/kfdef.yaml
@@ -9,10 +9,43 @@ spec:
   applications:
     - kustomizeConfig:
         repoRef:
-          name: manifests
+          name: meteor
           path: config
       name: cnbi-operator
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-common
+      name: odh-common
+    - kustomizeConfig:
+        parameters:
+          - name: notebook_destination
+            value: "opf-jupyterhub-stage"
+          - name: s3_endpoint_url
+            value: s3.odh.com
+        overlays:
+          - byon
+        repoRef:
+          name: manifests
+          path: jupyterhub/jupyterhub
+      name: jupyterhub
+    - kustomizeConfig:
+        overlays:
+          - additional
+        repoRef:
+          name: manifests
+          path: jupyterhub/notebook-images
+      name: notebook-images
+    - kustomizeConfig:
+        overlays:
+          - authentication
+        repoRef:
+          name: manifests
+          path: odh-dashboard
+      name: odh-dashboard
   repos:
     - name: manifests
+      uri: https://github.com/operate-first/odh-manifests/tarball/osc-cl1-byon
+    - name: meteor
       uri: https://github.com/thoth-station/meteor-operator/tarball/main
   version: v1.1.0


### PR DESCRIPTION
The Custom Notebook Image functionality at this point needs the meteor operator and the ODH dashboard in the same namespace.

This PR moves the staging ODH deployment to the aicoe-meteor namespace.