### PR TITLE
feat: Increase quota for web-terminal-service-catalog namespace

### DIFF
--- a/cluster-scope/base/core/namespaces/web-terminal-service-catalog/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/web-terminal-service-catalog/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
 components:
 - ../../../../components/limitranges/default
 - ../../../../components/project-admin-rolebindings/service-catalog
-- ../../../../components/resourcequotas/small
+- ../../../../components/resourcequotas/medium


### PR DESCRIPTION
I found out that `small` resource quotas are not enough for running at least two webterminals at once (one devworkspace has limit 800m) therefore we cant spawn two devworkspaces at once