### PR TITLE
fix: Increase kubeval job memory request to 4GB

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -33,10 +33,10 @@ presubmits:
             - "test-kubeval-validation"
           resources:
             requests:
-              memory: "1Gi"
+              memory: "4Gi"
               cpu: "1500m"
             limits:
-              memory: "2Gi"
+              memory: "4Gi"
               cpu: "2"
 
   - name: pre-commit


### PR DESCRIPTION
As the bump to 1 GB in https://github.com/operate-first/apps/pull/2761 does not seem to be enough (as can be seen in https://github.com/operate-first/apps/pull/2759, which is still being OOMKilled)  and from testing which I did it seems that kubeval can use more than 2 GB, I am bumping this value to 4GB to have some reserve.

Reason why this is happening is that kubeval caches in memory schemas which it might need for the validation. These schemas are regularly updated in [schema-store](https://github.com/operate-first/schema-store) and I suspect that lately there has been some change that impacted size of the schemas dramatically. This means that also size that is cached increased.