### PR TITLE
Added machinesets to osc cl1 to sync with cl2

### DIFF
--- a/cluster-scope/overlays/prod/osc/osc-cl1/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/kustomization.yaml
@@ -72,5 +72,8 @@ resources:
 - configmaps/service-catalog-k8s-plugin.yaml
 - externalsecrets
 - ingresscontroller
+- machinesets
+- nodefeaturediscovery
 - machineconfigs/kepler
+- nvidia-gpu
 - secret-mgmt

--- a/cluster-scope/overlays/prod/osc/osc-cl1/machinesets/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/machinesets/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - machineset-compute-notebook.yaml
+  - machineset-notebook-gpu-g.yaml
+  - machineset-worker.yaml
+  - machineset-kepler-edge-m4.yaml
+  - machineset-kepler-edge-m5.yaml
+  - machineset-kepler-edge-m6.yaml

--- a/cluster-scope/overlays/prod/osc/osc-cl1/machinesets/machineset-compute-notebook.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/machinesets/machineset-compute-notebook.yaml
@@ -1,0 +1,68 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  name: odh-cl1-lbbst-odh-notebook-us-east-1c
+  namespace: openshift-machine-api
+  labels:
+    machine.openshift.io/cluster-api-cluster: odh-cl1-lbbst
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: odh-cl1-lbbst
+      machine.openshift.io/cluster-api-machineset: odh-cl1-lbbst-odh-notebook-us-east-1c
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: odh-cl1-lbbst
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset: odh-cl1-lbbst-odh-notebook-us-east-1c
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/odh-notebook: ''
+      providerSpec:
+        value:
+          userDataSecret:
+            name: worker-user-data
+          placement:
+            availabilityZone: us-east-1c
+            region: us-east-1
+          credentialsSecret:
+            name: aws-cloud-credentials
+          instanceType: c5.2xlarge
+          metadata:
+            creationTimestamp: null
+          blockDevices:
+            - ebs:
+                encrypted: true
+                iops: 0
+                kmsKey:
+                  arn: ''
+                volumeSize: 120
+                volumeType: gp2
+          securityGroups:
+            - filters:
+                - name: 'tag:Name'
+                  values:
+                    - odh-cl1-lbbst-worker-sg
+          kind: AWSMachineProviderConfig
+          tags:
+            - name: kubernetes.io/cluster/odh-cl1-lbbst
+              value: owned
+          deviceIndex: 0
+          ami:
+            id: ami-03d1c2cba04df838c
+          subnet:
+            filters:
+              - name: 'tag:Name'
+                values:
+                  - odh-cl1-lbbst-private-us-east-1c
+          apiVersion: awsproviderconfig.openshift.io/v1beta1
+          iamInstanceProfile:
+            id: odh-cl1-lbbst-worker-profile
+      taints:
+        - effect: NoSchedule
+          key: odh/notebook
+          value: 'true'

--- a/cluster-scope/overlays/prod/osc/osc-cl1/machinesets/machineset-kepler-edge-m4.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/machinesets/machineset-kepler-edge-m4.yaml
@@ -1,0 +1,69 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  name: odh-cl1-lbbst-kepler-edge-m4-us-east-1c
+  namespace: openshift-machine-api
+  labels:
+    machine.openshift.io/cluster-api-cluster: odh-cl1-lbbst
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: odh-cl1-lbbst
+      machine.openshift.io/cluster-api-machineset: odh-cl1-lbbst-kepler-edge-m4-us-east-1c
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: odh-cl1-lbbst
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset: odh-cl1-lbbst-kepler-edge-m4-us-east-1c
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/kepler-edge: ''
+          node-role.kubernetes.io/osc-platform: ''
+          node-role.kubernetes.io/worker: ''
+      providerSpec:
+        value:
+          userDataSecret:
+            name: worker-user-data
+          placement:
+            availabilityZone: us-east-1c
+            region: us-east-1
+          credentialsSecret:
+            name: aws-cloud-credentials
+          instanceType: m4.xlarge
+          metadata:
+            creationTimestamp: null
+          blockDevices:
+            - ebs:
+                encrypted: true
+                iops: 0
+                kmsKey:
+                  arn: ''
+                volumeSize: 120
+                volumeType: gp2
+          securityGroups:
+            - filters:
+                - name: 'tag:Name'
+                  values:
+                    - odh-cl1-lbbst-worker-sg
+          kind: AWSMachineProviderConfig
+          tags:
+            - name: kubernetes.io/cluster/odh-cl1-lbbst
+              value: owned
+          deviceIndex: 0
+          ami:
+            id: ami-03d1c2cba04df838c
+          subnet:
+            filters:
+              - name: 'tag:Name'
+                values:
+                  - odh-cl1-lbbst-private-us-east-1c
+          apiVersion: awsproviderconfig.openshift.io/v1beta1
+          iamInstanceProfile:
+            id: odh-cl1-lbbst-worker-profile
+      taints:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/kepler-edge

--- a/cluster-scope/overlays/prod/osc/osc-cl1/machinesets/machineset-kepler-edge-m5.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/machinesets/machineset-kepler-edge-m5.yaml
@@ -1,0 +1,69 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  name: odh-cl1-lbbst-kepler-edge-m5-us-east-1c
+  namespace: openshift-machine-api
+  labels:
+    machine.openshift.io/cluster-api-cluster: odh-cl1-lbbst
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: odh-cl1-lbbst
+      machine.openshift.io/cluster-api-machineset: odh-cl1-lbbst-kepler-edge-m5-us-east-1c
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: odh-cl1-lbbst
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset: odh-cl1-lbbst-kepler-edge-m5-us-east-1c
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/kepler-edge: ''
+          node-role.kubernetes.io/osc-platform: ''
+          node-role.kubernetes.io/worker: ''
+      providerSpec:
+        value:
+          userDataSecret:
+            name: worker-user-data
+          placement:
+            availabilityZone: us-east-1c
+            region: us-east-1
+          credentialsSecret:
+            name: aws-cloud-credentials
+          instanceType: m5.xlarge
+          metadata:
+            creationTimestamp: null
+          blockDevices:
+            - ebs:
+                encrypted: true
+                iops: 0
+                kmsKey:
+                  arn: ''
+                volumeSize: 120
+                volumeType: gp2
+          securityGroups:
+            - filters:
+                - name: 'tag:Name'
+                  values:
+                    - odh-cl1-lbbst-worker-sg
+          kind: AWSMachineProviderConfig
+          tags:
+            - name: kubernetes.io/cluster/odh-cl1-lbbst
+              value: owned
+          deviceIndex: 0
+          ami:
+            id: ami-03d1c2cba04df838c
+          subnet:
+            filters:
+              - name: 'tag:Name'
+                values:
+                  - odh-cl1-lbbst-private-us-east-1c
+          apiVersion: awsproviderconfig.openshift.io/v1beta1
+          iamInstanceProfile:
+            id: odh-cl1-lbbst-worker-profile
+      taints:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/kepler-edge

--- a/cluster-scope/overlays/prod/osc/osc-cl1/machinesets/machineset-kepler-edge-m6.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/machinesets/machineset-kepler-edge-m6.yaml
@@ -1,0 +1,69 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  name: odh-cl1-lbbst-kepler-edge-m6-us-east-1c
+  namespace: openshift-machine-api
+  labels:
+    machine.openshift.io/cluster-api-cluster: odh-cl1-lbbst
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: odh-cl1-lbbst
+      machine.openshift.io/cluster-api-machineset: odh-cl1-lbbst-kepler-edge-m6-us-east-1c
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: odh-cl1-lbbst
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset: odh-cl1-lbbst-kepler-edge-m6-us-east-1c
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/kepler-edge: ''
+          node-role.kubernetes.io/osc-platform: ''
+          node-role.kubernetes.io/worker: ''
+      providerSpec:
+        value:
+          userDataSecret:
+            name: worker-user-data
+          placement:
+            availabilityZone: us-east-1c
+            region: us-east-1
+          credentialsSecret:
+            name: aws-cloud-credentials
+          instanceType: m6i.xlarge
+          metadata:
+            creationTimestamp: null
+          blockDevices:
+            - ebs:
+                encrypted: true
+                iops: 0
+                kmsKey:
+                  arn: ''
+                volumeSize: 120
+                volumeType: gp2
+          securityGroups:
+            - filters:
+                - name: 'tag:Name'
+                  values:
+                    - odh-cl1-lbbst-worker-sg
+          kind: AWSMachineProviderConfig
+          tags:
+            - name: kubernetes.io/cluster/odh-cl1-lbbst
+              value: owned
+          deviceIndex: 0
+          ami:
+            id: ami-03d1c2cba04df838c
+          subnet:
+            filters:
+              - name: 'tag:Name'
+                values:
+                  - odh-cl1-lbbst-private-us-east-1c
+          apiVersion: awsproviderconfig.openshift.io/v1beta1
+          iamInstanceProfile:
+            id: odh-cl1-lbbst-worker-profile
+      taints:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/kepler-edge

--- a/cluster-scope/overlays/prod/osc/osc-cl1/machinesets/machineset-notebook-gpu-g.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/machinesets/machineset-notebook-gpu-g.yaml
@@ -1,0 +1,68 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  name: odh-cl1-lbbst-odh-notebook-gpu-g-us-east-1c
+  namespace: openshift-machine-api
+  labels:
+    machine.openshift.io/cluster-api-cluster: odh-cl1-lbbst
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: odh-cl1-lbbst
+      machine.openshift.io/cluster-api-machineset: odh-cl1-lbbst-odh-notebook-gpu-g-us-east-1c
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: odh-cl1-lbbst
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset: odh-cl1-lbbst-odh-notebook-gpu-g-us-east-1c
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/odh-notebook: ''
+      providerSpec:
+        value:
+          userDataSecret:
+            name: worker-user-data
+          placement:
+            availabilityZone: us-east-1c
+            region: us-east-1
+          credentialsSecret:
+            name: aws-cloud-credentials
+          instanceType: g4dn.2xlarge
+          metadata:
+            creationTimestamp: null
+          blockDevices:
+            - ebs:
+                encrypted: true
+                iops: 0
+                kmsKey:
+                  arn: ''
+                volumeSize: 120
+                volumeType: gp2
+          securityGroups:
+            - filters:
+                - name: 'tag:Name'
+                  values:
+                    - odh-cl1-lbbst-worker-sg
+          kind: AWSMachineProviderConfig
+          tags:
+            - name: kubernetes.io/cluster/odh-cl1-lbbst
+              value: owned
+          deviceIndex: 0
+          ami:
+            id: ami-03d1c2cba04df838c
+          subnet:
+            filters:
+              - name: 'tag:Name'
+                values:
+                  - odh-cl1-lbbst-private-us-east-1c
+          apiVersion: awsproviderconfig.openshift.io/v1beta1
+          iamInstanceProfile:
+            id: odh-cl1-lbbst-worker-profile
+      taints:
+        - effect: NoSchedule
+          key: odh/notebook
+          value: 'true'

--- a/cluster-scope/overlays/prod/osc/osc-cl1/machinesets/machineset-worker.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/machinesets/machineset-worker.yaml
@@ -1,0 +1,64 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  name: odh-cl1-lbbst-worker-us-east-1c
+  namespace: openshift-machine-api
+  labels:
+    machine.openshift.io/cluster-api-cluster: odh-cl1-lbbst
+spec:
+  replicas: 8
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: odh-cl1-lbbst
+      machine.openshift.io/cluster-api-machineset: odh-cl1-lbbst-worker-us-east-1c
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: odh-cl1-lbbst
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset: odh-cl1-lbbst-worker-us-east-1c
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/osc-platform: ''
+      providerSpec:
+        value:
+          userDataSecret:
+            name: worker-user-data
+          placement:
+            availabilityZone: us-east-1c
+            region: us-east-1
+          credentialsSecret:
+            name: aws-cloud-credentials
+          instanceType: m5.2xlarge
+          metadata:
+            creationTimestamp: null
+          blockDevices:
+            - ebs:
+                encrypted: true
+                iops: 0
+                kmsKey:
+                  arn: ''
+                volumeSize: 120
+                volumeType: gp2
+          securityGroups:
+            - filters:
+                - name: 'tag:Name'
+                  values:
+                    - odh-cl1-lbbst-worker-sg
+          kind: AWSMachineProviderConfig
+          tags:
+            - name: kubernetes.io/cluster/odh-cl1-lbbst
+              value: owned
+          deviceIndex: 0
+          ami:
+            id: ami-03d1c2cba04df838c
+          subnet:
+            filters:
+              - name: 'tag:Name'
+                values:
+                  - odh-cl1-lbbst-private-us-east-1c
+          apiVersion: awsproviderconfig.openshift.io/v1beta1
+          iamInstanceProfile:
+            id: odh-cl1-lbbst-worker-profile

--- a/cluster-scope/overlays/prod/osc/osc-cl1/nodefeaturediscovery/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/nodefeaturediscovery/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - nfd-instance.yaml

--- a/cluster-scope/overlays/prod/osc/osc-cl1/nodefeaturediscovery/nfd-instance.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/nodefeaturediscovery/nfd-instance.yaml
@@ -1,0 +1,19 @@
+apiVersion: nfd.openshift.io/v1
+kind: NodeFeatureDiscovery
+metadata:
+  name: nfd-instance
+  namespace: openshift-nfd
+spec:
+  instance: ''
+  workerConfig:
+    configData: |
+      core:
+        sleepInterval: 300s
+      sources:
+        pci:
+          deviceClassWhitelist:
+            - "0200"
+            - "03"
+            - "12"
+          deviceLabelFields:
+            - "vendor"

--- a/cluster-scope/overlays/prod/osc/osc-cl1/nvidia-gpu/gpu-cluster-policy.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/nvidia-gpu/gpu-cluster-policy.yaml
@@ -1,0 +1,49 @@
+apiVersion: nvidia.com/v1
+kind: ClusterPolicy
+metadata:
+  name: gpu-cluster-policy
+spec:
+  migManager:
+    enabled: true
+  operator:
+    defaultRuntime: crio
+    initContainer: {}
+    runtimeClass: nvidia
+  dcgm:
+    enabled: true
+  gfd: {}
+  dcgmExporter:
+    config:
+      name: ''
+  driver:
+    certConfig:
+      name: ''
+    enabled: true
+    licensingConfig:
+      configMapName: ''
+      nlsEnabled: false
+    repoConfig:
+      configMapName: ''
+    use_ocp_driver_toolkit: true
+    virtualTopology:
+      config: ''
+  devicePlugin: {}
+  mig:
+    strategy: single
+  validator:
+    plugin:
+      env:
+        - name: WITH_WORKLOAD
+          value: 'true'
+  nodeStatusExporter:
+    enabled: true
+  daemonsets:
+    tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
+      - effect: NoSchedule
+        key: odh/notebook
+        value: 'true'
+  toolkit:
+    enabled: true

--- a/cluster-scope/overlays/prod/osc/osc-cl1/nvidia-gpu/kustomization.yaml
+++ b/cluster-scope/overlays/prod/osc/osc-cl1/nvidia-gpu/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - gpu-cluster-policy.yaml


### PR DESCRIPTION
Part of the process of bringing osc-cl1 cluster to the level of control by operate-first processes as for ocs-cl2. Adding previously manually managed machinesets to the repo. Also adjustments to address https://github.com/os-climate/os_c_data_commons/issues/246 