### PR TITLE
chore: Remove duplicit namespace definitions from cert-manager manifests

### DIFF
--- a/cert-manager/overlays/emea/jerry/api/certificate.yaml
+++ b/cert-manager/overlays/emea/jerry/api/certificate.yaml
@@ -2,7 +2,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: api-certificate-letsencrypt
-  namespace: openshift-config
 spec:
   dnsNames:
   - api.jerry.ionos.emea.operate-first.cloud

--- a/cert-manager/overlays/emea/jerry/api/issuer.yaml
+++ b/cert-manager/overlays/emea/jerry/api/issuer.yaml
@@ -2,7 +2,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: api-letsencrypt-production
-  namespace: openshift-config
 spec:
   acme:
     email: ops-team@operate-first.cloud

--- a/cert-manager/overlays/emea/jerry/ingress/certificate.yaml
+++ b/cert-manager/overlays/emea/jerry/ingress/certificate.yaml
@@ -2,7 +2,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ingress-certificate
-  namespace: openshift-ingress
 spec:
   dnsNames:
   - '*.apps.jerry.ionos.emea.operate-first.cloud'

--- a/cert-manager/overlays/emea/jerry/ingress/issuer.yaml
+++ b/cert-manager/overlays/emea/jerry/ingress/issuer.yaml
@@ -2,7 +2,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: ingress-letsencrypt-production
-  namespace: openshift-ingress
 spec:
   acme:
     email: ops-team@operate-first.cloud

--- a/cert-manager/overlays/moc/curator/api/certificate.yaml
+++ b/cert-manager/overlays/moc/curator/api/certificate.yaml
@@ -2,7 +2,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: api-certificate-letsencrypt
-  namespace: openshift-config
 spec:
   dnsNames:
   - api.curator.massopen.cloud

--- a/cert-manager/overlays/moc/curator/api/issuer.yaml
+++ b/cert-manager/overlays/moc/curator/api/issuer.yaml
@@ -2,7 +2,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: api-letsencrypt
-  namespace: openshift-config
 spec:
   acme:
     email: ops-team@operate-first.cloud

--- a/cert-manager/overlays/moc/curator/ingress/certificate.yaml
+++ b/cert-manager/overlays/moc/curator/ingress/certificate.yaml
@@ -2,7 +2,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ingress-certificate
-  namespace: openshift-ingress
 spec:
   dnsNames:
   - '*.apps.curator.massopen.cloud'

--- a/cert-manager/overlays/moc/curator/ingress/issuer.yaml
+++ b/cert-manager/overlays/moc/curator/ingress/issuer.yaml
@@ -2,7 +2,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: ingress-letsencrypt
-  namespace: openshift-ingress
 spec:
   acme:
     email: ops-team@operate-first.cloud

--- a/cert-manager/overlays/moc/infra/api/certificate.yaml
+++ b/cert-manager/overlays/moc/infra/api/certificate.yaml
@@ -2,7 +2,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: api-certificate-letsencrypt
-  namespace: openshift-config
 spec:
   dnsNames:
   - api.moc-infra.massopen.cloud

--- a/cert-manager/overlays/moc/infra/api/issuer.yaml
+++ b/cert-manager/overlays/moc/infra/api/issuer.yaml
@@ -2,7 +2,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: ingress-letsencrypt
-  namespace: openshift-config
 spec:
   acme:
     email: ops-team@operate-first.cloud

--- a/cert-manager/overlays/moc/smaug/api/certificate.yaml
+++ b/cert-manager/overlays/moc/smaug/api/certificate.yaml
@@ -2,7 +2,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: api-certificate-letsencrypt
-  namespace: openshift-config
 spec:
   dnsNames:
   - api.smaug.na.operate-first.cloud

--- a/cert-manager/overlays/moc/smaug/api/issuer.yaml
+++ b/cert-manager/overlays/moc/smaug/api/issuer.yaml
@@ -2,7 +2,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: api-letsencrypt-production
-  namespace: openshift-config
 spec:
   acme:
     email: ops-team@operate-first.cloud

--- a/cert-manager/overlays/moc/smaug/ingress/certificate.yaml
+++ b/cert-manager/overlays/moc/smaug/ingress/certificate.yaml
@@ -2,7 +2,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ingress-certificate
-  namespace: openshift-ingress
 spec:
   dnsNames:
   - '*.apps.smaug.na.operate-first.cloud'

--- a/cert-manager/overlays/moc/smaug/ingress/issuer.yaml
+++ b/cert-manager/overlays/moc/smaug/ingress/issuer.yaml
@@ -2,7 +2,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: ingress-letsencrypt-production
-  namespace: openshift-ingress
 spec:
   acme:
     email: ops-team@operate-first.cloud

--- a/cert-manager/overlays/osc/osc-cl1/ingress/certificate.yaml
+++ b/cert-manager/overlays/osc/osc-cl1/ingress/certificate.yaml
@@ -2,7 +2,6 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ingress-certificate
-  namespace: openshift-ingress
 spec:
   dnsNames:
     - "*.apps.odh-cl1.apps.os-climate.org"

--- a/cert-manager/overlays/osc/osc-cl1/ingress/issuer.yaml
+++ b/cert-manager/overlays/osc/osc-cl1/ingress/issuer.yaml
@@ -2,7 +2,6 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: ingress-letsencrypt-production
-  namespace: openshift-ingress
 spec:
   acme:
     email: ops-team@operate-first.cloud


### PR DESCRIPTION
Small cleanup, `kustomize build` diff yields 0 since the `namespace` is already defined in the `kustomization.yaml`.