### PR TITLE
fix(infra): revert ingress cert to default

### DIFF
--- a/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/kustomization.yaml
@@ -16,7 +16,6 @@ resources:
   - ../../../../base/core/namespaces/vault
   - ../../../../base/core/serviceaccounts/service-catalog-prometheus-plugin
   - ../../../../base/nmstate.io/nmstates/nmstate
-  - ../../../../base/operator.openshift.io/ingresscontrollers/default
   - ../../../../base/operators.coreos.com/operatorgroups/openshift-nmstate
   - ../../../../base/operators.coreos.com/operatorgroups/operator-acm-group
   - ../../../../base/operators.coreos.com/subscriptions/acm-operator-subscription


### PR DESCRIPTION
Attempt to revert custom ingress cert (which is currently expired and we're unable to issue a new one) to the default cert issued and self-signed by OCP.