### PR TITLE
Requesting 16 cpu limit for smart-village-view

### DIFF
--- a/cluster-scope/base/core/namespaces/smart-village-view/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/smart-village-view/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 namespace: smart-village-view
 resources:
     - namespace.yaml
+    - resourcequota.yaml
 components:
     - ../../../../components/limitranges/default
     - ../../../../components/project-admin-rolebindings/boston-university-redhat
-    - ../../../../components/resourcequotas/large

--- a/cluster-scope/base/core/namespaces/smart-village-view/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/smart-village-view/resourcequota.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: smart-village-view-custom
+spec:
+  hard:
+    limits.cpu: '16'
+    limits.memory: 16Gi
+    requests.cpu: '16'
+    requests.memory: 16Gi
+    requests.storage: 80Gi
+    count/objectbucketclaims.objectbucket.io: 1


### PR DESCRIPTION
Hello Operate First team! Could I please increase the ResourceQuota of the smart-village-view project with a custom ResourceQuota with a 16 CPU limit? 

We are onboarding a new FIWARE Context Broker and other applications as part of our IoT Traffic Simulations. We also have large data imports and it seems to be limited by the database, search engine, cluster manager, and application having enough CPU limit to process the data. 