### PR TITLE
removing osc references from infra ACM

### DIFF
--- a/acm/overlays/moc/infra/managedclusters/kustomization.yaml
+++ b/acm/overlays/moc/infra/managedclusters/kustomization.yaml
@@ -4,7 +4,5 @@ resources:
 - curator.yaml
 - ocp-prod.yaml
 - ocp-staging.yaml
-- osc-cl1.yaml
-- osc-cl2.yaml
 - smaug.yaml
 - jerry.yaml

--- a/acm/overlays/moc/infra/managedclusters/osc-cl1.yaml
+++ b/acm/overlays/moc/infra/managedclusters/osc-cl1.yaml
@@ -1,7 +1,0 @@
-apiVersion: cluster.open-cluster-management.io/v1
-kind: ManagedCluster
-metadata:
-  name: osc-cl1
-  labels:
-    cluster.open-cluster-management.io/clusterset: osc
-    observability: disabled

--- a/acm/overlays/moc/infra/managedclusters/osc-cl2.yaml
+++ b/acm/overlays/moc/infra/managedclusters/osc-cl2.yaml
@@ -1,7 +1,0 @@
-apiVersion: cluster.open-cluster-management.io/v1
-kind: ManagedCluster
-metadata:
-  name: osc-cl2
-  labels:
-    cluster.open-cluster-management.io/clusterset: osc
-    observability: disabled

--- a/acm/overlays/moc/infra/managedclustersetbindings/base/kustomization.yaml
+++ b/acm/overlays/moc/infra/managedclustersetbindings/base/kustomization.yaml
@@ -7,4 +7,3 @@ resources:
   - argocd-managed.yaml
   - drvbw.yaml
   - octo-ushift-dev.yaml
-  - osc.yaml

--- a/acm/overlays/moc/infra/managedclustersetbindings/base/osc.yaml
+++ b/acm/overlays/moc/infra/managedclustersetbindings/base/osc.yaml
@@ -1,6 +1,0 @@
-apiVersion: cluster.open-cluster-management.io/v1alpha1
-kind: ManagedClusterSetBinding
-metadata:
-  name: osc
-spec:
-  clusterSet: osc

--- a/acm/overlays/moc/infra/managedclustersets/kustomization.yaml
+++ b/acm/overlays/moc/infra/managedclustersets/kustomization.yaml
@@ -6,4 +6,3 @@ resources:
   - argocd-managed.yaml
   - drvbw.yaml
   - octo-ushift-dev.yaml
-  - osc.yaml

--- a/acm/overlays/moc/infra/managedclustersets/osc.yaml
+++ b/acm/overlays/moc/infra/managedclustersets/osc.yaml
@@ -1,5 +1,0 @@
-kind: ManagedClusterSet
-apiVersion: cluster.open-cluster-management.io/v1alpha1
-metadata:
-  name: osc
-spec: {}


### PR DESCRIPTION
Addresses: https://github.com/os-climate/os_c_data_commons/issues/288
/cc @cooktheryan 
/cc @redmikhail 
Do not merge until creds are backed up for `kubeadmin` to 3 OSC clusters to new vault instance (as mentioned here: https://github.com/os-climate/os_c_data_commons/issues/288#issuecomment-1502152292)
/hold