### PR TITLE
Fixed patch for OSC grafana to include sostrades as editors

### DIFF
--- a/grafana/overlays/osc/common/grafana_oauth_patch.yaml
+++ b/grafana/overlays/osc/common/grafana_oauth_patch.yaml
@@ -28,6 +28,7 @@ spec:
         contains(groups[*], 'cluster-admins') && 'Admin' ||
         contains(groups[*], 'odh-admin') && 'Editor' ||
         contains(groups[*], 'kepler-admins') && 'Editor' ||
+        contains(groups[*], 'sostrades') && 'Editor' ||
         contains(groups[*], 'odh-users') && 'Viewer' ||
         'Deny'
       role_attribute_strict: true

--- a/grafana/overlays/osc/osc-cl1/grafana_oauth_patch.yaml
+++ b/grafana/overlays/osc/osc-cl1/grafana_oauth_patch.yaml
@@ -10,5 +10,3 @@ spec:
       api_url: https://dex-dex.apps.odh-cl1.apps.os-climate.org/userinfo
       auth_url: https://dex-dex.apps.odh-cl1.apps.os-climate.org/auth
       token_url: https://dex-dex.apps.odh-cl1.apps.os-climate.org/token
-      role_attribute_path: >-
-        contains(groups[*], 'sostrades') && 'Editor' ||

--- a/grafana/overlays/osc/osc-cl2/grafana_oauth_patch.yaml
+++ b/grafana/overlays/osc/osc-cl2/grafana_oauth_patch.yaml
@@ -10,5 +10,3 @@ spec:
       api_url: https://dex-dex.apps.odh-cl2.apps.os-climate.org/userinfo
       auth_url: https://dex-dex.apps.odh-cl2.apps.os-climate.org/auth
       token_url: https://dex-dex.apps.odh-cl2.apps.os-climate.org/token
-      role_attribute_path: >-
-        contains(groups[*], 'sostrades') && 'Editor' ||


### PR DESCRIPTION
Original PR https://github.com/operate-first/apps/pull/2654 has caused only sostrades to be sole group that has access (also was malformed) , this PR is correcting this issue and adding sostrades under patch in common