### PR TITLE
feat: Add namespace for users service-catalog

### DIFF
--- a/cluster-scope/base/core/namespaces/web-terminal-service-catalog/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/web-terminal-service-catalog/kustomization.yaml
@@ -1,0 +1,9 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+namespace: web-terminal-service-catalog
+resources:
+- namespace.yaml
+components:
+- ../../../../components/limitranges/default
+- ../../../../components/project-admin-rolebindings/service-catalog
+- ../../../../components/resourcequotas/small

--- a/cluster-scope/base/core/namespaces/web-terminal-service-catalog/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/web-terminal-service-catalog/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: web-terminal-service-catalog
+    annotations:
+        openshift.io/display-name: Web Terminal Service Catalog
+        openshift.io/requester: service-catalog

--- a/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ../../../../base/core/namespaces/openshift-nmstate
   - ../../../../base/core/namespaces/opf-alertreceiver
   - ../../../../base/core/namespaces/vault
+  - ../../../../base/core/namespaces/web-terminal-service-catalog
   - ../../../../base/core/serviceaccounts/service-catalog-prometheus-plugin
   - ../../../../base/nmstate.io/nmstates/nmstate
   - ../../../../base/operator.openshift.io/ingresscontrollers/default

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -104,6 +104,7 @@ resources:
   - ../../../../base/core/namespaces/thoth-infra-prod
   - ../../../../base/core/namespaces/thoth-middletier-prod
   - ../../../../base/core/namespaces/tremor-demo
+  - ../../../../base/core/namespaces/web-terminal-service-catalog
   - ../../../../base/core/namespaces/wildfly-service
   - ../../../../base/core/persistentvolumeclaims/image-registry-storage
   - ../../../../base/imageregistry.operator.openshift.io/configs/cluster


### PR DESCRIPTION
Adds a namespace for service-catalog webterminal because by design only kubeadmin can create DevWorkspaces in `openshift-terminal` namespace. I went with small quota because each workspace uses roughly 200m so this means we can run roughly 5 terminals at one time which seems to me like good starting point. For now I have also allowed to users who are in `service-catalog` rolebinding to use this namespace.