### PR TITLE
chore(catalog): Update ClusterRole for OCM plugin

### DIFF
--- a/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/service-catalog-k8s-plugin-acm/clusterrole.yaml
+++ b/cluster-scope/base/rbac.authorization.k8s.io/clusterroles/service-catalog-k8s-plugin-acm/clusterrole.yaml
@@ -11,3 +11,11 @@ rules:
   - get
   - watch
   - list
+- apiGroups:
+  - internal.open-cluster-management.io
+  resources:
+  - managedclusterinfos
+  verbs:
+  - get
+  - watch
+  - list


### PR DESCRIPTION
Update `ClusterRole` definition for service catalog OCM plugin, see https://github.com/janus-idp/backstage-plugins/pull/67.