### PR TITLE
argocd: Allow apex group access to apex project

### DIFF
--- a/argocd/overlays/moc-infra/configs/argo_rbac_cm/policy.csv
+++ b/argocd/overlays/moc-infra/configs/argo_rbac_cm/policy.csv
@@ -1,2 +1,10 @@
 # Give Openshift group (argocd-admins) the argocd admin role with unrestricted argocd access
 g, argocd-admins, role:admin
+
+# Allow Apex users to administer the Apex Project
+p, role:apex-admins, applications, get, apex/*, allow
+p, role:apex-admins, applications, sync, apex/*, allow
+p, role:apex-admins, logs, get, apex/*, allow
+p, role:apex-admins, exec, create, apex/*, allow
+p, role:apex-admins, projects, get, apex, allow
+g, apex, role:apex-admins


### PR DESCRIPTION
This should allow us to click sync through the web UI and use the argocd cli. Some of the permissions, `projects get` and `logs get` might already be granted to readonly users, but I'm not sure if these propagate to logged in users so adding them to be safe.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>