### PR TITLE
increased cpu limits

### DIFF
--- a/cluster-scope/base/core/namespaces/opf-jupyterhub/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/opf-jupyterhub/resourcequota.yaml
@@ -4,7 +4,7 @@ metadata:
   name: opf-jupyterhub-custom
 spec:
   hard:
-    limits.cpu: '160'
+    limits.cpu: '180'
     limits.memory: 800Gi
-    requests.cpu: '100'
+    requests.cpu: '120'
     requests.memory: 600Gi


### PR DESCRIPTION
Jupyterhub is unable to spawn up because the cpu limits are reached. Increased the resource limits and request

<img width="1503" alt="Screenshot 2023-02-03 at 7 00 32 PM" src="https://user-images.githubusercontent.com/32435206/216615573-bdb38e34-e2b0-49c2-8f0e-36a20b292273.png">
