### PR TITLE
Adding Kubescape workflow

### DIFF
--- a/.github/workflows/kubescape.yaml
+++ b/.github/workflows/kubescape.yaml
@@ -1,0 +1,16 @@
+name: Kubescape scanning for misconfigurations
+on: [push, pull_request]
+jobs:
+  kubescape:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: kubescape/github-action@main
+      continue-on-error: true
+      with:
+        format: sarif
+        outputFile: results.sarif
+    - name: Upload Kubescape scan results to Github Code Scanning
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: results.sarif


### PR DESCRIPTION
[Kubescape](https://github.com/kubescape/kubescape) is a tool for detecting Kubernetes manifests misconfigurations based on security, best practices, and compliance.

In this PR, I added [Kubescape's GitHub actions](https://github.com/kubescape/github-action) so you will see in the security tab the misconfigurations detected in the submitted YAML files.

**This will not break/block the current CI!** 

If the maintainers wish to block critical severities from being pushed, they will need to set the parameter as demonstrated [here](https://github.com/kubescape/github-action#fail-kubescape-scanning-based-on-maximum-severity-of-a-failed-control).
 
Here is a screenshot of how the security tab will look like:
![image](https://user-images.githubusercontent.com/64066841/207866211-6d6bedc0-c6ae-445d-abfd-36a3009ee9f8.png)


 