### PR TITLE
feat: Add k8s plugin tokens to janus-idp

### DIFF
--- a/cluster-scope/overlays/prod/moc/smaug/externalsecrets/janus-idp.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/externalsecrets/janus-idp.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: janus-idp-cluster-tokens
+  namespace: janus-idp
+spec:
+  secretStoreRef:
+    name: opf-vault-store
+    kind: SecretStore
+  refreshInterval: "1h"
+  target:
+    name: janus-idp-cluster-tokens
+  dataFrom:
+    - extract:
+        key: moc/smaug/service-catalog/k8s-plugin-tokens


### PR DESCRIPTION
Add k8s plugin tokens to the `janus-idp` namespace since we need them for the `ocm` plugin installation. I also updated the `janus-idp` policy to allow reads to the referenced vault secret.