### PR TITLE
OKD: Update builder Dockerfile path and image name

### DIFF
--- a/kvm-device-plugin/base/buildconfig.yaml
+++ b/kvm-device-plugin/base/buildconfig.yaml
@@ -15,7 +15,7 @@ spec:
       uri: https://github.com/cgwalters/kvm-device-plugin
     type: Git
     dockerfile: |
-      FROM image-registry.openshift-image-registry.svc:5000/okd-centos/centos:okd-golang-builder AS builder
+      FROM image-registry.openshift-image-registry.svc:5000/okd-centos/centos:okd-builder AS builder
       WORKDIR /go/src/github.com/cgwalters/kvm-device-plugin
       COPY . .
       RUN make
@@ -33,6 +33,6 @@ spec:
   - imageChange:
       from:
         kind: ImageStreamTag
-        name: "centos:okd-golang-builder"
+        name: "centos:okd-builder"
         namespace: okd-centos
     type: ImageChange

--- a/okd-centos/base/buildconfig.yaml
+++ b/okd-centos/base/buildconfig.yaml
@@ -3,7 +3,7 @@ kind: BuildConfig
 apiVersion: build.openshift.io/v1
 metadata:
   namespace: okd-centos
-  name: okd-golang-builder
+  name: okd-builder
 spec:
   successfulBuildsHistoryLimit: 1
   failedBuildsHistoryLimit: 2
@@ -18,12 +18,12 @@ spec:
         kind: ImageStreamTag
         name: "centos:stream9"
         namespace: okd-centos
-      dockerfilePath: okd-golang-builder.Dockerfile
+      dockerfilePath: okd-builder.Dockerfile
     type: Docker
   output:
     to:
       kind: ImageStreamTag
-      name: centos:okd-golang-builder
+      name: centos:okd-builder
       namespace: okd-centos
   triggers:
   - type: ConfigChange


### PR DESCRIPTION
The image has been renamed from okd-golang-builder to okd-builder.