### PR TITLE
Added project view public access for openshift-tuning

### DIFF
--- a/cluster-scope/base/core/namespaces/openshift-tuning/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/openshift-tuning/kustomization.yaml
@@ -6,4 +6,5 @@ components:
 - ../../../../components/project-admin-rolebindings/kruize
 - ../../../../components/limitranges/default
 - ../../../../components/resourcequotas/small
+- ../../../../components/project-view-public
 namespace: openshift-tuning


### PR DESCRIPTION
We want our project Kruize HPO with namespace 'openshift-tuning' to be accessible for everyone on the smaug cluster. requesting you to approve this