### PR TITLE
Updating kafka to v3.2.0 due to strimzi operator v0.32.0 upgrade

### DIFF
--- a/kafka/base/opf-kafka.yaml
+++ b/kafka/base/opf-kafka.yaml
@@ -5,7 +5,7 @@ metadata:
   name: odh-message-bus
 spec:
   kafka:
-    version: 3.1.0
+    version: 3.2.0
     replicas: 5
     listeners:
       - name: plain
@@ -29,7 +29,7 @@ spec:
     config:
       auto.create.topics.enable: false
       default.replication.factor: 3
-      inter.broker.protocol.version: '3.1'
+      inter.broker.protocol.version: '3.2'
       min.insync.replicas: 1
       offsets.topic.replication.factor: 3
       transaction.state.log.min.isr: 3


### PR DESCRIPTION
Addresses: https://github.com/operate-first/support/issues/1187
Stems from update information found in the strimzi operator overview on Smaug: https://console-openshift-console.apps.smaug.na.operate-first.cloud/k8s/ns/opf-kafka/clusterserviceversions/strimzi-cluster-operator.v0.32.0
Version upgrade table found here: https://strimzi.io/docs/operators/latest/deploying.html#ref-kafka-versions-str