### PR TITLE
fix: Add by clause to PromQL expression custom rule

### DIFF
--- a/cluster-scope/overlays/prod/moc/infra/configmaps/thanos-ruler-custom-rules.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/configmaps/thanos-ruler-custom-rules.yaml
@@ -13,7 +13,7 @@ data:
             summary: Machine {{ $labels.name }} on {{ $labels.cluster }} has no valid node.
             description: "The machine {{ $labels.name }} on {{ $labels.cluster }} has no valid node."
             runbook_url: "https://github.com/openshift/machine-api-operator/blob/master/docs/user/Alerts.md"
-          expr: sum (mapi_machine_created_timestamp_seconds unless on(node) kube_node_info) > 0
+          expr: sum by (name, clusterID, cluster) (mapi_machine_created_timestamp_seconds unless on(node) kube_node_info) > 0
           for: 10m
           labels:
             severity: critical


### PR DESCRIPTION
The custom alert rule `MachineWithoutValidNode` does not seem to display proper labels. The PromQL expression is missing aggregation operator which would add proper labels to the alert. More about aggregation can be seen [here](https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators) 
Here is the result of query without aggregation
![image](https://user-images.githubusercontent.com/47832967/226554383-0c7c6bef-73b4-477a-870e-84b95138b22f.png)
Here is the result of query with aggregation
![image](https://user-images.githubusercontent.com/47832967/226554622-a660f09a-cb76-44a0-a46d-30dc16fbabd5.png)
