### PR TITLE
feat: Allow Certificate and Issuer in ArgoCD global_project template

### DIFF
--- a/argocd/overlays/moc-infra/projects/global_project.yaml
+++ b/argocd/overlays/moc-infra/projects/global_project.yaml
@@ -80,6 +80,10 @@ spec:
       kind: CephObjectStore
     - group: ceph.rook.io
       kind: CephObjectStoreUser
+    - group: cert-manager.io
+      kind: Certificate
+    - group: cert-manager.io
+      kind: Issuer
     - group: external-secrets.io
       kind: ExternalSecret
     - group: extensions


### PR DESCRIPTION
#2676 fails to deploy because `Certificate` and `Issuer` is not allowed for regular ArgoCD projects. This PR fixes that.

![image](https://user-images.githubusercontent.com/7453394/206235911-1f1a81d9-14e2-4e3a-b820-3b6c03a2dcbe.png)