### PR TITLE
fix(smaug): Relocate image registry to PVC part 2

### DIFF
--- a/cluster-scope/overlays/prod/moc/smaug/imageregistry.operator.openshift.io/configs/cluster/config_patch.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/imageregistry.operator.openshift.io/configs/cluster/config_patch.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: imageregistry.operator.openshift.io/v1
+kind: Config
+metadata:
+  name: cluster
+  namespace: openshift-image-registry
+spec:
+  replicas: 1
+  rolloutStrategy: Recreate

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 patchesStrategicMerge:
   - backingstores/noobaa-default-backing-store_patch.yaml
   - groups/cluster-admins.yaml
+  - imageregistry.operator.openshift.io/configs/cluster/config_patch.yaml
   - storageclasses/ocs-external-storagecluster-ceph-rbd.yaml
   - subscriptions/cluster-logging-operator_patch.yaml
   - subscriptions/nfd_patch.yaml


### PR DESCRIPTION
Further refinement of #2709 

Current PVC fails to bind with multiple replicas, adjusting according to:

https://docs.openshift.com/container-platform/4.8/registry/configuring_registry_storage/configuring-registry-storage-baremetal.html#installation-registry-storage-block-recreate-rollout-bare-metal_configuring-registry-storage-baremetal