### PR TITLE
feat: Add MachineWithoutValidNode alert

### DIFF
--- a/cluster-scope/overlays/prod/moc/infra/configmaps/thanos-ruler-custom-rules.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/configmaps/thanos-ruler-custom-rules.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: thanos-ruler-custom-rules
+  namespace: open-cluster-management-observability
+data:
+  custom_rules.yaml: |
+    groups:
+      - name: machineStateAlerts
+        rules:
+        - alert: MachineWithoutValidNode
+          annotations:
+            summary: Machine {{ $labels.name }} on {{ $labels.cluster }} has no valid node.
+            description: "The machine {{ $labels.name }} on {{ $labels.cluster }} has no valid node."
+            runbook_url: "https://github.com/openshift/machine-api-operator/blob/master/docs/user/Alerts.md"
+          expr: sum (mapi_machine_created_timestamp_seconds unless on(node) kube_node_info) > 0
+          for: 10m
+          labels:
+            severity: critical
+            managed_cluster_id: "{{ $labels.clusterID }}"

--- a/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
@@ -42,6 +42,7 @@ resources:
   - ../../../../bundles/odf-external
   - apiserver/api_server_cert.yaml
   - configmaps/service-catalog-k8s-plugin.yaml
+  - configmaps/thanos-ruler-custom-rules.yaml
   - configmaps/observability-metrics-custom-allowlist.yaml
   - clusterversion.yaml
   - externalsecrets


### PR DESCRIPTION
This PR adds a MachineWithoutValidNode alert.
The metrics it uses do not include `managed_cluster_id`
 label by default but they have `clusterID` instead. In this case `clusterID` is the ID of the cluster the alert originated in (therefore we can define `managed_cluster_id` label ourselves). For now I used following [guide](https://github.com/openshift/machine-api-operator/blob/master/docs/user/Alerts.md) If you have ideas for better guide feel free to point them out.