### PR TITLE
add hostPath to scc

### DIFF
--- a/cluster-scope/base/security.openshift.io/securitycontextconstraints/nfs-server-and-provisioner/securitycontextconstraints.yaml
+++ b/cluster-scope/base/security.openshift.io/securitycontextconstraints/nfs-server-and-provisioner/securitycontextconstraints.yaml
@@ -30,5 +30,6 @@ volumes:
 - configMap
 - downwardAPI
 - emptyDir
+- hostPath
 - persistentVolumeClaim
 - secret


### PR DESCRIPTION
hostPath is added to live manifest, so the cluster-resources app is always out of sync


<img width="1552" alt="image" src="https://user-images.githubusercontent.com/161888/202695412-f483b5eb-e429-4df7-bbe7-d3d53ecdfeb4.png">
