### PR TITLE
Update Openmetadata to 0.13.1

### DIFF
--- a/openmetadata/base/openmetadata-dependencies/configmaps/files/pod_template.yaml
+++ b/openmetadata/base/openmetadata-dependencies/configmaps/files/pod_template.yaml
@@ -25,7 +25,7 @@ spec:
     []
   containers:
     - name: base
-      image: quay.io/os-climate/ingestion:0.12.1.trino.317
+      image: quay.io/os-climate/ingestion:0.13.1.trino.320
       imagePullPolicy: IfNotPresent
       envFrom:
         - secretRef:

--- a/openmetadata/base/openmetadata-dependencies/configmaps/openmetadata-dependencies-config-envs.yaml
+++ b/openmetadata/base/openmetadata-dependencies/configmaps/openmetadata-dependencies-config-envs.yaml
@@ -69,7 +69,7 @@ data:
   ## ================
   AIRFLOW__KUBERNETES__NAMESPACE: "openmetadata"
   AIRFLOW__KUBERNETES__WORKER_CONTAINER_REPOSITORY: "quay.io/os-climate/ingestion"
-  AIRFLOW__KUBERNETES__WORKER_CONTAINER_TAG: "0.12.1.trino.317"
+  AIRFLOW__KUBERNETES__WORKER_CONTAINER_TAG: "0.13.1.trino.320"
   AIRFLOW__KUBERNETES__POD_TEMPLATE_FILE: "/opt/airflow/pod_templates/pod_template.yaml"
   ## ================
   ## User Configs

--- a/openmetadata/base/openmetadata-dependencies/deployments/airflow-db-migrations.yaml
+++ b/openmetadata/base/openmetadata-dependencies/deployments/airflow-db-migrations.yaml
@@ -38,7 +38,7 @@ spec:
       serviceAccountName: airflow
       initContainers:
         - name: check-db
-          image: quay.io/operate-first/om-ingestion:0.12.1
+          image: quay.io/os-climate/ingestion:0.13.1
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:
@@ -68,7 +68,7 @@ spec:
               mountPath: /opt/airflow/logs
       containers:
         - name: db-migrations
-          image: quay.io/operate-first/om-ingestion:0.12.1
+          image: quay.io/os-climate/ingestion:0.13.1
           imagePullPolicy: IfNotPresent
           resources: {}
           envFrom:

--- a/openmetadata/base/openmetadata-dependencies/deployments/airflow-scheduler.yaml
+++ b/openmetadata/base/openmetadata-dependencies/deployments/airflow-scheduler.yaml
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: airflow
       initContainers:
         - name: check-db
-          image: quay.io/operate-first/om-ingestion:0.12.1
+          image: quay.io/os-climate/ingestion:0.13.1
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:
@@ -70,7 +70,7 @@ spec:
             - name: logs-data
               mountPath: /opt/airflow/logs
         - name: wait-for-db-migrations
-          image: quay.io/operate-first/om-ingestion:0.12.1
+          image: quay.io/os-climate/ingestion:0.13.1
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/airflow/logs
       containers:
         - name: airflow-scheduler
-          image: quay.io/operate-first/om-ingestion:0.12.1
+          image: quay.io/os-climate/ingestion:0.13.1
           imagePullPolicy: IfNotPresent
           resources: {}
           envFrom:

--- a/openmetadata/base/openmetadata-dependencies/deployments/airflow-sync-users.yaml
+++ b/openmetadata/base/openmetadata-dependencies/deployments/airflow-sync-users.yaml
@@ -38,7 +38,7 @@ spec:
       serviceAccountName: airflow
       initContainers:
         - name: check-db
-          image: quay.io/operate-first/om-ingestion:0.12.1
+          image: quay.io/os-climate/ingestion:0.13.1
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:
@@ -67,7 +67,7 @@ spec:
             - name: logs-data
               mountPath: /opt/airflow/logs
         - name: wait-for-db-migrations
-          image: quay.io/operate-first/om-ingestion:0.12.1
+          image: quay.io/os-climate/ingestion:0.13.1
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:
@@ -97,7 +97,7 @@ spec:
               mountPath: /opt/airflow/logs
       containers:
         - name: sync-airflow-users
-          image: quay.io/operate-first/om-ingestion:0.12.1
+          image: quay.io/os-climate/ingestion:0.13.1
           imagePullPolicy: IfNotPresent
           resources: {}
           envFrom:

--- a/openmetadata/base/openmetadata-dependencies/deployments/airflow-web.yaml
+++ b/openmetadata/base/openmetadata-dependencies/deployments/airflow-web.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: airflow
       initContainers:
         - name: check-db
-          image: quay.io/operate-first/om-ingestion:0.12.1
+          image: quay.io/os-climate/ingestion:0.13.1
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:
@@ -63,7 +63,7 @@ spec:
             - name: logs-data
               mountPath: /opt/airflow/logs
         - name: wait-for-db-migrations
-          image: quay.io/operate-first/om-ingestion:0.12.1
+          image: quay.io/os-climate/ingestion:0.13.1
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:
@@ -93,7 +93,7 @@ spec:
               mountPath: /opt/airflow/logs
       containers:
         - name: airflow-web
-          image: quay.io/operate-first/om-ingestion:0.12.1
+          image: quay.io/os-climate/ingestion:0.13.1
           imagePullPolicy: IfNotPresent
           resources: {}
           ports:

--- a/openmetadata/base/openmetadata-dependencies/deployments/airlfow-triggerer.yaml
+++ b/openmetadata/base/openmetadata-dependencies/deployments/airlfow-triggerer.yaml
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: airflow
       initContainers:
         - name: check-db
-          image: quay.io/operate-first/om-ingestion:0.12.1
+          image: quay.io/os-climate/ingestion:0.13.1
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:
@@ -70,7 +70,7 @@ spec:
             - name: logs-data
               mountPath: /opt/airflow/logs
         - name: wait-for-db-migrations
-          image: quay.io/operate-first/om-ingestion:0.12.1
+          image: quay.io/os-climate/ingestion:0.13.1
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:
@@ -100,7 +100,7 @@ spec:
               mountPath: /opt/airflow/logs
       containers:
         - name: airflow-triggerer
-          image: quay.io/operate-first/om-ingestion:0.12.1
+          image: quay.io/os-climate/ingestion:0.13.1
           imagePullPolicy: IfNotPresent
           resources: {}
           envFrom:

--- a/openmetadata/base/openmetadata/deployments/openmetadata.yaml
+++ b/openmetadata/base/openmetadata/deployments/openmetadata.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
         - name: openmetadata
           securityContext: {}
-          image: "quay.io/operate-first/om-server:0.12.1"
+          image: "quay.io/operate-first/om-server:0.13.1"
           imagePullPolicy: Always
           ports:
             - name: http

--- a/openmetadata/overlays/osc/osc-cl2/kustomization.yaml
+++ b/openmetadata/overlays/osc/osc-cl2/kustomization.yaml
@@ -20,4 +20,4 @@ patchesStrategicMerge:
 images:
   - name: quay.io/operate-first/om-ingestion
     newName: quay.io/os-climate/ingestion
-    newTag: 0.12.1.trino.317
+    newTag: 0.13.1.trino.320

--- a/openmetadata/overlays/osc/osc-cl2/patches/deployments/openmetadata.yaml
+++ b/openmetadata/overlays/osc/osc-cl2/patches/deployments/openmetadata.yaml
@@ -26,21 +26,21 @@ spec:
       # Decode it onto an emptydir volume which is read by OM.
       initContainers:
         - name: openmetadata-init
-          image: "quay.io/operate-first/om-server:0.12.1"
+          image: "quay.io/operate-first/om-server:0.13.1"
           volumeMounts:
-            - mountPath: /openmetadata-0.12.1/jwt
+            - mountPath: /openmetadata-0.13.1/jwt
               name: rsakeys
             - mountPath: /tmp/rsakeys
               name: openmetadata-auth
-          command: ["/bin/sh", "-c", "base64 -d /tmp/rsakeys/private_key.der > /openmetadata-0.12.1/jwt/private_key.der && base64 -d /tmp/rsakeys/public_key.der > /openmetadata-0.12.1/jwt/public_key.der"]
+          command: ["/bin/sh", "-c", "base64 -d /tmp/rsakeys/private_key.der > /openmetadata-0.13.1/jwt/private_key.der && base64 -d /tmp/rsakeys/public_key.der > /openmetadata-0.13.1/jwt/public_key.der"]
       containers:
         - name: openmetadata
           volumeMounts:
-            - mountPath: /openmetadata-0.12.1/logs
+            - mountPath: /openmetadata-0.13.1/logs
               name: logs
-            - mountPath: /openmetadata-0.12.1/jwt
+            - mountPath: /openmetadata-0.13.1/jwt
               name: rsakeys
-            - mountPath: /openmetadata-0.12.1/conf/
+            - mountPath: /openmetadata-0.13.1/conf/
               name: openmetadata-config
           envFrom:
             - secretRef:
@@ -84,9 +84,9 @@ spec:
             - name: SERVER_HOST_API_URL
               value: "http://openmetadata.openmetadata.svc.cluster.local:8585/api"
             - name: RSA_PUBLIC_KEY_FILE_PATH
-              value: /openmetadata-0.12.1/jwt/public_key.der
+              value: /openmetadata-0.13.1/jwt/public_key.der
             - name: RSA_PRIVATE_KEY_FILE_PATH
-              value: /openmetadata-0.12.1/jwt/private_key.der
+              value: /openmetadata-0.13.1/jwt/private_key.der
             - name: DB_USER_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
This includes updating the Trino-attached image to 320, and redirecting all references to the non-public/non-existent operate-first/om-ingestion repo to os-climate/ingestion.

Signed-off-by: Eric Ball <eball@linuxfoundation.org>