### PR TITLE
adding ryan cook to smaug and vault admins

### DIFF
--- a/cluster-scope/overlays/prod/moc/smaug/groups/cluster-admins.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/groups/cluster-admins.yaml
@@ -15,3 +15,4 @@ users:
     - tumido
     - guymguym
     - oritwas
+    - cooktheryan

--- a/cluster-scope/overlays/prod/moc/smaug/groups/vault-admins.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/groups/vault-admins.yaml
@@ -11,3 +11,4 @@ users:
   - tumido
   - durandom
   - mimotej
+  - cooktheryan


### PR DESCRIPTION
As some OPF workloads are migrating to ROSA, Ryan requires to gain visibility into how OPF manifests and resources look like.