### PR TITLE
Update OpenShift Pipelines at Jerry to version 1.8

### DIFF
--- a/cluster-scope/overlays/prod/emea/jerry/kustomization.yaml
+++ b/cluster-scope/overlays/prod/emea/jerry/kustomization.yaml
@@ -14,3 +14,12 @@ resources:
 - imageregistry.operator.openshift.io/configs/cluster
 patchesStrategicMerge:
 - groups/cluster-admins.yaml
+
+patches:
+- target:
+    kind: Subscription
+    name: openshift-pipelines-operator-rh
+  patch: |-
+    - op: replace
+      path: /spec/channel
+      value: pipelines-1.8


### PR DESCRIPTION
PR to update OpenShift Pipelines to Version 1.8 at Jerry cluster.

Discussed here: https://operatefirst.slack.com/archives/C01RF4SPNDD/p1675620390285109 