### PR TITLE
feat: Create SCC with seccomp runtime/default

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/scc-restricted-seccomp/clusterrolebinding.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/scc-restricted-seccomp/clusterrolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: scc-restricted-seccomp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:restricted-seccomp
+subjects:
+  - kind: ServiceAccount
+    name: cert-manager
+    namespace: openshift-operators
+  - kind: ServiceAccount
+    name: cert-manager-cainjector
+    namespace: openshift-operators
+  - kind: ServiceAccount
+    name: cert-manager-webhook
+    namespace: openshift-operators

--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/scc-restricted-seccomp/kustomization.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterrolebindings/scc-restricted-seccomp/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- clusterrolebinding.yaml

--- a/cluster-scope/base/security.openshift.io/securitycontextconstraints/restricted-seccomp/README.md
+++ b/cluster-scope/base/security.openshift.io/securitycontextconstraints/restricted-seccomp/README.md
@@ -1,0 +1,3 @@
+This SCC can be removed once all clusters deploying it are migrated to OCP 4.11 and use `restricted-v2` as a default SCC.
+
+https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html#ocp-4-11-auth-pod-security-admission

--- a/cluster-scope/base/security.openshift.io/securitycontextconstraints/restricted-seccomp/kustomization.yaml
+++ b/cluster-scope/base/security.openshift.io/securitycontextconstraints/restricted-seccomp/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- securitycontextconstraint.yaml

--- a/cluster-scope/base/security.openshift.io/securitycontextconstraints/restricted-seccomp/securitycontextconstraint.yaml
+++ b/cluster-scope/base/security.openshift.io/securitycontextconstraints/restricted-seccomp/securitycontextconstraint.yaml
@@ -1,0 +1,36 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: restricted-seccomp
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+fsGroup:
+  type: MustRunAs
+groups:
+- system:authenticated
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- KILL
+- MKNOD
+- SETUID
+- SETGID
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+seccompProfiles:
+- runtime/default
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret

--- a/cluster-scope/bundles/cert-manager/kustomization.yaml
+++ b/cluster-scope/bundles/cert-manager/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base/operators.coreos.com/subscriptions/cert-manager
+- ../../base/rbac.authorization.k8s.io/clusterrolebindings/scc-restricted-seccomp
+- ../../base/security.openshift.io/securitycontextconstraints/restricted-seccomp

--- a/cluster-scope/overlays/prod/emea/jerry/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/jerry/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../../../base/operators.coreos.com/subscriptions/cert-manager
 - ../../../../base/user.openshift.io/groups/cluster-admins
+- ../../../../bundles/cert-manager
 - ../../../../bundles/external-secrets-operator
 - ../../../../bundles/openshift-pipelines
 - ../common

--- a/cluster-scope/overlays/prod/moc/curator/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/curator/kustomization.yaml
@@ -9,12 +9,12 @@ resources:
   - ../../../../base/hostpathprovisioner.kubevirt.io/hostpathprovisioners/hostpath-provisioner
   - ../../../../base/machineconfiguration.openshift.io/machineconfigs/50-set-selinux-for-hostpath-provisioner-controller
   - ../../../../base/operators.coreos.com/operatorgroups/openshift-storage
-  - ../../../../base/operators.coreos.com/subscriptions/cert-manager
   - ../../../../base/operators.coreos.com/subscriptions/kubevirt-hyperconverged
   - ../../../../base/operators.coreos.com/subscriptions/ocs-operator
   - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-rb
   - ../../../../base/storage.k8s.io/storageclasses/hostpath-provisioner
   - ../../../../base/user.openshift.io/groups/cluster-admins
+  - ../../../../bundles/cert-manager
   - ../../../../bundles/external-secrets-operator
   - ../../../../bundles/service-catalog-k8s-plugin
   - apiserver

--- a/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
@@ -20,7 +20,6 @@ resources:
   - ../../../../base/operators.coreos.com/operatorgroups/openshift-nmstate
   - ../../../../base/operators.coreos.com/operatorgroups/operator-acm-group
   - ../../../../base/operators.coreos.com/subscriptions/acm-operator-subscription
-  - ../../../../base/operators.coreos.com/subscriptions/cert-manager
   - ../../../../base/operators.coreos.com/subscriptions/cluster-logging
   - ../../../../base/operators.coreos.com/subscriptions/kubernetes-nmstate-operator
   - ../../../../base/operators.coreos.com/subscriptions/web-terminal
@@ -37,6 +36,7 @@ resources:
   - ../../../../base/rbac.authorization.k8s.io/clusterroles/service-catalog-k8s-plugin-acm
   - ../../../../base/user.openshift.io/groups/cluster-admins
   - ../../../../bundles/acme-operator
+  - ../../../../bundles/cert-manager
   - ../../../../bundles/external-secrets-operator
   - ../../../../bundles/idp-mgmt-operator
   - ../../../../bundles/odf-external

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -125,7 +125,6 @@ resources:
   - ../../../../base/operators.coreos.com/operatorgroups/rapidast
   - ../../../../base/operators.coreos.com/subscriptions/apex-rhsso-operator
   - ../../../../base/operators.coreos.com/subscriptions/camel-k
-  - ../../../../base/operators.coreos.com/subscriptions/cert-manager
   - ../../../../base/operators.coreos.com/subscriptions/cluster-logging
   - ../../../../base/operators.coreos.com/subscriptions/crunchy-postgres
   - ../../../../base/operators.coreos.com/subscriptions/grafana-operator
@@ -163,6 +162,7 @@ resources:
   - ../../../../bundles/acme-operator
   - ../../../../bundles/b4mad-racing
   - ../../../../bundles/banzaicloud-vault
+  - ../../../../bundles/cert-manager
   - ../../../../bundles/curator
   - ../../../../bundles/external-secrets-operator
   - ../../../../bundles/fybrik

--- a/cluster-scope/overlays/prod/osc/osc-cl1/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/kustomization.yaml
@@ -40,7 +40,6 @@ resources:
 - ../../../../base/core/namespaces/opf-monitoring
 - ../../../../base/core/namespaces/sandbox
 - ../../../../base/core/namespaces/sostrades-namespace
-- ../../../../base/operators.coreos.com/subscriptions/cert-manager
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/acme-operator
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-admins-rb
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-reader-k8s-annotations-exporter
@@ -62,6 +61,7 @@ resources:
 - ../../../../base/user.openshift.io/groups/seldon-admin
 - ../../../../base/user.openshift.io/groups/sostrades
 - ../../../../bundles/external-secrets-operator
+- ../../../../bundles/cert-manager
 - ../../../../bundles/grafana-operator
 - ../../../../bundles/kepler
 - ../../../../bundles/opendatahub-operator-manual


### PR DESCRIPTION
This change will allow cert-manager to use http01 challenge. This SCC is equivalent to `runtime-v2` available since OCP 4.11.

https://docs.openshift.com/container-platform/4.10/security/seccomp-profiles.html#configuring-default-seccomp-profile_configuring-seccomp-profiles
https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html#ocp-4-11-auth-pod-security-admission
https://cert-manager.io/docs/release-notes/release-notes-1.10/#on-openshift-the-cert-manager-pods-may-fail-until-you-modify-security-context-constraints