### PR TITLE
feat: Enable Grafana* resources in ArgoCD globally

### DIFF
--- a/argocd/overlays/moc-infra/projects/b4mad.yaml
+++ b/argocd/overlays/moc-infra/projects/b4mad.yaml
@@ -24,12 +24,3 @@ spec:
       groups:
         - b4mad
         - operate-first
-  namespaceResourceWhitelist:
-    - group: integreatly.org
-      kind: GrafanaDashboard
-    - group: integreatly.org
-      kind: GrafanaDataSource
-    - group: integreatly.org
-      kind: Grafana
-    - group: postgres-operator.crunchydata.com
-      kind: PostgresCluster

--- a/argocd/overlays/moc-infra/projects/global_project.yaml
+++ b/argocd/overlays/moc-infra/projects/global_project.yaml
@@ -220,5 +220,11 @@ spec:
       kind: OVirtProvider
     - group: v2v.kubevirt.io
       kind: V2VVmware
+    - group: integreatly.org
+      kind: GrafanaDashboard
+    - group: integreatly.org
+      kind: GrafanaDataSource
+    - group: integreatly.org
+      kind: Grafana
     - group: postgres-operator.crunchydata.com
       kind: PostgresCluster

--- a/argocd/overlays/moc-infra/projects/operate-first.yaml
+++ b/argocd/overlays/moc-infra/projects/operate-first.yaml
@@ -35,12 +35,6 @@ spec:
       kind: Observatorium
     - group: external-secrets.io
       kind: ExternalSecret
-    - group: integreatly.org
-      kind: GrafanaDashboard
-    - group: integreatly.org
-      kind: GrafanaDataSource
-    - group: integreatly.org
-      kind: Grafana
     - group: kafka.strimzi.io
       kind: Kafka
     - group: kafka.strimzi.io
@@ -77,5 +71,3 @@ spec:
       kind: ThanosRuler
     - group: logging.openshift.io
       kind: ClusterLogForwarder
-    - group: postgres-operator.crunchydata.com
-      kind: PostgresCluster


### PR DESCRIPTION
Resolves: https://github.com/operate-first/apps/issues/1964

Additionally removes these resources from projects which inherit from `global_project` template.