### PR TITLE
set hive.timestamp-precision to MICROSECONDS

### DIFF
--- a/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/osc_datacommons_hive_ingest.properties
+++ b/kfdefs/overlays/osc/osc-cl2/trino/configs/catalogs/osc_datacommons_hive_ingest.properties
@@ -10,5 +10,6 @@ hive.allow-drop-table=true
 hive.parquet.use-column-names=true
 hive.recursive-directories=true
 hive.non-managed-table-writes-enabled=true
+hive.timestamp-precision=MICROSECONDS
 hive.s3.aws-access-key=${ENV:OSC_DATACOMMONS_HIVE_INGEST_AWS_ACCESS_KEY_ID}
 hive.s3.aws-secret-key=${ENV:OSC_DATACOMMONS_HIVE_INGEST_AWS_SECRET_ACCESS_KEY}


### PR DESCRIPTION
The goal is to align the timestamp format between hive and iceberg, and greatly reduce friction on data ingestion due to timestamp format mismatches.
cc @MichaelTiemannOSC 