### PR TITLE
removal of healthy apps that migrated

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl1/cluster-management/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl1/cluster-management/kustomization.yaml
@@ -1,20 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - acme-operator.yaml
-  - cloudbeaver.yaml
   - cluster-resources.yaml
   - das.yaml
-  - dex.yaml
-  - dex-secondary.yaml
-  - external-secrets.yaml
-  - kepler.yaml
-  - grafana.yaml
-  - k8s-annotations-exporter.yaml
   - kfdefs.yaml
-  - odh-operator.yaml
   - openmetadata.yaml
-  - training-operator.yaml
 patches:
   - patch: |
       - op: replace

--- a/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/cluster-management/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/osc/osc-cl2/cluster-management/kustomization.yaml
@@ -1,23 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - acme-operator.yaml
-  - cloudbeaver.yaml
   - cluster-resources.yaml
   - das.yaml
-  - dex.yaml
-  - dex-secondary.yaml
-  - external-secrets.yaml
-  - grafana.yaml
   - kafka.yaml
-  - kepler.yaml
-  - k8s-annotations-exporter.yaml
   - kfdefs.yaml
   - kfp-tekton.yaml
-  - odh-operator.yaml
   - openmetadata.yaml
-  - pachyderm.yaml
-  - reloader.yaml
 patches:
   - patch: |
       - op: replace


### PR DESCRIPTION
The applications removed here have been migrated and defined in the new OSC repository. To help from dual syncing we should remove.