### PR TITLE
Add Pep to the cluster admins group for the osc-cl1 cluster

### DIFF
--- a/cluster-scope/overlays/prod/osc/osc-cl1/groups/cluster-admins.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/groups/cluster-admins.yaml
@@ -12,3 +12,4 @@ users:
   - MightyNerdEric
   - Gregory-Pereira
   - husky-parul
+  - codificat


### PR DESCRIPTION
This PR is to add myself to the `cluster-admins` for OSC's odh-cl1 cluster.

The driver for this is the ongoing development of ODH's custom notebook images functionality, whose staging env is in that cluster.
In that context, I would complement @harshad16 who is already on that list.