### PR TITLE
:zap: Update pulp version and include nodeaffinity to pulp backup

### DIFF
--- a/cluster-scope/base/operators.coreos.com/subscriptions/pulp-operator/subscription.yaml
+++ b/cluster-scope/base/operators.coreos.com/subscriptions/pulp-operator/subscription.yaml
@@ -4,7 +4,7 @@ kind: Subscription
 metadata:
   name: pulp-operator
 spec:
-  channel: alpha
+  channel: beta
   installPlanApproval: Automatic
   name: pulp-operator
   source: community-operators

--- a/pulp/overlays/moc/smaug/opf-pulp-backup.yaml
+++ b/pulp/overlays/moc/smaug/opf-pulp-backup.yaml
@@ -10,3 +10,12 @@ spec:
   instance_name: pulp
   admin_password_secret: pulp-admin-password
   postgres_configuration_secret: pulp-postgres-configuration
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: kubernetes.io/hostname
+            operator: In
+            values:
+            - oct-03-31-compute


### PR DESCRIPTION
Update pulp version and include nodeaffinity to pulp backup
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

- The channel is to be updated to `beta`
https://github.com/pulp/pulp-operator/blob/8a20f46d878ac29856334d3364629847385b8a1d/bundle/metadata/annotations.yaml#L7

fixes: https://github.com/operate-first/support/issues/1148

- The Pulp backup is requiring node affinity to fix the issue of PVC bound.
Related-to: https://github.com/pulp/pulp-operator/issues/782
 