### PR TITLE
Add Sostrades project and applications to argocd

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/kustomization.yaml
@@ -5,3 +5,4 @@ nameSuffix: -osc-cl2
 resources:
 - cluster-management
 - fybrik
+- sostrades

--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/sostrades/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/sostrades/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- sostrades.yaml
+patches:
+  - patch: |
+      - op: replace
+        path: /spec/project
+        value: sostrades
+    target:
+      group: argoproj.io
+      kind: Application

--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/sostrades/sostrades.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/sostrades/sostrades.yaml
@@ -7,7 +7,7 @@ spec:
   project: sostrades
   source:
     path: sostrades/deploy/overlays/osc/osc-cl2
-    repoURL: https://github.com/sostrades-radouanbouadel/ArgocdOF.git
+    repoURL: https://github.com/SoSTrades/infrastructure.git
     targetRevision: HEAD
   destination:
     name: osc-cl2

--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/sostrades/sostrades.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/sostrades/sostrades.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sostrades
+  namespace: argocd
+spec:
+  project: sostrades
+  source:
+    path: sostrades/deploy/overlays/osc/osc-cl2
+    repoURL: https://github.com/sostrades-radouanbouadel/ArgocdOF.git
+    targetRevision: HEAD
+  destination:
+    name: osc-cl2
+    namespace: sostrades
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=false

--- a/argocd/overlays/moc-infra/projects/sostrades.yaml
+++ b/argocd/overlays/moc-infra/projects/sostrades.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1sostrades
+kind: AppProject
+metadata:
+  name: sostrades
+  labels:
+    project-template: global
+spec:
+  destinations:
+    - namespace: 'sostrades'
+      server: 'https://api.odh-cl1.apps.os-climate.org:6443'
+    - namespace: 'sostrades'
+      server: 'https://api.odh-cl2.apps.os-climate.org:6443'
+  sourceRepos:
+    - '*'
+  roles:
+    - name: project-admin
+      description: Read/Write access to this project only
+      policies:
+        - p, proj:sostrades:project-admin, applications, get, sostrades/*, allow
+        - p, proj:sostrades:project-admin, applications, create, sostrades/*, allow
+        - p, proj:sostrades:project-admin, applications, update, sostrades/*, allow
+        - p, proj:sostrades:project-admin, applications, delete, sostrades/*, allow
+        - p, proj:sostrades:project-admin, applications, sync, sostrades/*, allow
+        - p, proj:sostrades:project-admin, applications, override, sostrades/*, allow
+        - p, proj:sostrades:project-admin, applications, action/*, sostrades/*, allow
+      groups:
+        - sostrades
+        - osc-admins


### PR DESCRIPTION
On behalf of sostrades team from OS-Climate adding new project and application to ArgoCD. This PR should address https://github.com/operate-first/support/issues/1185. Source for artifacts is outside of operate-first org. All artifacts will be created in sostrades on OS-Climate  `osc-cl2` cluster  . 
@sostrades-radouanbouadel , please check PR to make sure that it is addressing your requirements and provide 'lgtm' 