### PR TITLE
Updating Kruize.yaml to add smaug server URL

### DIFF
--- a/argocd/overlays/moc-infra/projects/kruize.yaml
+++ b/argocd/overlays/moc-infra/projects/kruize.yaml
@@ -8,6 +8,7 @@ spec:
   destinations:
     - namespace: 'openshift-tuning'
       name: 'smaug'
+      server: 'https://api.smaug.na.operate-first.cloud:6443'
   sourceRepos:
     - '*'
   roles:


### PR DESCRIPTION
We were getting InvalidSpecError -application destination {https://api.smaug.na.operate-first.cloud:6443 openshift-tuning} is not permitted in project 'kruize' and realised we hadn't specifed server in the yaml file.