### PR TITLE
Updating Kruize application name

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/kruize/kruize.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/kruize/kruize.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: hpo
+  name: Kruize-HPO
 spec:
   destination:
     name: smaug

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/kruize/kruize.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/kruize/kruize.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: Kruize-HPO
+  name: kruize-hpo
 spec:
   destination:
     name: smaug


### PR DESCRIPTION
Earlier the application name was just hpo - renaming it to Kruize-HPO for better understanding