### PR TITLE
fix: Increase kubeval job memory request to 1GB

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -33,7 +33,7 @@ presubmits:
             - "test-kubeval-validation"
           resources:
             requests:
-              memory: "512Mi"
+              memory: "1Gi"
               cpu: "1500m"
             limits:
               memory: "2Gi"


### PR DESCRIPTION
It seems that the https://github.com/operate-first/apps/pull/2759 fails because of not enough memory for kubeval validation. This PR increases this limit to 1GB