### PR TITLE
removing osc argocd apps from op1st management

### DIFF
--- a/argocd/overlays/moc-infra/applications/app-of-apps/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/app-of-apps/kustomization.yaml
@@ -6,8 +6,8 @@ resources:
   - app-of-apps-infra.yaml
   - app-of-apps-ocp-prod.yaml
   - app-of-apps-ocp-staging.yaml
-  - app-of-apps-osc-cl1.yaml
-  - app-of-apps-osc-cl2.yaml
+  # - app-of-apps-osc-cl1.yaml
+  # - app-of-apps-osc-cl2.yaml
   - app-of-apps-smaug.yaml
   - workshops-app-of-apps.yaml
   - app-of-apps-jerry.yaml


### PR DESCRIPTION
/cc @cooktheryan 
Will remove manifests entirely once we have resolved syncing issues.
related to: https://github.com/operate-first/apps/pull/2778