### PR TITLE
osc-cl1: Add CNBi / CRE pipelines to the osc-cl1 deployment

### DIFF
--- a/kfdefs/overlays/osc/osc-cl1/cnbi/kfdef.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/cnbi/kfdef.yaml
@@ -14,6 +14,11 @@ spec:
       name: cnbi-operator
     - kustomizeConfig:
         repoRef:
+          name: meteor
+          path: pipelines
+      name: cnbi-pipelines
+    - kustomizeConfig:
+        repoRef:
           name: manifests
           path: odh-common
       name: odh-common


### PR DESCRIPTION
This is to add the pipeline manifests that implement the Custom Notebook Image (CNBi) functionality to the `cnbi` ODH deployment on osc-cl1