### PR TITLE
argocd: Fix Apex Destinations

### DIFF
--- a/argocd/overlays/moc-infra/projects/apex.yaml
+++ b/argocd/overlays/moc-infra/projects/apex.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   destinations:
     - namespace: apex
-      name: smaug
+      server: "https://api.smaug.na.operate-first.cloud:6443"
   sourceRepos:
-    - '*'
+    - "*"
   roles:
     - name: project-admin
       description: Read/Write access to this project only


### PR DESCRIPTION
Argo app fails with "application destination
{https://api.smaug.na.operate-first.cloud:6443 apex} is not permitted in project 'apex'"
Hoping this should fix it.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>