### PR TITLE
fix: Project admin component has to be of a Component kind, not Kustomization

### DIFF
--- a/scripts/onboarding.sh
+++ b/scripts/onboarding.sh
@@ -81,7 +81,7 @@ else
   mkdir ${RBAC_PATH}
   jsonnet --ext-str GROUP --ext-code USERS scripts/jsonnet/rbac.jsonnet | yq -P > ${RBAC_PATH}/rbac.yaml
   cd ${RBAC_PATH}
-  kustomize init ${RBAC_PATH}
+  echo -e "apiVersion: kustomize.config.k8s.io/v1alpha1\nkind: Component" > ./kustomization.yaml
   kustomize edit add resource rbac.yaml
 fi
 


### PR DESCRIPTION
Follow up to #2705

Fixes failure observed at #2719 

Unfortunately I was unable to find any alternative to `kustomize init/create` for `kind: Component`