### PR TITLE
OKD-89: feature: adds a new argoCD app to deploy okd tekton pipeline

### DIFF
--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/okd-team/kustomization.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/okd-team/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - okd-centos.yaml
   - kvm-device-plugin.yaml
+  - okd-tekton-release-pipeline.yaml

--- a/argocd/overlays/moc-infra/applications/envs/moc/smaug/okd-team/okd-tekton-release-pipeline.yaml
+++ b/argocd/overlays/moc-infra/applications/envs/moc/smaug/okd-team/okd-tekton-release-pipeline.yaml
@@ -1,0 +1,13 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: okd-tekton-release-pipeline
+spec:
+  destination:
+    name: smaug
+    namespace: okd-team
+  project: okd-team
+  source:
+    path: base
+    repoURL: https://github.com/okd-project/okd-release-pipeline.git
+    targetRevision: HEAD


### PR DESCRIPTION
This argoCD app will allow the automatic deployment of resource of okd release pipelines when a new commit is merged on main branch.