### PR TITLE
moving prow storage to ionos s3 bucket

### DIFF
--- a/prow/overlays/smaug/externalsecrets/s3-credentials.yaml
+++ b/prow/overlays/smaug/externalsecrets/s3-credentials.yaml
@@ -11,4 +11,4 @@ spec:
     name: s3-credentials
   dataFrom:
     - extract:
-        key: moc/smaug/opf-ci-prow/s3-credentials
+        key: moc/smaug/opf-ci-prow/s3-credentials-jerry


### PR DESCRIPTION
A new secret has been created with this vault path. I used Jerry as the cluster on which to host the OBCs / S3 buckets, however before we ran into issues due to the prow service being in NA on Smaug, and the ionos s3 bucket living in EMEA, and the long connection time causing data transfer to drop. If this proves to still be an issue, I will opt to use Infra. I started with Jerry because on infra there is no backing storage class except for noobbaa, which caused the storage issues in first place.

/cc @tumido 
/cc @durandom 

Signed-off-by: greg pereira <grpereir@redhat.com>