### PR TITLE
feat: Enable Vault and ArgoCD for Janus-IDP

### DIFF
--- a/argocd/overlays/moc-infra/projects/janus-idp.yaml
+++ b/argocd/overlays/moc-infra/projects/janus-idp.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: janus-idp
+  labels:
+    project-template: global
+spec:
+  destinations:
+    - namespace: 'janus-idp'
+      server: 'https://api.smaug.na.operate-first.cloud:6443'
+  sourceRepos:
+    - '*'
+  roles:
+    - name: project-admin
+      description: Read/Write access to this project only
+      policies:
+        - p, proj:janus-idp:project-admin, applications, get, janus-idp/*, allow
+        - p, proj:janus-idp:project-admin, applications, create, janus-idp/*, allow
+        - p, proj:janus-idp:project-admin, applications, update, janus-idp/*, allow
+        - p, proj:janus-idp:project-admin, applications, delete, janus-idp/*, allow
+        - p, proj:janus-idp:project-admin, applications, sync, janus-idp/*, allow
+        - p, proj:janus-idp:project-admin, applications, override, janus-idp/*, allow
+        - p, proj:janus-idp:project-admin, applications, action/*, janus-idp/*, allow
+      groups:
+        - janus-idp
+        - operate-first

--- a/argocd/overlays/moc-infra/projects/kustomization.yaml
+++ b/argocd/overlays/moc-infra/projects/kustomization.yaml
@@ -4,23 +4,24 @@ resources:
   - apex.yaml
   - apicurio-registry.yaml
   - b4mad.yaml
+  - chris.yaml
   - cluster-management.yaml
+  - copilot-ops.yaml
   - data-science.yaml
   - fybrik.yaml
   - global_project.yaml
+  - janus-idp.yaml
+  - kepler.yaml
+  - kruize.yaml
   - lab-cicd.yaml
   - mocops.yaml
   - octo-ushift-dev.yaml
   - okd-team.yaml
   - operate-first.yaml
   - os-climate.yaml
+  - otel-dev.yaml
   - rekor.yaml
+  - sostrades.yaml
   - thoth.yaml
   - tremor-demo.yaml
   - workshops.yaml
-  - chris.yaml
-  - otel-dev.yaml
-  - copilot-ops.yaml
-  - kepler.yaml
-  - kruize.yaml
-  - sostrades.yaml

--- a/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/janus-idp/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/janus-idp/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: janus-idp
+resources:
+  - ../base
+patchesStrategicMerge:
+  - opf-vault-store.yaml

--- a/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/janus-idp/opf-vault-store.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/janus-idp/opf-vault-store.yaml
@@ -1,0 +1,10 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: opf-vault-store
+spec:
+  provider:
+    vault:
+      auth:
+        kubernetes:
+          role: janus-idp

--- a/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/secret-mgmt/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - apicurio-apicurio-registry
 - copilot-ops
 - dex
+- janus-idp
 - kubeflow
 - openshift-config
 - openshift-ingress


### PR DESCRIPTION
We want to deploy https://github.com/janus-idp/backstage-showcase to OPF via ArgoCD and helm chart.

This PR is a foundation enabling the team to access Vault and ArgoCD.

cc @PatAKnight 