### PR TITLE
change rollout strategy

### DIFF
--- a/cluster-scope/overlays/prod/emea/jerry/imageregistry.operator.openshift.io/configs/cluster/config.yaml
+++ b/cluster-scope/overlays/prod/emea/jerry/imageregistry.operator.openshift.io/configs/cluster/config.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   logging: 2
   replicas: 1
+  rolloutStrategy: Recreate
   managementState: Managed
   storage:
     pvc:


### PR DESCRIPTION
otherwise upgrading the openshift-image-registry will not work, since our storage in jerry is only block storage