### PR TITLE
chore: Update physrisk-resilience resource quotas

### DIFF
--- a/cluster-scope/base/core/namespaces/physrisk-resilience/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/physrisk-resilience/kustomization.yaml
@@ -1,9 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- namespace.yaml
+  - namespace.yaml
+  - resourcequota.yaml
 namespace: physrisk-resilience
 components:
-- ../../../../components/limitranges/default
-- ../../../../components/resourcequotas/small
-- ../../../../components/project-admin-rolebindings/physrisk
+  - ../../../../components/limitranges/default
+  - ../../../../components/project-admin-rolebindings/physrisk

--- a/cluster-scope/base/core/namespaces/physrisk-resilience/resourcequota.yaml
+++ b/cluster-scope/base/core/namespaces/physrisk-resilience/resourcequota.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: physrisk-resilience-custom
+spec:
+  hard:
+    limits.cpu: '4'
+    limits.memory: 16Gi
+    requests.cpu: '4'
+    requests.memory: 16Gi


### PR DESCRIPTION
This team will need cpu and ram limits similar to a "large" resource quota, but need to have storage and objectbucketclaims unlimited for now.