### PR TITLE
Temporary sync change

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/janus-idp/janus-idp.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/janus-idp/janus-idp.yaml
@@ -11,7 +11,3 @@ spec:
     repoURL: 'https://github.com/janus-idp/backstage-showcase'
     targetRevision: HEAD
   project: janus-idp
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true


### PR DESCRIPTION
Janus-idp is having some issues and we are wanting to temporarily disable the auto sync while we work on them.