### PR TITLE
Request large quota for WildFly

### DIFF
--- a/cluster-scope/base/core/namespaces/wildfly-service/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/wildfly-service/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
 namespace: wildfly-service
 components:
 - ../../../../components/limitranges/default
-- ../../../../components/resourcequotas/medium
+- ../../../../components/resourcequotas/large


### PR DESCRIPTION
I requested a medium quota last week, but unfortunately that is not enough.

The service currently consists of a postgres instance and a back-end 'manager'. The intent is that users upload their Java applications, and they get deployed to a provisioned WildFly instance. Invoking a `deploy` via the manager results in a Helm chart getting installed, which creates a series of buildconfigs and image streams, and then it starts the first build in the chain (one-deployment-build-1-build in the below error) as a binary build uploading applications.

Trying to do this with my manager, I see the following errors in the logs

> 22s         Warning   FailedCreate             build/one-deployment-build-1                      Error creating build pod: pods "one-deployment-build-1-build" is forbidden: exceeded quota: medium, requested: limits.cpu=500m, used: limits.cpu=2, limited: limits.cpu=2

I tried to run the entry build manually, and got the same error.

If I uninstall the postgres database and the back-end manager completely, I seem to be able to get around the limits. In this case I am able to install the Helm chart manually and trigger the build. However, we need to be able to run everything :-)