### PR TITLE
Add initial test of Iris notebook for osc-cl1

### DIFF
--- a/kfdefs/overlays/osc/osc-cl1/jupyterhub/notebook-images/iris-notebook.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/jupyterhub/notebook-images/iris-notebook.yaml
@@ -1,0 +1,26 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: iris-notebook
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url:
+      # This will be moved to os-climate once it has been validated
+      "https://github.com/MightyNerdEric/iris-notebook"
+    opendatahub.io/notebook-image-name:
+      "Iris"
+    opendatahub.io/notebook-image-desc:
+      "Jupyter notebooks for Iris"
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: "latest"
+      from:
+        kind: DockerImage
+        # This will be moved to os-climate once it has been validated
+        name: quay.io/eball_lf/iris-notebook:latest
+      importPolicy:
+        scheduled: true

--- a/kfdefs/overlays/osc/osc-cl1/jupyterhub/notebook-images/kustomization.yaml
+++ b/kfdefs/overlays/osc/osc-cl1/jupyterhub/notebook-images/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - aicoe-osc-demo.yaml
   - corporate-data-pipeline-nb.yaml
   - elyra-image.yaml
+  - iris-notebook.yaml


### PR DESCRIPTION
Code and container are currently stored in my personal spaces. Once it has been validated in cl1, we can move the code and container to OS-Climate orgs and apply the cl2.

Signed-off-by: Eric Ball <eball@linuxfoundation.org>