### PR TITLE
feat: Create certificate for pulp.operate-first.cloud

### DIFF
--- a/pulp/overlays/moc/smaug/certificate.yaml
+++ b/pulp/overlays/moc/smaug/certificate.yaml
@@ -1,0 +1,10 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: pulp
+spec:
+  dnsNames:
+    - pulp.operate-first.cloud
+  issuerRef:
+    name: letsencrypt
+  secretName: pulp-letsencrypt

--- a/pulp/overlays/moc/smaug/issuer.yaml
+++ b/pulp/overlays/moc/smaug/issuer.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    email: ops-team@operate-first.cloud
+    privateKeySecretRef:
+      name: letsencrypt-key
+    server: 'https://acme-v02.api.letsencrypt.org/directory'
+    solvers:
+      - http01:
+          ingress:
+            serviceType: ClusterIP

--- a/pulp/overlays/moc/smaug/kustomization.yaml
+++ b/pulp/overlays/moc/smaug/kustomization.yaml
@@ -3,5 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - opf-pulp-backup.yaml
+  - certificate.yaml
+  - issuer.yaml
 patchesStrategicMerge:
   - opf-pulp.yaml


### PR DESCRIPTION
Depends on: #2675
Related to: #2662

This will create a `pulp-letsencrypt` Secret in the `opf-pulp` namespace. This secret will contain `tls.crt` and `tls.key` keys.

/hold (until requirements are merged)
/cc @fao89 @harshad16 
