### PR TITLE
needed permissions in infra for context when migrating osc clusters

### DIFF
--- a/cluster-scope/overlays/prod/moc/infra/groups/cluster-admins.yaml
+++ b/cluster-scope/overlays/prod/moc/infra/groups/cluster-admins.yaml
@@ -18,3 +18,4 @@ users:
   - naved001
   - rob-baron
   - tumido
+  - cooktheryan


### PR DESCRIPTION
/cc @cooktheryan 
