### PR TITLE
Expand Apex!

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/apex/apex-qa.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/apex/apex-qa.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: apex-qa
+spec:
+  destination:
+    name: smaug
+    namespace: apex-qa
+  source:
+    path: deploy/apex/overlays/qa
+    repoURL: "https://github.com/redhat-et/apex"
+    targetRevision: HEAD
+  project: apex
+  syncPolicy:
+    syncOptions:
+      - Replace=true
+    automated:
+      prune: true

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/apex/apex.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/apex/apex.yaml
@@ -7,7 +7,7 @@ spec:
     name: smaug
     namespace: apex
   source:
-    path: deploy/apex/overlays/operate-first
+    path: deploy/apex/overlays/prod
     repoURL: 'https://github.com/redhat-et/apex'
     targetRevision: HEAD
   project: apex

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/apex/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/apex/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - apex.yaml
+  - apex-qa.yaml

--- a/cluster-scope/base/core/namespaces/apex-monitoring/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/apex-monitoring/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+- ../../../../components/project-admin-rolebindings/apex
+namespace: apex
+components:
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/large

--- a/cluster-scope/base/core/namespaces/apex-monitoring/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/apex-monitoring/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
 - namespace.yaml
 - ../../../../components/project-admin-rolebindings/apex
-namespace: apex
+namespace: apex-monitoring
 components:
 - ../../../../components/limitranges/default
 - ../../../../components/resourcequotas/large

--- a/cluster-scope/base/core/namespaces/apex-monitoring/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/apex-monitoring/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    op1st/docs: https://github.com/redhat-et/apex
+    op1st/onboarding-issue: https://github.com/operate-first/support/issues/1143
+    op1st/project-owner: russellb
+    openshift.io/display-name: apex-monitoring
+    openshift.io/requester: russellb
+  name: apex-monitoring

--- a/cluster-scope/base/core/namespaces/apex-qa/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/apex-qa/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+- ../../../../components/project-admin-rolebindings/apex
+namespace: apex
+components:
+- ../../../../components/limitranges/default
+- ../../../../components/resourcequotas/large

--- a/cluster-scope/base/core/namespaces/apex-qa/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/apex-qa/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
 - namespace.yaml
 - ../../../../components/project-admin-rolebindings/apex
-namespace: apex
+namespace: apex-qa
 components:
 - ../../../../components/limitranges/default
 - ../../../../components/resourcequotas/large

--- a/cluster-scope/base/core/namespaces/apex-qa/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/apex-qa/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    op1st/docs: https://github.com/redhat-et/apex
+    op1st/onboarding-issue: https://github.com/operate-first/support/issues/1143
+    op1st/project-owner: russellb
+    openshift.io/display-name: apex-qa
+    openshift.io/requester: russellb
+  name: apex-qa

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -22,6 +22,8 @@ resources:
   - ../../../../base/core/namespaces/aicoe-meteor
   - ../../../../base/core/namespaces/aiops-tools-workshop
   - ../../../../base/core/namespaces/apex
+  - ../../../../base/core/namespaces/apex-monitoring
+  - ../../../../base/core/namespaces/apex-qa
   - ../../../../base/core/namespaces/api-designer
   - ../../../../base/core/namespaces/apicurio-apicurio-registry
   - ../../../../base/core/namespaces/b4mad-minecraft


### PR DESCRIPTION
This adds two new namespaces:
- apex-qa (for our QA environment)
- apex-monitoring (where we'll be setting necessary prometheus/grafana/jaeger resources to monitor the apex and apex-qa namespaces)

It updates our `apex` ArgoCD application based on a incoming code change, and adds a new `apex-qa` application that handles our staging environment deployment.